### PR TITLE
Changed parallel_mod to cism_parallel

### DIFF
--- a/cism_driver/cism_driver.F90
+++ b/cism_driver/cism_driver.F90
@@ -28,7 +28,7 @@ program cism_driver
 !  use glimmer_commandline
 !  use glide
   use gcm_cism_interface
-  use parallel_mod, only: parallel_initialise, parallel_finalise
+  use cism_parallel, only: parallel_initialise, parallel_finalise
 
   integer :: which_gcm = GCM_GLINT_MODEL
   type(gcm_to_cism_type) :: g2c

--- a/cism_driver/eismint_forcing.F90
+++ b/cism_driver/eismint_forcing.F90
@@ -211,7 +211,7 @@ contains
     ! print eismint_climate configuration
 
     use glimmer_log
-    use parallel_mod, only: tasks
+    use cism_parallel, only: tasks
 
     implicit none
 

--- a/cism_driver/gcm_cism_interface.F90
+++ b/cism_driver/gcm_cism_interface.F90
@@ -60,7 +60,7 @@ subroutine gci_init_interface(which_gcm,g2c)
   use glimmer_config
   use glide
   use glide_types
-  use parallel_mod, only: main_task
+  use cism_parallel, only: main_task
  
   use cism_front_end 
 

--- a/cism_driver/gcm_to_cism_glint.F90
+++ b/cism_driver/gcm_to_cism_glint.F90
@@ -46,7 +46,7 @@ module gcm_to_cism_glint
   use glimmer_writestats
 !  use glimmer_commandline
   use glimmer_paramets, only: GLC_DEBUG
-  use parallel_mod, only: main_task
+  use cism_parallel, only: main_task
 
 type gcm_to_cism_type
 

--- a/libglad/glad_initialise.F90
+++ b/libglad/glad_initialise.F90
@@ -71,7 +71,7 @@ contains
     use glad_constants
     use glad_restart_gcm
     use glide_diagnostics
-    use parallel_mod, only: main_task
+    use cism_parallel, only: main_task
 
     implicit none
 

--- a/libglad/glad_input_averages.F90
+++ b/libglad/glad_input_averages.F90
@@ -51,7 +51,7 @@ module glad_input_averages
   use glimmer_global, only : dp
   use glimmer_paramets, only: GLC_DEBUG, stdout
   use glimmer_log
-  use parallel_mod, only : main_task
+  use cism_parallel, only : main_task
   
   implicit none
   private

--- a/libglad/glad_main.F90
+++ b/libglad/glad_main.F90
@@ -44,7 +44,7 @@ module glad_main
   use glad_input_averages, only : get_av_start_time, accumulate_averages, &
        calculate_averages, reset_glad_input_averages, averages_okay_to_restart
   use glimmer_paramets, only: stdout, GLC_DEBUG, unphys_val
-  use parallel_mod, only: main_task, this_rank
+  use cism_parallel, only: main_task, this_rank
 
   implicit none
   private
@@ -512,7 +512,7 @@ contains
 
     ! Output arrays do NOT have halo cells
 
-    use parallel_mod, only: parallel_type, parallel_convert_haloed_to_nonhaloed
+    use cism_parallel, only: parallel_type, parallel_convert_haloed_to_nonhaloed
     
     ! Subroutine argument declarations --------------------------------------------------------
 
@@ -598,7 +598,7 @@ contains
     use glimmer_physcon, only : celsius_to_kelvin
     use glide_types, only : get_ewn, get_nsn, get_nzocn
     use glad_output_fluxes, only : calculate_average_output_fluxes
-    use parallel_mod, only : parallel_type, parallel_convert_nonhaloed_to_haloed
+    use cism_parallel, only : parallel_type, parallel_convert_nonhaloed_to_haloed
 
     implicit none
 
@@ -971,7 +971,7 @@ contains
 
     use glad_output_states, only : set_output_states
     use glide_types, only : get_ewn, get_nsn
-    use parallel_mod, only : parallel_type, parallel_convert_haloed_to_nonhaloed
+    use cism_parallel, only : parallel_type, parallel_convert_haloed_to_nonhaloed
 
     ! Subroutine argument declarations --------------------------------------------------------
 

--- a/libglad/glad_timestep.F90
+++ b/libglad/glad_timestep.F90
@@ -39,7 +39,7 @@ module glad_timestep
   use glad_type
   use glad_constants
   use glimmer_global, only: dp
-  use parallel_mod, only: tasks, main_task, this_rank
+  use cism_parallel, only: tasks, main_task, this_rank
 
   implicit none
 

--- a/libglad/glad_type.F90
+++ b/libglad/glad_type.F90
@@ -264,7 +264,7 @@ contains
 
     use glimmer_log
     use glad_constants, only: hours2years
-    use parallel_mod, only: tasks
+    use cism_parallel, only: tasks
 
     implicit none
 

--- a/libglide/felix_dycore_interface.F90
+++ b/libglide/felix_dycore_interface.F90
@@ -33,7 +33,7 @@ module felix_dycore_interface
    use glimmer_log
    use glissade_grid_operators, only: glissade_stagger 
    !use glimmer_to_dycore
-   use parallel_mod, only: this_rank, nhalo
+   use cism_parallel, only: this_rank, nhalo
    implicit none
    private
 

--- a/libglide/glide.F90
+++ b/libglide/glide.F90
@@ -149,7 +149,7 @@ contains
     use glide_bwater
     use glimmer_paramets, only: len0
     use glimmer_physcon, only: rhoi, rhow
-    use parallel_mod, only: distributed_grid
+    use cism_parallel, only: distributed_grid
 
     type(glide_global_type), intent(inout) :: model     ! model instance
 

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -35,7 +35,7 @@ module glide_diagnostics
   use glimmer_global, only: dp
   use glimmer_log
   use glide_types
-  use parallel_mod, only: this_rank, main_task, lhalo, uhalo, &
+  use cism_parallel, only: this_rank, main_task, lhalo, uhalo, &
        parallel_type, broadcast, parallel_localindex, parallel_globalindex, &
        parallel_reduce_sum, parallel_reduce_max, parallel_reduce_maxloc, parallel_reduce_minloc
 

--- a/libglide/glide_lithot.F90
+++ b/libglide/glide_lithot.F90
@@ -105,7 +105,7 @@ contains
     use glide_types
     use glimmer_log
     use glide_mask
-    use parallel_mod, only: not_parallel
+    use cism_parallel, only: not_parallel
 
     implicit none
     type(glide_global_type),intent(inout) :: model       !> model instance

--- a/libglide/glide_mask.F90
+++ b/libglide/glide_mask.F90
@@ -35,7 +35,7 @@ module glide_mask
     ! masking ice thicknesses
 
     use glimmer_global, only : dp
-    use parallel_mod, only: lhalo, uhalo, parallel_type, parallel_halo, parallel_reduce_sum
+    use cism_parallel, only: lhalo, uhalo, parallel_type, parallel_halo, parallel_reduce_sum
 
     implicit none
 

--- a/libglide/glide_nc_custom.F90
+++ b/libglide/glide_nc_custom.F90
@@ -74,7 +74,7 @@ contains
     use glide_types
     use glimmer_ncdf
     use glimmer_paramets, only : len0
-    use parallel_mod, only: parallel_inq_varid, parallel_put_var, parallel_enddef
+    use cism_parallel, only: parallel_inq_varid, parallel_put_var, parallel_enddef
 
     implicit none
 

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -271,7 +271,7 @@ contains
     use glide_types
     use glimmer_log
     use glimmer_filenames
-    use parallel_mod, only: main_task, broadcast
+    use cism_parallel, only: main_task, broadcast
 
     implicit none
 
@@ -403,7 +403,7 @@ contains
     use glide_types
     use glimmer_config
     use glimmer_log
-    use parallel_mod, only: main_task
+    use cism_parallel, only: main_task
 
     implicit none
 
@@ -840,7 +840,7 @@ contains
 
     use glide_types
     use glimmer_log
-    use parallel_mod, only: tasks
+    use cism_parallel, only: tasks
 
     implicit none
 
@@ -2872,7 +2872,7 @@ contains
 
     use glide_types
     use glimmer_log
-    use parallel_mod, only: tasks
+    use cism_parallel, only: tasks
 
     implicit none
     type(glide_global_type)  :: model

--- a/libglide/glide_temp.F90
+++ b/libglide/glide_temp.F90
@@ -82,7 +82,7 @@ contains
     !> initialise temperature module
     use glimmer_physcon, only : rhoi, shci, coni, scyr, grav, gn, lhci, rhow, trpt
     use glimmer_paramets, only : tim0, thk0, acc0, len0, vis0, vel0
-    use parallel_mod, only: lhalo, uhalo
+    use cism_parallel, only: lhalo, uhalo
 
     type(glide_global_type), intent(inout) :: model       ! model instance
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -54,7 +54,7 @@ module glide_types
   use glimmer_coordinates, only: coordsystem_type
   use glimmer_map_types, only: glimmap_proj
   use glimmer_sparse_type, only: sparse_matrix_type
-  use parallel_mod, only: parallel_type
+  use cism_parallel, only: parallel_type
 
   implicit none
 

--- a/libglide/isostasy_elastic.F90
+++ b/libglide/isostasy_elastic.F90
@@ -136,7 +136,7 @@ contains
     !> The main difference is that this subroutine uses a global gather and scatter to compute
     !>  the load for simulations on more than one task.
 
-    use parallel_mod, only: this_rank, main_task, &
+    use cism_parallel, only: this_rank, main_task, &
          parallel_type, distributed_gather_var, distributed_scatter_var, parallel_halo
 
     implicit none

--- a/libglimmer/glimmer_commandline.F90
+++ b/libglimmer/glimmer_commandline.F90
@@ -39,7 +39,7 @@ module glimmer_commandline
 
   use glimmer_global, only: fname_length
 
-  use parallel_mod, only: main_task
+  use cism_parallel, only: main_task
 
   implicit none
 

--- a/libglimmer/glimmer_config.F90
+++ b/libglimmer/glimmer_config.F90
@@ -103,7 +103,7 @@ contains
   !> read a configuration file
   subroutine ConfigRead(fname,config,fileunit)
     !> read configuration file
-    use parallel_mod, only: main_task, broadcast
+    use cism_parallel, only: main_task, broadcast
     use glimmer_log
 
     implicit none

--- a/libglimmer/glimmer_log.F90
+++ b/libglimmer/glimmer_log.F90
@@ -56,7 +56,7 @@
 module glimmer_log
 
   use glimmer_global, only : fname_length,dirsep
-  use parallel_mod, only: this_rank, main_task, parallel_stop
+  use cism_parallel, only: this_rank, main_task, parallel_stop
 
   implicit none
 

--- a/libglimmer/glimmer_map_CFproj.F90
+++ b/libglimmer/glimmer_map_CFproj.F90
@@ -40,7 +40,7 @@ module glimmer_map_CFproj
 
   use glimmer_map_types
   use glimmer_ncdf, only: nc_errorhandle
-  use parallel_mod, only: parallel_get_att, parallel_put_att, parallel_inquire, &
+  use cism_parallel, only: parallel_get_att, parallel_put_att, parallel_inquire, &
        parallel_inquire_variable, parallel_inq_attname
   use netcdf
 

--- a/libglimmer/glimmer_map_init.F90
+++ b/libglimmer/glimmer_map_init.F90
@@ -480,7 +480,7 @@ contains
 
     use glimmer_log
     use glimmer_physcon, only: pi, rearth
-    use parallel_mod, only: parallel_type, parallel_globalindex, &
+    use cism_parallel, only: parallel_type, parallel_globalindex, &
          parallel_reduce_max, parallel_reduce_min
 
     type(proj_stere),intent(inout) :: params

--- a/libglimmer/glimmer_ncio.F90
+++ b/libglimmer/glimmer_ncio.F90
@@ -36,7 +36,7 @@ module glimmer_ncio
   !> written by Magnus Hagdorn, 2004
 
   use glimmer_ncdf
-  use parallel_mod, only: parallel_type, parallel_create, parallel_open, parallel_put_var, parallel_get_var, &
+  use cism_parallel, only: parallel_type, parallel_create, parallel_open, parallel_put_var, parallel_get_var, &
        parallel_put_att, parallel_def_var, parallel_def_dim, parallel_inq_varid, parallel_inq_dimid,  &
        parallel_inquire_dimension, parallel_redef, parallel_enddef, parallel_sync
 

--- a/libglimmer/glimmer_writestats.F90
+++ b/libglimmer/glimmer_writestats.F90
@@ -37,7 +37,7 @@ contains
   subroutine glimmer_write_stats(resname, cfgname, wallTime)
 
     use glimmer_global, only : dp
-    use parallel_mod, only: main_task
+    use cism_parallel, only: main_task
     implicit none
     character(len=*), intent(in) :: resname    !< name of the output result file
     character(len=*), intent(in) :: cfgname    !< name of ice sheet configuration file

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -137,7 +137,7 @@ contains
   
   subroutine NAME_io_create(outfile,model,data)
 
-    use parallel_mod, only: parallel_type, &
+    use cism_parallel, only: parallel_type, &
          parallel_def_dim, parallel_inq_dimid, parallel_def_var, parallel_inq_varid, parallel_put_att
     use glide_types
     use DATAMOD
@@ -230,7 +230,7 @@ contains
 
   subroutine NAME_io_write(outfile,data)
 
-    use parallel_mod, only: parallel_type, parallel_inq_varid, distributed_put_var, parallel_put_var
+    use cism_parallel, only: parallel_type, parallel_inq_varid, distributed_put_var, parallel_put_var
     use DATAMOD
     use glimmer_paramets
     use glimmer_physcon
@@ -408,7 +408,7 @@ contains
     ! Read data from forcing files
     use glimmer_log
     use glide_types
-    use parallel_mod, only: main_task
+    use cism_parallel, only: main_task
 
     implicit none
     type(DATATYPE) :: data
@@ -499,7 +499,7 @@ contains
   subroutine NAME_io_read(infile,data)
 
     ! read variables from a netCDF file
-    use parallel_mod, only: parallel_type, &
+    use cism_parallel, only: parallel_type, &
          parallel_inq_varid, parallel_get_att, distributed_get_var, parallel_get_var
     use glimmer_log
     use DATAMOD
@@ -527,7 +527,7 @@ contains
   subroutine NAME_io_checkdim(infile,model,data)
 
     ! check if dimension sizes in file match dims of model
-    use parallel_mod, only: parallel_type, parallel_inq_dimid, parallel_inquire_dimension
+    use cism_parallel, only: parallel_type, parallel_inq_dimid, parallel_inquire_dimension
     use glimmer_log
     use glide_types
     use DATAMOD
@@ -556,7 +556,7 @@ contains
     !        will be too large, because this subroutine will be called more than once per time step.
     ! TODO: Write code to check for doubly listed tavg variables and throw a fatal error.
 
-    use parallel_mod, only: parallel_inq_varid
+    use cism_parallel, only: parallel_inq_varid
     use glide_types
     use DATAMOD
     implicit none
@@ -578,7 +578,7 @@ contains
 
   subroutine NAME_avg_reset(outfile,data)
 
-    use parallel_mod, only: parallel_inq_varid
+    use cism_parallel, only: parallel_inq_varid
     use DATAMOD
     implicit none
     type(glimmer_nc_output), pointer :: outfile

--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -24,7 +24,7 @@
 !
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-module parallel_mod
+module cism_parallel
 
   use netcdf
   use glimmer_global, only : dp, sp
@@ -9691,7 +9691,7 @@ contains
 
   !=======================================================================
 
-end module parallel_mod
+end module cism_parallel
 
 !=======================================================================
 

--- a/libglimmer/parallel_slap.F90
+++ b/libglimmer/parallel_slap.F90
@@ -24,7 +24,7 @@
 !
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-module parallel_mod
+module cism_parallel
 
   use netcdf
   use glimmer_global, only : dp, sp
@@ -4196,6 +4196,6 @@ contains
 
 !=======================================================================
 
-end module parallel_mod
+end module cism_parallel
 
 !=======================================================================

--- a/libglimmer/profile.F90
+++ b/libglimmer/profile.F90
@@ -35,8 +35,8 @@ module profile
 
 #if (defined CCSMCOUPLED || defined CESMTIMERS)
   use perf_mod
-  !TODO - Add an 'only' for 'use parallel_mod'?
-  use parallel_mod
+  !TODO - Add an 'only' for 'use cism_parallel'?
+  use cism_parallel
 #endif
 
   use glimmer_global, only: dp

--- a/libglint/glint_commandline.F90
+++ b/libglint/glint_commandline.F90
@@ -64,7 +64,7 @@ contains
 
   subroutine glint_GetCommandline()
 
-    use parallel_mod, only: main_task
+    use cism_parallel, only: main_task
     implicit none
 
     integer :: numargs, nfiles

--- a/libglint/glint_downscale.F90
+++ b/libglint/glint_downscale.F90
@@ -59,7 +59,7 @@ contains
                                orogflag)
 
     use glint_interp
-    use parallel_mod, only: parallel_type
+    use cism_parallel, only: parallel_type
 
     !> Downscale global input fields to the local ice sheet grid
 
@@ -122,7 +122,7 @@ contains
     use glint_type
     use glint_interp, only: interp_to_local, copy_to_local
     use glimmer_log
-    use parallel_mod, only: tasks, main_task, this_rank
+    use cism_parallel, only: tasks, main_task, this_rank
 
     ! Downscale global input fields from the global grid (with multiple elevation classes)
     ! to the local ice sheet grid.

--- a/libglint/glint_initialise.F90
+++ b/libglint/glint_initialise.F90
@@ -43,7 +43,7 @@ module glint_initialise
 
   use glint_type
   use glimmer_global, only: dp
-  use parallel_mod, only: main_task
+  use cism_parallel, only: main_task
 
   implicit none
 
@@ -601,7 +601,7 @@ contains
     use glint_global_grid  , only : global_grid
     use glimmer_coordinates, only : coordsystem_new
     use glide_types        , only : get_dew, get_dns
-    use parallel_mod       , only : parallel_type, distributed_gather_var
+    use cism_parallel       , only : parallel_type, distributed_gather_var
 
     implicit none
 

--- a/libglint/glint_interp.F90
+++ b/libglint/glint_interp.F90
@@ -177,7 +177,7 @@ contains
     use glimmer_utils
     use glimmer_coordinates
     use glimmer_log
-    use parallel_mod, only : parallel_type, tasks
+    use cism_parallel, only : parallel_type, tasks
 
     ! Argument declarations
 
@@ -248,7 +248,7 @@ contains
     use glimmer_utils
     use glimmer_coordinates
     use glimmer_log
-    use parallel_mod, only : main_task, parallel_type, distributed_scatter_var, parallel_halo
+    use cism_parallel, only : main_task, parallel_type, distributed_scatter_var, parallel_halo
 
     !TODO - Not sure we need localsp now that the code is fully double precision 
 
@@ -489,7 +489,7 @@ contains
     ! on the main task.
 
     use glimmer_coordinates
-    use parallel_mod, only : main_task, parallel_type, distributed_scatter_var, parallel_halo
+    use cism_parallel, only : main_task, parallel_type, distributed_scatter_var, parallel_halo
 
     ! Argument declarations
 
@@ -695,7 +695,7 @@ contains
     !> \texttt{interp\_to\_local} routine.
     !> \end{itemize}
 
-    use parallel_mod, only : main_task, parallel_type, distributed_gather_var
+    use cism_parallel, only : main_task, parallel_type, distributed_gather_var
 
     ! Arguments
 
@@ -785,7 +785,7 @@ contains
     !> \item \texttt{gboxn} is the same size as \texttt{global}
     !> \end{itemize}
 
-    use parallel_mod, only : main_task, parallel_type, distributed_gather_var
+    use cism_parallel, only : main_task, parallel_type, distributed_gather_var
 
     ! Arguments
 
@@ -854,7 +854,7 @@ contains
     !> \item \texttt{gboxn} is the same size as \texttt{global}
     !> \end{itemize}
 
-    use parallel_mod, only : main_task, parallel_type, distributed_gather_var
+    use cism_parallel, only : main_task, parallel_type, distributed_gather_var
 
     ! Arguments
 
@@ -1006,7 +1006,7 @@ contains
     use glint_global_grid
     use glimmer_coordinates
     use glimmer_map_trans
-    use parallel_mod, only : main_task
+    use cism_parallel, only : main_task
 
     ! Arguments
 

--- a/libglint/glint_main.F90
+++ b/libglint/glint_main.F90
@@ -38,7 +38,7 @@ module glint_main
   use glad_constants
   use glint_anomcouple
   use glimmer_paramets, only: stdout, GLC_DEBUG
-  use parallel_mod, only: main_task, tasks
+  use cism_parallel, only: main_task, tasks
 
   implicit none
 

--- a/libglint/glint_timestep.F90
+++ b/libglint/glint_timestep.F90
@@ -39,7 +39,7 @@ module glint_timestep
   use glint_type
   use glad_constants
   use glimmer_global, only: dp
-  use parallel_mod, only: tasks, main_task, this_rank
+  use cism_parallel, only: tasks, main_task, this_rank
 
   implicit none
 

--- a/libglint/glint_type.F90
+++ b/libglint/glint_type.F90
@@ -473,7 +473,7 @@ contains
 
     use glimmer_log
     use glad_constants, only: hours2years
-    use parallel_mod, only: tasks
+    use cism_parallel, only: tasks
 
     implicit none
 

--- a/libglint/glint_upscale.F90
+++ b/libglint/glint_upscale.F90
@@ -177,7 +177,7 @@ contains
 
     use glimmer_paramets, only: thk0, GLC_DEBUG
     use glimmer_log
-    use parallel_mod, only: tasks, main_task
+    use cism_parallel, only: tasks, main_task
 
     ! Arguments ----------------------------------------------------------------------------
  

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -63,7 +63,7 @@ module glissade
        glissade_test_halo, glissade_test_transport, glissade_test_comm_row_col
   use glide_thck, only: glide_calclsrf  ! TODO - Make this a glissade subroutine, or inline
   use profile, only: t_startf, t_stopf
-  use parallel_mod, only: this_rank, main_task, comm, nhalo
+  use cism_parallel, only: this_rank, main_task, comm, nhalo
 
   implicit none
 
@@ -88,7 +88,7 @@ contains
 
     ! initialise Glissade model instance
 
-    use parallel_mod, only: parallel_type, distributed_gather_var,  &
+    use cism_parallel, only: parallel_type, distributed_gather_var,  &
          distributed_scatter_var, parallel_finalise, &
          distributed_grid, distributed_grid_active_blocks,  &
          parallel_halo, parallel_halo_extrapolate, parallel_reduce_max, &
@@ -1028,7 +1028,7 @@ contains
 
     ! Perform time-step of an ice model instance with the Glissade dycore
 
-    use parallel_mod, only:  parallel_type, not_parallel
+    use cism_parallel, only:  parallel_type, not_parallel
 
     use glimmer_paramets, only: tim0, len0, thk0
     use glimmer_physcon, only: scyr
@@ -1735,7 +1735,7 @@ contains
     ! Do the vertical thermal solve.
     ! First call a driver subroutine for vertical temperature or enthalpy evolution,
     ! and then update the basal water.
-    use parallel_mod, only: parallel_type, parallel_halo
+    use cism_parallel, only: parallel_type, parallel_halo
 
     use glimmer_paramets, only: tim0, thk0, len0
     use glimmer_physcon, only: scyr
@@ -1930,7 +1930,7 @@ contains
     !       after horizontal transport and before applying the surface and basal mass balance.
     ! ------------------------------------------------------------------------ 
 
-    use parallel_mod, only: parallel_type, parallel_halo, parallel_halo_tracers, staggered_parallel_halo, &
+    use cism_parallel, only: parallel_type, parallel_halo, parallel_halo_tracers, staggered_parallel_halo, &
          parallel_reduce_max
 
     use glimmer_paramets, only: eps11, tim0, thk0, vel0, len0
@@ -2861,7 +2861,7 @@ contains
     ! Calculate iceberg calving
     ! ------------------------------------------------------------------------ 
 
-    use parallel_mod, only: parallel_type, parallel_halo
+    use cism_parallel, only: parallel_type, parallel_halo
 
     use glimmer_paramets, only: thk0, tim0, len0
     use glissade_calving, only: glissade_calve_ice, glissade_cull_calving_front, &
@@ -3489,7 +3489,7 @@ contains
     ! Calculate isostatic adjustment
     ! ------------------------------------------------------------------------ 
 
-    use parallel_mod, only: parallel_type, parallel_halo, parallel_halo_extrapolate
+    use cism_parallel, only: parallel_type, parallel_halo, parallel_halo_extrapolate
 
     use isostasy, only: isos_compute, isos_icewaterload
     use glimmer_paramets, only: thk0
@@ -3583,7 +3583,7 @@ contains
      ! This is needed at the end of each time step once the prognostic variables (thickness, tracers) have been updated.  
      ! It is also needed to fill out the initial state from the fields that have been read in.
 
-    use parallel_mod, only: parallel_type, parallel_halo, &
+    use cism_parallel, only: parallel_type, parallel_halo, &
          staggered_parallel_halo, staggered_parallel_halo_extrapolate, &
          parallel_reduce_max, parallel_reduce_min, parallel_globalindex
 
@@ -4805,7 +4805,7 @@ contains
     ! Clean up prognostic variables in ice-free cells.
     ! This means seting most tracers to zero (or min(artm,0) for the case of temperature).
 
-    use parallel_mod, only: parallel_halo
+    use cism_parallel, only: parallel_halo
 
     type(glide_global_type), intent(inout) :: model   ! model instance
 

--- a/libglissade/glissade_basal_traction.F90
+++ b/libglissade/glissade_basal_traction.F90
@@ -50,7 +50,7 @@
   use glimmer_paramets, only : vel0, tau0
   use glimmer_log
   use glide_types
-  use parallel_mod, only : this_rank, main_task, parallel_type, &
+  use cism_parallel, only : this_rank, main_task, parallel_type, &
        parallel_halo, staggered_parallel_halo, parallel_globalindex, distributed_scatter_var
 
   implicit none

--- a/libglissade/glissade_bmlt_float.F90
+++ b/libglissade/glissade_bmlt_float.F90
@@ -40,7 +40,7 @@ module glissade_bmlt_float
   use glimmer_paramets, only: unphys_val
   use glimmer_log
   use glide_types
-  use parallel_mod, only: this_rank, main_task, nhalo, &
+  use cism_parallel, only: this_rank, main_task, nhalo, &
        parallel_type, parallel_halo, parallel_globalindex, &
        parallel_reduce_sum, parallel_reduce_min, parallel_reduce_max
 

--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -32,7 +32,7 @@ module glissade_calving
   use glide_types
   use glimmer_global, only: dp
   use glimmer_log
-  use parallel_mod, only: this_rank, main_task, nhalo, &
+  use cism_parallel, only: this_rank, main_task, nhalo, &
        parallel_halo, parallel_globalindex, parallel_reduce_sum, parallel_reduce_max
 
   use glimmer_paramets, only: eps08, thk0

--- a/libglissade/glissade_grid_operators.F90
+++ b/libglissade/glissade_grid_operators.F90
@@ -41,7 +41,7 @@ module glissade_grid_operators
     use glimmer_global, only: dp
     use glimmer_log
     use glide_types
-    use parallel_mod, only: this_rank, main_task, nhalo, &
+    use cism_parallel, only: this_rank, main_task, nhalo, &
          parallel_type, parallel_halo, parallel_reduce_sum, parallel_globalindex
 
     implicit none

--- a/libglissade/glissade_grounding_line.F90
+++ b/libglissade/glissade_grounding_line.F90
@@ -41,7 +41,7 @@
     use glimmer_global, only: dp
     use glimmer_physcon, only: rhoi, rhoo
     use glide_types  ! grounding line options
-    use parallel_mod, only: this_rank, nhalo, parallel_type, parallel_halo
+    use cism_parallel, only: this_rank, nhalo, parallel_type, parallel_halo
     !TODO - May be able to remove parallel halo updates from this module
 
     implicit none

--- a/libglissade/glissade_inversion.F90
+++ b/libglissade/glissade_inversion.F90
@@ -31,7 +31,7 @@ module glissade_inversion
   use glimmer_log
   use glide_types
   use glide_thck, only: glide_calclsrf
-  use parallel_mod, only: this_rank, main_task, nhalo, &
+  use cism_parallel, only: this_rank, main_task, nhalo, &
        parallel_type, parallel_halo, staggered_parallel_halo, &
        parallel_reduce_min, parallel_reduce_max
 

--- a/libglissade/glissade_masks.F90
+++ b/libglissade/glissade_masks.F90
@@ -42,7 +42,7 @@
     use glimmer_log
     use glimmer_physcon, only: rhoi, rhoo
     use glide_types
-    use parallel_mod, only: this_rank, main_task, nhalo, parallel_globalindex, &
+    use cism_parallel, only: this_rank, main_task, nhalo, parallel_globalindex, &
          parallel_type, parallel_halo, parallel_reduce_sum
 
     implicit none

--- a/libglissade/glissade_remap.F90
+++ b/libglissade/glissade_remap.F90
@@ -59,7 +59,7 @@ module glissade_remap
   use glimmer_global, only: dp
   use glimmer_log
 
-  use parallel_mod, only: this_rank, parallel_type, parallel_halo, parallel_globalindex, broadcast
+  use cism_parallel, only: this_rank, parallel_type, parallel_halo, parallel_globalindex, broadcast
 
   implicit none
   save

--- a/libglissade/glissade_test.F90
+++ b/libglissade/glissade_test.F90
@@ -52,7 +52,7 @@ contains
 
   subroutine glissade_test_halo(model)
 
-    use parallel_mod, only: main_task, this_rank, uhalo, lhalo, staggered_lhalo, staggered_uhalo, &
+    use cism_parallel, only: main_task, this_rank, uhalo, lhalo, staggered_lhalo, staggered_uhalo, &
          parallel_type, parallel_halo, staggered_parallel_halo, parallel_globalID_scalar, &
          parallel_globalindex, parallel_halo_tracers
 
@@ -833,7 +833,7 @@ contains
     ! Optionally, these communicators can be used when solving a 1D system of equations
     !  along a single row or column of the domain.
 
-    use parallel_mod, only: parallel_type, this_rank, main_task, &
+    use cism_parallel, only: parallel_type, this_rank, main_task, &
          distributed_gather_var_row, distributed_gather_var_col, &
          distributed_scatter_var_row, distributed_scatter_var_col
     use mpi_mod

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -57,7 +57,7 @@ module glissade_therm
     use glimmer_global, only : dp 
     use glide_types
     use glimmer_log
-    use parallel_mod, only: this_rank, broadcast, parallel_globalindex
+    use cism_parallel, only: this_rank, broadcast, parallel_globalindex
 
     implicit none
 

--- a/libglissade/glissade_transport.F90
+++ b/libglissade/glissade_transport.F90
@@ -43,7 +43,7 @@
     use glimmer_global, only: dp
     use glimmer_log
     use glissade_remap, only: glissade_horizontal_remap, make_remap_mask, puny
-    use parallel_mod, only: this_rank, main_task, nhalo, lhalo, uhalo, staggered_lhalo, staggered_uhalo, &
+    use cism_parallel, only: this_rank, main_task, nhalo, lhalo, uhalo, staggered_lhalo, staggered_uhalo, &
          parallel_type, parallel_reduce_max, parallel_reduce_sum, parallel_reduce_minloc, &
          parallel_globalindex, broadcast
 

--- a/libglissade/glissade_utils.F90
+++ b/libglissade/glissade_utils.F90
@@ -33,7 +33,7 @@ module glissade_utils
   use glimmer_global, only: dp
   use glimmer_log
   use glide_types
-  use parallel_mod, only: this_rank, main_task
+  use cism_parallel, only: this_rank, main_task
 
   implicit none
 
@@ -60,7 +60,7 @@ contains
     !TODO: In this and the next two subroutines, we could pass in thck, topg, etc. instead of the model derived type.
 
     use glimmer_paramets, only: thk0
-    use parallel_mod, only: parallel_reduce_max
+    use cism_parallel, only: parallel_reduce_max
 
     !----------------------------------------------------------------
     ! Input-output arguments

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -88,7 +88,7 @@
          trilinos_test
 #endif
 
-    use parallel_mod, only: this_rank, main_task, nhalo, tasks, &
+    use cism_parallel, only: this_rank, main_task, nhalo, tasks, &
          parallel_type, parallel_halo, staggered_parallel_halo, parallel_globalindex, &
          parallel_reduce_max, parallel_reduce_sum, not_parallel
 

--- a/libglissade/glissade_velo_higher_pcg.F90
+++ b/libglissade/glissade_velo_higher_pcg.F90
@@ -46,7 +46,7 @@
     use glide_types   ! for preconditioning options
     use glimmer_log
     use profile, only: t_startf, t_stopf
-    use parallel_mod, only: this_rank, main_task, &
+    use cism_parallel, only: this_rank, main_task, &
          parallel_type, staggered_parallel_halo, parallel_reduce_sum
 
     implicit none
@@ -4634,7 +4634,7 @@
                                       first_time,   gather_data)
 
     use glimmer_utils, only: tridiag
-    use parallel_mod, only: distributed_gather_var_row, distributed_gather_var_col, &
+    use cism_parallel, only: distributed_gather_var_row, distributed_gather_var_col, &
          distributed_gather_all_var_row, distributed_gather_all_var_col, &
          distributed_scatter_var_row, distributed_scatter_var_col
 

--- a/libglissade/glissade_velo_higher_trilinos.F90
+++ b/libglissade/glissade_velo_higher_trilinos.F90
@@ -39,7 +39,7 @@
   module glissade_velo_higher_trilinos
 
     use glimmer_global, only: dp
-    use parallel_mod, only: this_rank, main_task, nhalo, staggered_parallel_halo
+    use cism_parallel, only: this_rank, main_task, nhalo, staggered_parallel_halo
 
     implicit none
     private

--- a/libglissade/glissade_velo_sia.F90
+++ b/libglissade/glissade_velo_sia.F90
@@ -62,7 +62,7 @@
     use glide_types
     use glissade_grid_operators, only: glissade_stagger, glissade_gradient, &
                                        glissade_gradient_at_edges
-    use parallel_mod, only: this_rank, main_task, nhalo, &
+    use cism_parallel, only: this_rank, main_task, nhalo, &
          parallel_halo, staggered_parallel_halo
 
     implicit none


### PR DESCRIPTION
The name of the parallel module was recently changed from 'parallel' to 'parallel_mod'.
This created a naming conflict in CESM builds.
The module name is now 'cism_parallel'.

The two parallel files are still called parallel_slap.F90 (for serial builds)
and parallel_mpi.F90 (for parallel MPI builds).

In the future, we might want to change names of other modules without a unique prefix
such as 'glide', 'glissade', 'glad', or 'cism'.