### PR TITLE
Lipscomb/total flux tavg

### DIFF
--- a/builds/cheyenne-intel/cheyenne-intel-cmake
+++ b/builds/cheyenne-intel/cheyenne-intel-cmake
@@ -8,10 +8,10 @@ module purge
 module load ncarenv/1.2
 module load intel/17.0.1
 module load mkl/2017.0.1
-module load mpt/2.15f
-module load netcdf-mpi/4.4.1.1
+module load mpt/2.19
+module load netcdf-mpi/4.6.2
 module load ncarcompilers/0.4.1
-module load pnetcdf/1.8.0
+module load pnetcdf/1.11.0
 module load cmake/3.7.2
 module load python/2.7.13
 module load numpy/1.12.0

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -933,7 +933,6 @@ module glide_types
     logical :: empty = .true.   ! true if totpts = 0
 
     ! global scalars
-    !TODO - Allow these scalars to be output as time averages instead of snapshots
 
     real(dp) :: iarea                  ! total ice area (m^2)
     real(dp) :: iareag                 ! total grounded ice area (m^2)
@@ -945,6 +944,10 @@ module glide_types
     real(dp) :: total_bmb_flux         ! total basal mass balance flux (kg/s)
     real(dp) :: total_calving_flux     ! total calving mass flux (kg/s)
     real(dp) :: total_gl_flux          ! total grounding line mass flux (kg/s)
+    real(dp) :: total_smb_flux_tavg    ! total surface mass balance flux (kg/s), time average
+    real(dp) :: total_bmb_flux_tavg    ! total basal mass balance flux (kg/s), time average
+    real(dp) :: total_calving_flux_tavg! total calving mass flux (kg/s), time average
+    real(dp) :: total_gl_flux_tavg     ! total grounding line mass flux (kg/s), time average
 
   end type glide_geometry
 

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -621,18 +621,21 @@ dimensions:    time
 units:         kg/s
 long_name:     total surface mass balance flux
 data:          data%geometry%total_smb_flux
+average:       1
 
 [total_bmb_flux]
 dimensions:    time
 units:         kg/s
 long_name:     total basal mass balance flux
 data:          data%geometry%total_bmb_flux
+average:       1
 
 [total_calving_flux]
 dimensions:    time
 units:         kg/s
 long_name:     total calving mass balance flux
 data:          data%geometry%total_calving_flux
+average:       1
 
 [thkmask]
 dimensions:    time, y1, x1
@@ -1428,6 +1431,7 @@ dimensions:    time
 units:         kg/s
 long_name:     total grounding line flux
 data:          data%geometry%total_gl_flux
+average:       1
 
 [rho_ice]
 dimensions:    time


### PR DESCRIPTION
Changes to support writing total flux tavg fields to history files and to support the new modules needed to build CISM standalone on Cheyenne.