### PR TITLE
Changes to support CESM ocean coupling

### DIFF
--- a/libglad/glad_mbal_coupling.F90
+++ b/libglad/glad_mbal_coupling.F90
@@ -104,9 +104,7 @@ contains
 
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-  subroutine glad_accumulate_input_gcm(params, time, acab, artm, thermal_forcing) !, &
-!                                       thermal_forcing2, thermal_forcing3, thermal_forcing4,  &
-!                                       thermal_forcing5, thermal_forcing6, thermal_forcing7)
+  subroutine glad_accumulate_input_gcm(params, time, acab, artm, thermal_forcing)
 
     ! In glint, this was done in glint_downscale.F90
     
@@ -115,7 +113,7 @@ contains
 
     real(dp),dimension(:,:),intent(in) :: acab   ! Surface mass balance (m)
     real(dp),dimension(:,:),intent(in) :: artm   ! Mean air temperature (degC)
-    real(dp),dimension(:,:,:),intent(in) :: thermal_forcing   ! Mean thermal_forcing at level 0 (degK)
+    real(dp),dimension(:,:,:),intent(in) :: thermal_forcing   ! Ocean thermal_forcing (degK)
 
     ! Things to do the first time
 
@@ -161,7 +159,7 @@ contains
     integer,                intent(in)   :: dt     !> mbal accumulation time (hours)
     real(dp),dimension(:,:),intent(out)  :: artm   !> Mean air temperature (degC)
     real(dp),dimension(:,:),intent(out)  :: acab   !> Mass-balance (m/yr)
-    real(dp),dimension(:,:,:),intent(out)  :: thermal_forcing   ! Mean thermal_forcing at level 0 (degK)
+    real(dp),dimension(:,:,:),intent(out)  :: thermal_forcing   ! Ocean thermal_forcing (degK)
 
     if (.not. params%new_accum) then
        params%artm_save = params%artm_save / real(params%av_count,dp)

--- a/libglad/glad_timestep.F90
+++ b/libglad/glad_timestep.F90
@@ -66,6 +66,7 @@ contains
     use glide
     use glissade
     use glide_io
+    use glide_types
     use glad_mbal_coupling, only : glad_accumulate_input_gcm, glad_average_input_gcm
     use glad_io
     use glad_mbal_io
@@ -200,16 +201,21 @@ contains
           call glide_set_acab(instance%model, instance%acab * rhow/rhoi)
           call glide_set_artm(instance%model, instance%artm)
 
+          ! Note: CISM has several thermal forcing options, as determined by ocean_data_domain:
+          !        compute internally, read from external file, or receive from Glad.
+          !       Only if receiving from Glad do we set instance%model%ocean_data%thermal_forcing here.
+          !
           ! Note: The ocean thermal forcing is reset only on the first ice dynamics timestep within this loop.
-          ! The reason is that CISM has the option of extrapolating thermal forcing from open ocean
-          !  (i.e., the overlap region between the ocean and ice sheet domains) into sub-shelf cavities.
-          ! It is more efficient to do this extrapolation only once within the mass_balance timestep
-          !  (with minor subsequent adjustments if CISM ice shelves retreat) than to extrapolate
-          !  from the open ocean every ice dynamics time step.
+          !       The reason is that CISM has the option of extrapolating thermal forcing from open ocean
+          !        (i.e., the overlap region between the ocean and ice sheet domains) into sub-shelf cavities.
+          !       It is more efficient to do this extrapolation only once within the mass_balance timestep
+          !        (with minor subsequent adjustments if CISM ice shelves retreat) than to extrapolate
+          !        from the open ocean every ice dynamics time step.
 
           if (iter == 1) then
-             if ( associated(instance%model%ocean_data%thermal_forcing) ) then
-                ! GL: At this point, glide_set does not work for 3D variables.
+             if ( associated(instance%model%ocean_data%thermal_forcing) .and. &
+                  instance%model%options%ocean_data_domain == OCEAN_DATA_GLAD) then
+                ! GRL: At this point, glide_set does not work for 3D variables.
                 instance%model%ocean_data%thermal_forcing = instance%thermal_forcing
              endif
           endif

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -722,6 +722,7 @@ contains
     call GetValue(section,'bmlt_float_thermal_forcing_param',model%options%bmlt_float_thermal_forcing_param)
     call GetValue(section,'bmlt_float_ismip6_magnitude',model%options%bmlt_float_ismip6_magnitude)
     call GetValue(section,'ocean_data_domain',model%options%ocean_data_domain)
+    call GetValue(section,'ocean_data_extrapolate',model%options%ocean_data_extrapolate)
     call GetValue(section,'enable_bmlt_anomaly',model%options%enable_bmlt_anomaly)
     call GetValue(section,'basal_mass_balance',model%options%basal_mbal)
     call GetValue(section,'smb_input',model%options%smb_input)
@@ -936,9 +937,13 @@ contains
          'highest forcing magnitude '  /)
 
     character(len=*), dimension(0:2), parameter :: ocean_data_domain = (/ &
-         'data from external ocean model domain; extrapolate to cavities', &
-         'ocean data already extrapolated to ice shelf cavities         ', &
-         'apply data in CISM ice-free ocean; extrapolate to cavities    ' /)
+         'ocean data computed internally by CISM', &
+         'ocean data read from external file    ', &
+         'ocean data from coupler via Glad      ' /)
+
+    character(len=*), dimension(0:1), parameter :: ocean_data_extrapolate = (/ &
+         'ocean data not extrapolated to cavities', &
+         'ocean data extrapolated to cavities    ' /)
 
     character(len=*), dimension(0:1), parameter :: smb_input = (/ &
          'SMB input in units of m/yr ice  ', &
@@ -1521,6 +1526,9 @@ contains
        endif
        write(message,*) 'ocean data domain       : ', model%options%ocean_data_domain, &
             ocean_data_domain(model%options%ocean_data_domain)
+       call write_log(message)
+       write(message,*) 'ocean data extrapolate  : ', model%options%ocean_data_extrapolate, &
+            ocean_data_extrapolate(model%options%ocean_data_extrapolate)
        call write_log(message)
     endif
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -137,9 +137,12 @@ module glide_types
   integer, parameter :: BMLT_FLOAT_ISMIP6_MEDIAN = 1
   integer, parameter :: BMLT_FLOAT_ISMIP6_PCT95 = 2
 
-  integer, parameter :: DATA_OCEAN_ONLY = 0
-  integer, parameter :: DATA_OCEAN_ICE = 1
-  integer, parameter :: DATA_CISM_OCEAN_MASK = 2
+  integer, parameter :: OCEAN_DATA_INTERNAL = 0
+  integer, parameter :: OCEAN_DATA_EXTERNAL = 1
+  integer, parameter :: OCEAN_DATA_GLAD = 2
+
+  integer, parameter :: OCEAN_DATA_EXTRAPOLATE_FALSE = 0
+  integer, parameter :: OCEAN_DATA_EXTRAPOLATE_TRUE = 1
 
   integer, parameter :: BASAL_MBAL_NO_CONTINUITY = 0
   integer, parameter :: BASAL_MBAL_CONTINUITY = 1
@@ -522,12 +525,18 @@ module glide_types
     !> \item[2] High level of forcing (e.g., pct95)
     !> \end{description}
 
-    integer :: ocean_data_domain = 0
+    integer :: ocean_data_domain = 1
 
     !> \begin{description}
-    !> \item[0] ocean data on ocean domain only; extrapolate data to shelf cavities
-    !> \item[1] ocean data available everywhere; already extrapolated to shelf cavities
-    !> \item[2] ocean data applied where CISM has ice-free ocean; extrapolated to shelf cavities
+    !> \item[0] ocean data computed internally by CISM
+    !> \item[1] ocean data read from external file
+    !> \item[2] ocean data received from coupler via Glad
+    !> \end{description}
+
+    integer :: ocean_data_extrapolate = 0
+    !> \begin{description}
+    !> \item[0] ocean data not extrapolated to shelf cavities
+    !> \item[1] ocean data extrapolated to shelf cavities
     !> \end{description}
 
     logical :: enable_bmlt_anomaly = .false.


### PR DESCRIPTION
This commit includes several changes to support CISM coupling with POP in CESM.

* Modified the ocean_data_domain option, which determines where thermal forcing is computed.
  There are still three values, but they have new meanings:
  (0) ocean data computed internally by CISM (not yet supported)
  (1) ocean data read from external file (default; used for ISMIP6 runs)
  (2) ocean data received from coupler via Glad (used for CESM coupled runs)
* Added an ocean_data_extrapolate option.
  (0) Do not extrapolate ocean thermal forcing to ice-shelf cavities (default; used for ISMIP6 runs)
  (1) Extrapolate ocean thermal forcing to ice-shelf cavities (used for CESM coupled runs with POP)
* Modified logic in subroutine glad_i_tstep_gcm of glad_timestep.F90 so that TF from Glad
  does not overwrite TF from the CISM input file unless ocean_data_domain = 2.
* Other minor changes: Added a parallel_boundary_value interface; fixed a diagnostic print error; 
  cleaned up some comments and diagnostics

With these changes, the code runs to completion in cism-wrapper tests with a dynamic
Antarctic ice sheet, both when reading TF from an input file and when deriving TF
from idealized T and S fields set in Glad.
Note:  These tests require cism-wrapper changes in namelist_definition_cism.xml to support
the ocean_data_domain and ocean_data_extrapolate options.