### PR TITLE
Adding forced topography options

### DIFF
--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -2323,6 +2323,10 @@ contains
           call write_log('setting relx to first slice of input topg')
        elseif (model%isostasy%whichrelaxed==RELAXED_TOPO_COMPUTE) then
           call write_log('computing relx, given that input topg is in equilibrium')
+       elseif (model%isostasy%whichrelaxed==RELAXED_TOPO_TARGET) then
+          call write_log('reading relx as load-independent target topg')
+       elseif (model%isostasy%whichrelaxed==RELAXED_TOPO_FORCED) then
+          call write_log('setting relx as load-independent target to first slice of input topg ')
        else
           call write_log('Error, unknown whichrelaxed option',GM_FATAL)
        end if

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -139,10 +139,14 @@ module glide_types
   integer, parameter :: GTHF_PRESCRIBED_2D = 1
   integer, parameter :: GTHF_COMPUTE = 2
 
-  integer, parameter :: RELAXED_TOPO_DEFAULT = 0  ! topo and relx are separate input fields
+  integer, parameter :: RELAXED_TOPO_DEFAULT = 0  ! topg and relx are separate input fields
   integer, parameter :: RELAXED_TOPO_INPUT = 1    ! set relx to input topg
-  integer, parameter :: RELAXED_TOPO_COMPUTE = 2  ! Input topo in isostatic equilibrium
-                                                  ! compute relaxed topo
+  integer, parameter :: RELAXED_TOPO_COMPUTE = 2  ! Input topg in isostatic equilibrium
+                                                  ! compute relx
+  !HG: Adding options for forced bedrock adjustment
+  integer, parameter :: RELAXED_TOPO_TARGET = 3   ! use relx as load-independent target for topg
+  integer, parameter :: RELAXED_TOPO_FORCED = 4   ! set relx to input topg as load-independent
+                                                  ! target for topg
 
   integer, parameter :: ISOSTASY_NONE = 0
   integer, parameter :: ISOSTASY_COMPUTE = 1


### PR DESCRIPTION
Hi Bill,
this is the small contribution to the isostatic calculation we talked about...

Adding forced topography options whichrelaxed = 3 and whichrelaxed = 4. They may be used to relax the model to a given topography.

I have made a small example run for a schematic GrIS using whichrelaxed = 3 and relaxing topography to zero. 
[escomp_64km_isotest_skel.zip](https://github.com/ESCOMP/CISM/files/4167334/escomp_64km_isotest_skel.zip)

Greetings
    Heiko