### PR TITLE
Zero out bmlt_float in ice-free ocean for basal melting GLP

### DIFF
--- a/libglissade/glissade_transport.F90
+++ b/libglissade/glissade_transport.F90
@@ -1367,6 +1367,7 @@
       real(dp), intent(in) ::   &
          dt                     ! time step (s)
 
+      !TODO - Could remove ocean_mask argument, if acab and bmlt have already been set to 0 for ice-free ocean cells.
       integer, dimension(nx,ny), intent(in) :: &
          ocean_mask             ! = 1 if topg is below sea level and thk <= thklim, else = 0
 


### PR DESCRIPTION
This PR fixes an inconsistency in the way bmlt_float was handled for ice-free ocean with different values of which_ho_ground_bmlt. With this change, bmlt_float is set to zero in all cells that are ice-free ocean at the start of the time step, regardless of the value of which_ho_ground_bmlt.  (Previously, bmlt_float could be nonzero in cells that are ice-free ocean at the start of the step.)  Answers are unchanged for which_ho_ground_bmlt = 0, but can change for which_ho_ground_bmlt = 1 or 2.