### PR TITLE
Added a steady-state basal water routing scheme

### DIFF
--- a/libglide/felix_dycore_interface.F90
+++ b/libglide/felix_dycore_interface.F90
@@ -146,7 +146,7 @@ contains
    subroutine felix_velo_driver(model)
 
       use glimmer_global, only : dp
-      use glimmer_physcon, only: gn, scyr
+      use glimmer_physcon, only: scyr
       use glimmer_paramets, only: thk0, len0, vel0, vis0
       use glimmer_log
       use glide_types

--- a/libglide/glide.F90
+++ b/libglide/glide.F90
@@ -602,8 +602,8 @@ contains
           call calcbwat(model, &
                         model%options%whichbwat, &
                         model%basal_melt%bmlt, &
-                        model%temper%bwat, &
-                        model%temper%bwatflx, &
+                        model%basal_hydro%bwat, &
+                        model%basal_hydro%bwatflx, &
                         model%geometry%thck, &
                         model%geometry%topg, &
                         model%temper%temp(model%general%upn,:,:), &
@@ -612,8 +612,8 @@ contains
 
 
           ! This call is redundant for now, but is needed if the call to calcbwat is removed
-          call stagvarb(model%temper%bwat, &
-                        model%temper%stagbwat ,&
+          call stagvarb(model%basal_hydro%bwat, &
+                        model%basal_hydro%stagbwat ,&
                         model%general%ewn, &
                         model%general%nsn)
 
@@ -867,8 +867,8 @@ contains
        call calcbwat(model, &
                      model%options%whichbwat, &
                      model%basal_melt%bmlt, &
-                     model%temper%bwat, &
-                     model%temper%bwatflx, &
+                     model%basal_hydro%bwat, &
+                     model%basal_hydro%bwatflx, &
                      model%geometry%thck, &
                      model%geometry%topg, &
                      model%temper%temp(model%general%upn,:,:), &

--- a/libglide/glide_bwater.F90
+++ b/libglide/glide_bwater.F90
@@ -195,8 +195,8 @@ contains
     end select
 
     ! now also calculate basal water in velocity (staggered) coord system
-    call stagvarb(model%temper%bwat, &
-                  model%temper%stagbwat ,&
+    call stagvarb(model%basal_hydro%bwat, &
+                  model%basal_hydro%stagbwat ,&
                   model%general%ewn, &
                   model%general%nsn)
 
@@ -429,7 +429,7 @@ contains
   !> Compute the pressure wphi at the base of the ice sheet according to
   !> ice overburden plus bed height minus effective pressure.
   !>
-  !> whpi/(rhow*g) = topg + bwat * rhoi / rhow * thick - N / (rhow * g)
+  !> wphi/(rhow*g) = topg + bwat * rhoi / rhow * thick - N / (rhow * g)
 
     use glimmer_physcon, only : rhoi,rhow,grav
     implicit none

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -200,9 +200,12 @@ contains
          max_thck, max_thck_global,     &    ! max ice thickness (m)
          max_temp, max_temp_global,     &    ! max ice temperature (deg C)
          min_temp, min_temp_global,     &    ! min ice temperature (deg C)
-         max_bmlt, max_bmlt_global,     &    ! max basal melt rate (m/yr)
-         max_spd_sfc, max_spd_sfc_global,   &    ! max surface ice speed (m/yr)
-         max_spd_bas, max_spd_bas_global,   &    ! max basal ice speed (m/yr)
+         max_bmlt,                      &    ! max basal melt rate (m/yr)
+         max_bmlt_global,               &
+         max_bmlt_ground,               &    ! max basal melt rate, grounded ice (m/yr)
+         max_bmlt_ground_global,        &
+         max_spd_sfc, max_spd_sfc_global, &  ! max surface ice speed (m/yr)
+         max_spd_bas, max_spd_bas_global, &  ! max basal ice speed (m/yr)
          spd,                           &    ! speed
          thck_diag, usrf_diag,          &    ! local column diagnostics
          topg_diag, relx_diag,          &    
@@ -768,7 +771,8 @@ contains
                     min_temp_global, imin_global, jmin_global, kmin_global
     call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-    ! max basal melt rate
+    ! max applied basal melt rate
+    ! Usually, this will be for floating ice, if floating ice is present
     imax = 0
     jmax = 0
     max_bmlt = unphys_val
@@ -791,8 +795,36 @@ contains
     ! Write to diagnostics only if nonzero
 
     if (abs(max_bmlt_global*thk0*scyr/tim0) > eps) then
-       write(message,'(a25,f24.16,2i6)') 'Max bmlt (m/yr), i, j    ',   &
+       write(message,'(a25,f24.16,2i6)') 'Max bmlt (m/y), i, j     ',   &
             max_bmlt_global*thk0*scyr/tim0, imax_global, jmax_global
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+    endif
+
+    ! max basal melt rate for grounded ice
+    imax = 0
+    jmax = 0
+    max_bmlt_ground = unphys_val
+
+    do j = lhalo+1, nsn-uhalo
+       do i = lhalo+1, ewn-uhalo
+          if (model%basal_melt%bmlt_ground(i,j) > max_bmlt_ground) then
+             max_bmlt_ground = model%basal_melt%bmlt_ground(i,j)
+             imax = i
+             jmax = j
+          endif
+       enddo
+    enddo
+
+    call parallel_reduce_maxloc(xin=max_bmlt_ground, xout=max_bmlt_ground_global, xprocout=procnum)
+    call parallel_globalindex(imax, jmax, imax_global, jmax_global, parallel)
+    call broadcast(imax_global, proc = procnum)
+    call broadcast(jmax_global, proc = procnum)
+
+    ! Write to diagnostics only if nonzero
+
+    if (abs(max_bmlt_global*thk0*scyr/tim0) > eps) then
+       write(message,'(a25,f24.16,2i6)') 'Max bmlt grnd (m/y), i, j',   &
+            max_bmlt_ground_global*thk0*scyr/tim0, imax_global, jmax_global
        call write_log(trim(message), type = GM_DIAGNOSTIC)
     endif
 
@@ -818,7 +850,7 @@ contains
     call broadcast(imax_global, proc = procnum)
     call broadcast(jmax_global, proc = procnum)
 
-    write(message,'(a25,f24.16,2i6)') 'Max sfc spd (m/yr), i, j ',   &
+    write(message,'(a25,f24.16,2i6)') 'Max sfc spd (m/y), i, j  ',   &
                     max_spd_sfc_global*vel0*scyr, imax_global, jmax_global
     call write_log(trim(message), type = GM_DIAGNOSTIC)
 
@@ -843,7 +875,7 @@ contains
     call parallel_globalindex(imax, jmax, imax_global, jmax_global, parallel)
     call broadcast(imax_global, proc = procnum)
     call broadcast(jmax_global, proc = procnum)
-    write(message,'(a25,f24.16,2i6)') 'Max base spd (m/yr), i, j',   &
+    write(message,'(a25,f24.16,2i6)') 'Max base spd (m/y), i, j ',   &
                     max_spd_bas_global*vel0*scyr, imax_global, jmax_global
     call write_log(trim(message), type = GM_DIAGNOSTIC)
 

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -884,7 +884,7 @@ contains
           artm_diag = model%climate%artm_corrected(i,j)  ! artm_corrected = artm + artm_anomaly
           acab_diag = model%climate%acab_applied(i,j) * thk0*scyr/tim0
           bmlt_diag = model%basal_melt%bmlt_applied(i,j) * thk0*scyr/tim0
-          bwat_diag = model%temper%bwat(i,j) * thk0
+          bwat_diag = model%basal_hydro%bwat(i,j) * thk0
           bheatflx_diag = model%temper%bheatflx(i,j)
        
           temp_diag(:) = model%temper%temp(1:upn,i,j)          

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -160,7 +160,7 @@ contains
   subroutine glide_scale_params(model)
     !> scale parameters
     use glide_types
-    use glimmer_physcon,  only: scyr, gn
+    use glimmer_physcon,  only: scyr
     use glimmer_paramets, only: thk0, tim0, len0, vel0, vis0, acc0, tau0
 
     implicit none
@@ -1996,7 +1996,7 @@ contains
     use glimmer_config
     use glide_types
     use glimmer_log
-    use glimmer_physcon, only: rhoi, rhoo, grav, shci, lhci, trpt
+    use glimmer_physcon, only: rhoi, rhoo, grav, shci, lhci, trpt, n_glen
 
     implicit none
     type(ConfigSection), pointer :: section
@@ -2021,6 +2021,7 @@ contains
     call GetValue(section,'lhci', lhci)
     call GetValue(section,'trpt', trpt)
 #endif
+    call GetValue(section,'n_glen', n_glen)
 
     loglevel = GM_levels-GM_ERROR
     call GetValue(section,'log_level',loglevel)
@@ -2206,7 +2207,7 @@ contains
 
   subroutine print_parameters(model)
 
-    use glimmer_physcon, only: rhoi, rhoo, lhci, shci, trpt, grav
+    use glimmer_physcon, only: rhoi, rhoo, lhci, shci, trpt, grav, n_glen
     use glide_types
     use glimmer_log
     implicit none
@@ -2369,6 +2370,9 @@ contains
     call write_log(message)
 
     write(message,*) 'triple point of water (K)     : ', trpt
+    call write_log(message)
+
+    write(message,*) 'Glen flow law exponent        : ', n_glen
     call write_log(message)
 
     write(message,*) 'geothermal flux  (W/m^2)      : ', model%paramets%geot

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -786,6 +786,7 @@ contains
     call GetValue(section, 'which_ho_bmlt_inversion',     model%options%which_ho_bmlt_inversion)
     call GetValue(section, 'which_ho_bmlt_basin_inversion', model%options%which_ho_bmlt_basin_inversion)
     call GetValue(section, 'which_ho_bwat',               model%options%which_ho_bwat)
+    call GetValue(section, 'ho_flux_routing_scheme',      model%options%ho_flux_routing_scheme)
     call GetValue(section, 'which_ho_effecpress',         model%options%which_ho_effecpress)
     call GetValue(section, 'which_ho_resid',              model%options%which_ho_resid)
     call GetValue(section, 'which_ho_nonlinear',          model%options%which_ho_nonlinear)
@@ -1062,10 +1063,16 @@ contains
          'invert for basin-based basal melting parameters            ', &
          'apply basin basal melting parameters from earlier inversion' /)
 
-    character(len=*), dimension(0:2), parameter :: ho_whichbwat = (/ &
+    character(len=*), dimension(0:3), parameter :: ho_whichbwat = (/ &
          'zero basal water depth                          ', &
          'constant basal water depth                      ', &
-         'basal water depth computed from local till model' /)
+         'basal water depth computed from local till model', &
+         'steady-state water routing with flux calculation' /)
+
+    character(len=*), dimension(0:2), parameter :: ho_flux_routing_scheme = (/ &
+         'D8; route flux to lowest-elevation neighbor      ', &
+         'Dinf; route flux to two lower-elevation neighbors', &
+         'FD8; route flux to all lower-elevation neighbors ' /)
 
     character(len=*), dimension(0:4), parameter :: ho_whicheffecpress = (/ &
          'full overburden pressure                             ', &
@@ -1233,7 +1240,7 @@ contains
     end if
 
     if (tasks > 1 .and. model%options%whichbwat==BWATER_FLUX) then
-       call write_log('Error, flux-based basal water option not supported for more than one processor', GM_FATAL)
+       call write_log('Error, flux-based basal water option not yet supported for more than one processor', GM_FATAL)
     endif
 
     ! Forbidden options associated with Glissade dycore
@@ -1765,6 +1772,16 @@ contains
           call write_log('Error, HO basal water input out of range', GM_FATAL)
        end if
 
+       if (model%options%which_ho_bwat == HO_BWAT_FLUX_ROUTING) then
+          write(message,*) 'ho_flux_routing_scheme  : ',model%options%ho_flux_routing_scheme,  &
+               ho_flux_routing_scheme(model%options%ho_flux_routing_scheme)
+          call write_log(message)
+          if (model%options%ho_flux_routing_scheme < 0.or. &
+              model%options%ho_flux_routing_scheme >= size(ho_flux_routing_scheme)) then
+             call write_log('Error, HO flux routing scheme out of range', GM_FATAL)
+          end if
+       end if
+
        write(message,*) 'ho_whicheffecpress      : ',model%options%which_ho_effecpress,  &
                          ho_whicheffecpress(model%options%which_ho_effecpress)
        call write_log(message)
@@ -2103,9 +2120,9 @@ contains
     call GetValue(section, 'effecpress_bmlt_threshold', model%basal_physics%effecpress_bmlt_threshold)
 
     ! basal water parameters
-    call GetValue(section, 'const_bwat', model%basal_physics%const_bwat)
-    call GetValue(section, 'bwat_till_max', model%basal_physics%bwat_till_max)
-    call GetValue(section, 'c_drainage', model%basal_physics%c_drainage)
+    call GetValue(section, 'const_bwat', model%basal_hydro%const_bwat)
+    call GetValue(section, 'bwat_till_max', model%basal_hydro%bwat_till_max)
+    call GetValue(section, 'c_drainage', model%basal_hydro%c_drainage)
 
     ! pseudo-plastic parameters
     !TODO - Put pseudo-plastic and other basal sliding parameters in a separate section
@@ -2630,12 +2647,12 @@ contains
     endif
 
     if (model%options%which_ho_bwat == HO_BWAT_CONSTANT) then
-       write(message,*) 'constant basal water depth (m): ', model%basal_physics%const_bwat
+       write(message,*) 'constant basal water depth (m): ', model%basal_hydro%const_bwat
        call write_log(message)
     elseif (model%options%which_ho_bwat == HO_BWAT_LOCAL_TILL) then
-       write(message,*) 'maximum till water depth (m)  : ', model%basal_physics%bwat_till_max
+       write(message,*) 'maximum till water depth (m)  : ', model%basal_hydro%bwat_till_max
        call write_log(message)
-       write(message,*) 'till drainage rate (m/yr)     : ', model%basal_physics%c_drainage
+       write(message,*) 'till drainage rate (m/yr)     : ', model%basal_hydro%c_drainage
        call write_log(message)
     endif
 

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -883,11 +883,10 @@ contains
          'advective-diffusive balance ',&
          'temp from external file     ' /)
 
-    character(len=*), dimension(0:3), parameter :: flow_law = (/ &
-         'const 1e-16 Pa^-n a^-1      ', &
+    character(len=*), dimension(0:2), parameter :: flow_law = (/ &
+         'uniform factor flwa         ', &
          'Paterson and Budd (T = -5 C)', &
-         'Paterson and Budd           ', &
-         'read flwa/flwastag from file' /)
+         'Paterson and Budd           ' /)
 
     !TODO - Rename slip_coeff to which_btrc?
     character(len=*), dimension(0:5), parameter :: slip_coeff = (/ &
@@ -2034,9 +2033,9 @@ contains
     call GetValue(section,'pmp_offset',         model%temper%pmp_offset)
     call GetValue(section,'pmp_threshold',      model%temper%pmp_threshold)
     call GetValue(section,'geothermal',         model%paramets%geot)
-    !TODO - Change default_flwa to flwa_constant?  Would have to change config files.
     call GetValue(section,'flow_factor',        model%paramets%flow_enhancement_factor)
     call GetValue(section,'flow_factor_float',  model%paramets%flow_enhancement_factor_float)
+    !TODO - Change default_flwa to flwa_constant?  Would have to change config files.
     call GetValue(section,'default_flwa',       model%paramets%default_flwa)
     call GetValue(section,'efvs_constant',      model%paramets%efvs_constant)
     call GetValue(section,'effstrain_min',      model%paramets%effstrain_min)

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -959,10 +959,11 @@ contains
          'artm and d(artm)/dz input as function of (x,y)', &
          'artm input as function of (x,y,z)             ' /)
 
-    character(len=*), dimension(0:2), parameter :: overwrite_acab = (/ &
+    character(len=*), dimension(0:3), parameter :: overwrite_acab = (/ &
          'do not overwrite acab anywhere            ', &
          'overwrite acab where input acab = 0       ', &
-         'overwrite acab where input thck <= minthck' /)
+         'overwrite acab where input thck <= minthck', &
+         'overwrite acab based on input mask        ' /)
 
     ! NOTE: Set gthf = 1 in the config file to read the geothermal heat flux from an input file.
     !       Otherwise it will be overwritten, even if the 'bheatflx' field is present.
@@ -3343,7 +3344,7 @@ contains
         ! other Glissade options
 
         ! If overwriting acab in certain grid cells, than overwrite_acab_mask needs to be in the restart file.
-        ! This mask is set at model initialization based on the input acab or ice thickness.
+        ! This mask is read in at model initialization, or is set based on the input acab or ice thickness.
         if (options%overwrite_acab /= 0) then
            call glide_add_to_restart_variable_list('overwrite_acab_mask')
         endif

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -745,6 +745,7 @@ contains
     call GetValue(section,'cull_calving_front', model%options%cull_calving_front)
     call GetValue(section,'adjust_input_thickness', model%options%adjust_input_thickness)
     call GetValue(section,'smooth_input_topography', model%options%smooth_input_topography)
+    call GetValue(section,'smooth_input_usrf', model%options%smooth_input_usrf)
     call GetValue(section,'adjust_input_topography', model%options%adjust_input_topography)
     call GetValue(section,'read_lat_lon',model%options%read_lat_lon)
     call GetValue(section,'dm_dt_diag',model%options%dm_dt_diag)
@@ -1075,12 +1076,13 @@ contains
          'Dinf; route flux to two lower-elevation neighbors', &
          'FD8; route flux to all lower-elevation neighbors ' /)
 
-    character(len=*), dimension(0:4), parameter :: ho_whicheffecpress = (/ &
+    character(len=*), dimension(0:5), parameter :: ho_whicheffecpress = (/ &
          'full overburden pressure                             ', &
          'reduced effecpress near pressure melting point       ', &
          'reduced effecpress where there is melting at the bed ', &
          'reduced effecpress where bed is connected to ocean   ', &
-         'reduced effecpress with increasing basal water       '/)
+         'reduced effecpress with increasing basal water (B/vP)', &
+         'reduced effecpress with increasing basal water (ramp)'/)
 
     character(len=*), dimension(0:1), parameter :: which_ho_nonlinear = (/ &
          'use standard Picard iteration          ', &
@@ -1411,6 +1413,11 @@ contains
 
        if (model%options%adjust_input_thickness) then
           write(message,*) ' Input ice thickness will be adjusted based on surface and bed topography'
+          call write_log(message)
+       endif
+
+       if (model%options%smooth_input_usrf) then
+          write(message,*) ' Input usrf will be smoothed'
           call write_log(message)
        endif
 

--- a/libglide/glide_temp.F90
+++ b/libglide/glide_temp.F90
@@ -512,7 +512,7 @@ contains
 
                 call corrpmpt(model%temper%temp(:,ew,ns),     &
                               model%geometry%thck(ew,ns),     &
-                              model%temper%bwat(ew,ns),       &
+                              model%basal_hydro%bwat(ew,ns),  &
                               model%numerics%sigma,           &
                               model%general%upn)
             
@@ -560,7 +560,7 @@ contains
 
                    call corrpmpt(model%temper%temp(:,ew,ns),     &
                                  model%geometry%thck(ew,ns),     &
-                                 model%temper%bwat(ew,ns),       &
+                                 model%basal_hydro%bwat(ew,ns),  &
                                  model%numerics%sigma,           &
                                  model%general%upn)
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -104,7 +104,6 @@ module glide_types
   integer, parameter :: FLWA_CONST_FLWA = 0
   integer, parameter :: FLWA_PATERSON_BUDD_CONST_TEMP = 1
   integer, parameter :: FLWA_PATERSON_BUDD = 2
-  integer, parameter :: FLWA_INPUT = 3
 
   integer, parameter :: BTRC_ZERO = 0
   integer, parameter :: BTRC_CONSTANT = 1
@@ -470,7 +469,6 @@ module glide_types
     !> \item[1] \emph{Paterson and Budd} relationship, 
     !> with temperature set to $-5^{\circ}\mathrm{C}$ 
     !> \item[2] \emph{Paterson and Budd} relationship
-    !> \item[3] Read flwa/flwastag from file
     !> \end{description}
 
     integer :: whichbtrc = 0
@@ -2148,6 +2146,7 @@ module glide_types
   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
   !TODO - Move these parameters to types associated with a certain kind of physics
+  !TODO - Set default geot = 0, so that idealized tests by default have no mass loss
   type glide_paramets
     real(dp),dimension(5) :: bpar = (/ 0.2d0, 0.5d0, 0.0d0 ,1.0d-2, 1.0d0/)
     real(dp) :: btrac_const = 0.d0     ! m yr^{-1} Pa^{-1} (gets scaled during init)

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1945,7 +1945,7 @@ module glide_types
                                                  !> Where u > umax, let u = umax when evaluating beta(u)
 
      ! Note: A basal process model is not currently supported, but a specified mintauf can be passed to subroutine calcbeta
-     !       to simulate a plastic bed..
+     !       to simulate a plastic bed.
      real(dp),dimension(:,:)  ,pointer :: mintauf => null() ! Bed strength (yield stress) calculated with basal process model
 
   end type glide_basal_physics

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -282,6 +282,11 @@ module glide_types
   integer, parameter :: HO_BWAT_NONE = 0
   integer, parameter :: HO_BWAT_CONSTANT = 1
   integer, parameter :: HO_BWAT_LOCAL_TILL = 2
+  integer, parameter :: HO_BWAT_FLUX_ROUTING = 3
+
+  integer, parameter :: HO_FLUX_ROUTING_D8 = 0
+  integer, parameter :: HO_FLUX_ROUTING_DINF = 1
+  integer, parameter :: HO_FLUX_ROUTING_FD8 = 2
 
   !TODO - Remove option 2? Rarely used
   integer, parameter :: HO_EFFECPRESS_OVERBURDEN = 0
@@ -834,6 +839,15 @@ module glide_types
     !> \item[0] Set to zero everywhere
     !> \item[1] Set to constant everywhere, to force T = Tpmp.
     !> \item[2] Local basal till model with constant drainage
+    !> \item[3] Steady-state water routing with flux calculation
+    !> \end{description}
+
+    integer :: ho_flux_routing_scheme = 0
+    !> Flux routing scheme for basal water:
+    !> \begin{description}
+    !> \item[0] D8; send flux to lowest-elevation neighbor
+    !> \item[1] Dinf; divide flux between two lower-elevation neighbors
+    !> \item[2] FD8; divide flux amond all lower-elevation neighbors
     !> \end{description}
 
     integer :: which_ho_effecpress = 0
@@ -1523,12 +1537,6 @@ module glide_types
     real(dp),dimension(:,:),  pointer :: lcondflx => null()  !> conductive heat flux (W/m^2) at lower sfc (positive down)
     real(dp),dimension(:,:),  pointer :: dissipcol => null() !> total heat dissipation rate (W/m^2) in column (>= 0)
 
-     ! fields related to basal water
-     !TODO - Move these fields to the basal_physics type?
-     real(dp),dimension(:,:),  pointer :: bwat => null()      !> Basal water depth
-     real(dp),dimension(:,:),  pointer :: bwatflx => null()   !> Basal water flux 
-     real(dp),dimension(:,:),  pointer :: stagbwat => null()  !> Basal water depth on velo grid
-
     real(dp) :: pmp_offset = 5.0d0        ! offset of initial Tbed from pressure melting point temperature (deg C)
     real(dp) :: pmp_threshold = 1.0d-3    ! bed is assumed thawed where Tbed >= pmptemp - pmp_threshold (deg C)
 
@@ -1817,9 +1825,46 @@ module glide_types
 
   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+  type glide_basal_hydro
+
+     !> Holds variables related to basal hydrology
+     !> See glissade_bwater.F90 for usage details
+
+     ! fields related to basal water
+     ! Note: Ideally, bwat should have MKS units (m), but currently is scaled.
+     real(dp),dimension(:,:),  pointer :: bwat => null()      !> Basal water depth
+     real(dp),dimension(:,:),  pointer :: stagbwat => null()  !> Basal water depth on velo grid
+     real(dp),dimension(:,:),  pointer :: bwatflx => null()   !> Basal water flux (m^3/s)
+     real(dp),dimension(:,:),  pointer :: head => null()      !> Hydraulic head (m)
+
+     ! parameter for constant basal water
+     ! Note: This parameter applies to teh case HO_BWAT_CONSTANT.
+     ! For Glide's BWATER_CONST, the constant value is hardwired in subroutine calcbwat.
+     real(dp) :: const_bwat = 10.d0              !> constant basal water depth (m)
+
+     ! parameters for local till model
+     ! These parameters apply to the case HO_BWAT_LOCAL_TILL.
+     ! The default values are from Aschwanden et al. (2016) and Bueler and van Pelt (2015).
+     real(dp) :: bwat_till_max = 2.0d0           !> maximum water depth in till (m)
+     real(dp) :: c_drainage = 1.0d-3             !> uniform drainage rate (m/yr)
+     real(dp) :: N_0 = 1000.d0                   !> reference effective pressure (Pa)
+     real(dp) :: e_0 = 0.69d0                    !> reference void ratio (dimensionless)
+     real(dp) :: C_c = 0.12d0                    !> till compressibility (dimensionless)
+                                                 !> Note: The ratio (e_0/C_c) is the key parameter
+
+     ! parameters for steady-state flux-routing model
+     ! Could add visc_water and omega_hydro here; currently set in glissade_bwater module
+     ! Some of these parameters might apply to more general models like SHAKTI
+
+  end type glide_basal_hydro
+
+  !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
   type glide_basal_physics
+
      !> Holds variables related to basal physics associated with ice dynamics
      !> See glissade_basal_traction.F90 for usage details
+     !> TODO: Divide into separate types for basal friction/sliding and basal hydrology?
 
      !Note: By default, beta_grounded_min is set to a small nonzero value.
      !      Larger values (~10 to 100 Pa yr/m) might be needed for stability in realistic simulations.
@@ -1888,20 +1933,6 @@ module glide_types
      ! parameter to limit the min value of beta for various power laws
      real(dp) :: beta_powerlaw_umax = 0.0d0      !> upper limit of ice speed (m/yr) when evaluating powerlaw beta
                                                  !> Where u > umax, let u = umax when evaluating beta(u)
-
-     ! parameter for constant basal water
-     ! Note: This parameter applies to HO_BWAT_CONSTANT only.
-     !       For Glide's BWATER_CONST, the constant value is hardwired in subroutine calcbwat.
-     real(dp) :: const_bwat = 10.d0              !> constant basal water depth (m)
-
-     ! parameters for local till model
-     ! The default values are from Aschwanden et al. (2016) and Bueler and van Pelt (2015).
-     real(dp) :: bwat_till_max = 2.0d0           !> maximum water depth in till (m)
-     real(dp) :: c_drainage = 1.0d-3             !> uniform drainage rate (m/yr)
-     real(dp) :: N_0 = 1000.d0                   !> reference effective pressure (Pa)
-     real(dp) :: e_0 = 0.69d0                    !> reference void ratio (dimensionless)
-     real(dp) :: C_c = 0.12d0                    !> till compressibility (dimensionless)
-                                                 !> Note: The ratio (e_0/C_c) is the key parameter
 
      ! Note: A basal process model is not currently supported, but a specified mintauf can be passed to subroutine calcbeta
      !       to simulate a plastic bed..
@@ -2277,6 +2308,7 @@ module glide_types
     type(eismint_climate_type) :: eismint_climate
     type(glide_calving)  :: calving
     type(glide_temper)   :: temper
+    type(glide_basal_hydro)  :: basal_hydro
     type(glide_basal_physics):: basal_physics
     type(glide_basal_melt)   :: basal_melt
     type(glide_ocean_data)   :: ocean_data
@@ -2315,7 +2347,6 @@ contains
     !> \item \texttt{bheatflx(ewn,nsn)}
     !> \item \texttt{flwa(upn,ewn,nsn)}           !WHL - 2 choices
     !> \item \texttt{dissip(upn,ewn,nsn)}         !WHL - 2 choices
-    !> \item \texttt{bwat(ewn,nsn)}
     !> \item \texttt{bfricflx(ewn,nsn)}
     !> \item \texttt{ucondflx(ewn,nsn)}
     !> \item \texttt{lcondflx(ewn,nsn)}
@@ -2527,8 +2558,6 @@ contains
          model%temper%tempunstag(:,:,:) = unphys_val
 
     call coordsystem_allocate(model%general%ice_grid,  model%temper%bheatflx)
-    call coordsystem_allocate(model%general%ice_grid,  model%temper%bwat)
-    call coordsystem_allocate(model%general%velo_grid, model%temper%stagbwat)
     call coordsystem_allocate(model%general%ice_grid,  model%temper%bpmp)
     call coordsystem_allocate(model%general%velo_grid, model%temper%stagbpmp)
     call coordsystem_allocate(model%general%ice_grid,  model%temper%btemp)
@@ -2537,9 +2566,14 @@ contains
     call coordsystem_allocate(model%general%velo_grid, model%temper%stagbtemp)
     call coordsystem_allocate(model%general%ice_grid,  model%temper%ucondflx)
 
-    if (model%options%whichdycore == DYCORE_GLIDE) then   ! glide only
-       call coordsystem_allocate(model%general%ice_grid, model%temper%bwatflx)
-    else   ! glissade only
+    call coordsystem_allocate(model%general%ice_grid,  model%basal_hydro%bwat)
+    call coordsystem_allocate(model%general%velo_grid, model%basal_hydro%stagbwat)
+    call coordsystem_allocate(model%general%ice_grid,  model%basal_hydro%bwatflx)
+    if (model%options%which_ho_bwat == HO_BWAT_FLUX_ROUTING) then
+       call coordsystem_allocate(model%general%ice_grid,  model%basal_hydro%head)
+    endif
+
+    if (model%options%whichdycore == DYCORE_GLISSADE) then   ! glissade only
        call coordsystem_allocate(model%general%ice_grid, model%temper%bfricflx)
        call coordsystem_allocate(model%general%ice_grid, model%temper%lcondflx)
        call coordsystem_allocate(model%general%ice_grid, model%temper%dissipcol)
@@ -2956,12 +2990,6 @@ contains
         deallocate(model%temper%tempunstag)
     if (associated(model%temper%bheatflx)) &
         deallocate(model%temper%bheatflx)
-    if (associated(model%temper%bwat)) &
-        deallocate(model%temper%bwat)
-    if (associated(model%temper%bwatflx)) &
-        deallocate(model%temper%bwatflx)
-    if (associated(model%temper%stagbwat)) &
-        deallocate(model%temper%stagbwat)
     if (associated(model%temper%bpmp)) &
         deallocate(model%temper%bpmp)
     if (associated(model%temper%stagbpmp)) &
@@ -3117,6 +3145,16 @@ contains
         deallocate(model%stress%taudx)
     if (associated(model%stress%taudy)) &
         deallocate(model%stress%taudy)
+
+    ! basal hydrology arrays
+    if (associated(model%basal_hydro%bwat)) &
+        deallocate(model%basal_hydro%bwat)
+    if (associated(model%basal_hydro%stagbwat)) &
+        deallocate(model%basal_hydro%stagbwat)
+    if (associated(model%basal_hydro%bwatflx)) &
+        deallocate(model%basal_hydro%bwatflx)
+    if (associated(model%basal_hydro%head)) &
+        deallocate(model%basal_hydro%head)
 
     ! basal physics arrays
     if (associated(model%basal_physics%bpmp_mask)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -295,6 +295,7 @@ module glide_types
   integer, parameter :: HO_EFFECPRESS_BMLT = 2
   integer, parameter :: HO_EFFECPRESS_OCEAN_PENETRATION = 3
   integer, parameter :: HO_EFFECPRESS_BWAT = 4
+  integer, parameter :: HO_EFFECPRESS_BWAT_RAMP = 5
 
   !WHL - added Picard acceleration option
   integer, parameter :: HO_NONLIN_PICARD = 0
@@ -675,6 +676,9 @@ module glide_types
     logical :: adjust_input_thickness = .false.
     !> if true, then adjust thck to maintain usrf, instead of deriving usrf from topg and thck
 
+    logical :: smooth_input_usrf = .false.
+    !> if true, then apply Laplacian smoothing to usrf at initialization
+
     logical :: smooth_input_topography = .false.
     !> if true, then apply Laplacian smoothing to the topography at initialization
 
@@ -862,7 +866,8 @@ module glide_types
     !> \item[1] N is reduced where the bed is at or near the pressure melting point
     !> \item[2] N is reduced where there is melting at the bed
     !> \item[3] N is reduced due to connection of subglacial water to the ocean
-    !> \item[4] N is reduced where basal water is present
+    !> \item[4] N is reduced where basal water is present, following Bueler/van Pelt
+    !> \item[5] N is reduced where basal water is present, with a ramp function
     !> \end{description}
 
     integer :: which_ho_nonlinear = 0

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -160,6 +160,7 @@ module glide_types
   integer, parameter :: OVERWRITE_ACAB_NONE = 0
   integer, parameter :: OVERWRITE_ACAB_ZERO_ACAB = 1
   integer, parameter :: OVERWRITE_ACAB_THCKMIN = 2
+  integer, parameter :: OVERWRITE_ACAB_INPUT_MASK = 3
 
   integer, parameter :: GTHF_UNIFORM = 0
   integer, parameter :: GTHF_PRESCRIBED_2D = 1
@@ -402,8 +403,11 @@ module glide_types
 
     integer :: global_bc = 0     ! 0 for periodic, 1 for outflow, 2 for no_penetration, 3 for no_ice
 
-    !WHL - added to handle the active-blocks option
+    ! added to handle the active-blocks option
     integer, dimension(:,:), pointer :: ice_domain_mask => null()  ! = 1 for cells that are potentially active
+
+    ! mask to identify cells at the edge of the global domain
+    integer, dimension(:,:), pointer :: global_edge_mask => null() ! = 1 for cells at edge of global domain
 
     integer :: nx_block = 0      ! user-specified block sizes
     integer :: ny_block = 0      ! one task per block; optionally, tasks not assigned to inactive blocks
@@ -592,6 +596,7 @@ module glide_types
     !> \item[0] Do not overwrite acab anywhere
     !> \item[1] Overwrite acab where input acab = 0
     !> \item[2] Overwrite acab where input thickness <= threshold value
+    !> \item[3] Overwrite acab where input mask = 1
     !> \end{description}
 
     integer :: gthf = 0
@@ -2526,6 +2531,9 @@ contains
     ! ice domain mask (to identify active blocks)
     call coordsystem_allocate(model%general%ice_grid, model%general%ice_domain_mask)
 
+    ! mask to identify cells at global domain edge
+    call coordsystem_allocate(model%general%ice_grid, model%general%global_edge_mask)
+
     ! temperature arrays
 
     !NOTE: In the glide dycore (whichdycore = DYCORE_GLIDE), the temperature and 
@@ -2972,6 +2980,8 @@ contains
         deallocate(model%general%lon)
     if (associated(model%general%ice_domain_mask)) &
         deallocate(model%general%ice_domain_mask)
+    if (associated(model%general%global_edge_mask)) &
+        deallocate(model%general%global_edge_mask)
 
     ! vertical sigma coordinates
 

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1122,7 +1122,7 @@ load:          1
 dimensions:    time, y1, x1
 units:         meter
 long_name:     basal water depth
-data:          data%temper%bwat
+data:          data%basal_hydro%bwat
 factor:        thk0
 load:          1
 
@@ -1130,8 +1130,15 @@ load:          1
 dimensions:    time, y1, x1
 units:         meter3/year
 long_name:     basal water flux
-data:          data%temper%bwatflx
-factor:        thk0
+data:          data%basal_hydro%bwatflx
+factor:        scyr
+
+[head]
+dimensions:    time, y1, x1
+units:         meter
+long_name:     hydraulic head
+data:          data%basal_hydro%head
+factor:        1
 
 [effecpress]
 dimensions:    time, y1, x1

--- a/libglide/glide_velo.F90
+++ b/libglide/glide_velo.F90
@@ -1033,7 +1033,7 @@ contains
 
        do ns = 1,nsn-1
           do ew = 1,ewn-1
-             if (0.0d0 < model%temper%stagbwat(ew,ns)) then
+             if (0.0d0 < model%basal_hydro%stagbwat(ew,ns)) then
                 btrc(ew,ns) = model%velocity%bed_softness(ew,ns)
              else
                 btrc(ew,ns) = 0.0d0
@@ -1078,10 +1078,10 @@ contains
 
        do ns = 1,nsn-1
           do ew = 1,ewn-1
-             if (0.0d0 < model%temper%stagbwat(ew,ns)) then
+             if (0.0d0 < model%basal_hydro%stagbwat(ew,ns)) then
                
                 btrc(ew,ns) = model%velowk%c(1) + model%velowk%c(2) * tanh(model%velowk%c(3) * &
-                     model%temper%stagbwat(ew,ns) - model%velowk%c(4))
+                     model%basal_hydro%stagbwat(ew,ns) - model%velowk%c(4))
                 
                 if (0.0d0 > sum(model%isostasy%relx(ew:ew+1,ns:ns+1))) then
                    btrc(ew,ns) = btrc(ew,ns) * model%velowk%marine  

--- a/libglimmer/glimmer_paramets.F90
+++ b/libglimmer/glimmer_paramets.F90
@@ -33,7 +33,7 @@
 module glimmer_paramets
 
   use glimmer_global, only : dp
-  use glimmer_physcon, only : scyr, gn
+  use glimmer_physcon, only : scyr
 
   implicit none
   save
@@ -118,6 +118,7 @@ module glimmer_paramets
   real(dp), parameter :: grav_glam = 9.81d0           ! m s^{-2}
 
   ! GLAM scaling parameters; units are correct if thk0 has units of meters
+  integer, parameter :: gn = 3                              ! Glen flow exponent; fixed at 3 for purposes of setting vis0
   real(dp), parameter :: tau0 = rhoi_glam*grav_glam*thk0    ! stress scale in GLAM ( Pa )  
   real(dp), parameter :: evs0 = tau0 / (vel0/len0)          ! eff. visc. scale in GLAM ( Pa s )
   real(dp), parameter :: vis0 = tau0**(-gn) * (vel0/len0)   ! rate factor scale in GLAM ( Pa^-3 s^-1 )

--- a/libglimmer/glimmer_physcon.F90
+++ b/libglimmer/glimmer_physcon.F90
@@ -79,11 +79,17 @@ module glimmer_physcon
 !  real(dp) :: trpt = 273.16d0                     !< Triple point of water (K)
 #endif
 
+  ! The Glen flow-law exponent, n_glen, is used in Glissade.
+  ! It is not a parameter, because the default can be overridden in the config file.
+  ! TODO: Allow setting n_glen independently for each ice sheet instance?
+  ! Note: Earlier code used an integer parameter, gn = 3, for all flow-law calculations.
+  !       For backward compatiblity, gn = 3 is retained for Glide.
+  real(dp) :: n_glen = 3.0d0                     !< Exponent in Glen's flow law; user-configurable real(dp) in Glissade
+  integer, parameter :: gn = 3                   !< Exponent in Glen's flow law; fixed integer parameter in Glide
   real(dp),parameter :: celsius_to_kelvin = 273.15d0  !< Note: Not quite equal to trpt
   real(dp),parameter :: scyr = 31536000.d0       !< Number of seconds in a year of exactly 365 days
   real(dp),parameter :: rhom = 3300.0d0          !< The density of magma(?) (kg m<SUP>-3</SUP>) 
   real(dp),parameter :: rhos = 2600.0d0          !< The density of solid till (kg m$^{-3}$) 
-  integer, parameter :: gn = 3                   !< The power dependency of Glen's flow law.
   real(dp),parameter :: actenh = 139.0d3         !< Activation energy in Glen's flow law for \f$T^{*}\geq263\f$K. (J mol<SUP>-1</SUP>)
   real(dp),parameter :: actenl = 60.0d3          !< Activation energy in Glen's flow law for \f$T^{*}<263\f$K. (J mol<SUP>-1</SUP>)  
   real(dp),parameter :: arrmlh = 1.733d3         !< Constant of proportionality in Arrhenius relation

--- a/libglimmer/glimmer_scales.F90
+++ b/libglimmer/glimmer_scales.F90
@@ -45,7 +45,7 @@ contains
 
     ! set scale factors for I/O (can't have non-integer powers)
 
-    use glimmer_physcon, only : scyr, gn
+    use glimmer_physcon, only : scyr
     use glimmer_paramets, only : thk0, tim0, vel0, vis0, len0, acc0, tau0, evs0
     implicit none
 

--- a/libglimmer/parallel_slap.F90
+++ b/libglimmer/parallel_slap.F90
@@ -254,12 +254,19 @@ module cism_parallel
      module procedure parallel_get_var_real8_2d
   end interface
 
+  interface parallel_global_sum
+     module procedure parallel_global_sum_integer_2d
+     module procedure parallel_global_sum_real4_2d
+     module procedure parallel_global_sum_real8_2d
+  end interface
+
   interface parallel_halo
      module procedure parallel_halo_integer_2d
      module procedure parallel_halo_logical_2d
      module procedure parallel_halo_real4_2d
      module procedure parallel_halo_real8_2d
      module procedure parallel_halo_real8_3d
+     module procedure parallel_halo_real8_4d
   end interface
 
   interface parallel_halo_extrapolate
@@ -2470,6 +2477,91 @@ contains
 
 !=======================================================================
 
+  function parallel_global_sum_integer_2d(a, parallel)
+
+    ! Calculates the global sum of a 2D integer field
+
+    integer,dimension(:,:),intent(in) :: a
+    type(parallel_type) :: parallel
+
+    integer :: i, j
+    integer :: local_sum
+    integer :: parallel_global_sum_integer_2d
+
+    associate(  &
+         local_ewn   => parallel%local_ewn,    &
+         local_nsn   => parallel%local_nsn)
+
+    local_sum = 0
+    do j = nhalo+1, local_nsn-nhalo
+       do i = nhalo+1, local_ewn-nhalo
+          local_sum = local_sum + a(i,j)
+       enddo
+    enddo
+    parallel_global_sum_integer_2d = local_sum
+
+    end associate
+
+  end function parallel_global_sum_integer_2d
+
+
+  function parallel_global_sum_real4_2d(a, parallel)
+
+    ! Calculates the global sum of a 2D single-precision field
+
+    real(sp),dimension(:,:),intent(in) :: a
+    type(parallel_type) :: parallel
+
+    integer :: i, j
+    real(sp) :: local_sum
+    real(sp) :: parallel_global_sum_real4_2d
+
+    associate(  &
+         local_ewn   => parallel%local_ewn,    &
+         local_nsn   => parallel%local_nsn)
+
+    local_sum = 0.
+    do j = nhalo+1, local_nsn-nhalo
+       do i = nhalo+1, local_ewn-nhalo
+          local_sum = local_sum + a(i,j)
+       enddo
+    enddo
+    parallel_global_sum_real4_2d = local_sum
+
+    end associate
+
+  end function parallel_global_sum_real4_2d
+
+
+  function parallel_global_sum_real8_2d(a, parallel)
+
+    ! Calculates the global sum of a 2D integer field
+
+    real(dp),dimension(:,:),intent(in) :: a
+    type(parallel_type) :: parallel
+
+    integer :: i, j
+    real(dp) :: local_sum
+    real(dp) :: parallel_global_sum_real8_2d
+
+    associate(  &
+         local_ewn   => parallel%local_ewn,    &
+         local_nsn   => parallel%local_nsn)
+
+    local_sum = 0.0d0
+    do j = nhalo+1, local_nsn-nhalo
+       do i = nhalo+1, local_ewn-nhalo
+          local_sum = local_sum + a(i,j)
+       enddo
+    enddo
+    parallel_global_sum_real8_2d = local_sum
+
+    end associate
+
+  end function parallel_global_sum_real8_2d
+
+!=======================================================================
+
   subroutine parallel_globalindex(ilocal, jlocal, iglobal, jglobal, parallel)
 
     ! Calculates the global i,j indices from the local i,j indices
@@ -2851,6 +2943,68 @@ contains
     end associate
 
   end subroutine parallel_halo_real8_3d
+
+
+  subroutine parallel_halo_real8_4d(a, parallel)
+
+    implicit none
+    real(dp),dimension(:,:,:,:) :: a
+    type(parallel_type) :: parallel
+
+    real(dp),dimension(size(a,1),size(a,2),lhalo,parallel%local_nsn-lhalo-uhalo) :: ecopy
+    real(dp),dimension(size(a,1),size(a,2),uhalo,parallel%local_nsn-lhalo-uhalo) :: wcopy
+    real(dp),dimension(size(a,1),size(a,2),parallel%local_ewn,lhalo) :: ncopy
+    real(dp),dimension(size(a,1),size(a,2),parallel%local_ewn,uhalo) :: scopy
+
+    ! begin
+
+    associate(  &
+         outflow_bc  => parallel%outflow_bc,   &
+         no_ice_bc   => parallel%no_ice_bc,    &
+         local_ewn   => parallel%local_ewn,    &
+         local_nsn   => parallel%local_nsn)
+
+    ! staggered grid
+    if (size(a,3)==local_ewn-1 .and. size(a,4)==local_nsn-1) return
+
+    ! unknown grid
+    if (size(a,3)/=local_ewn .or. size(a,4)/=local_nsn) then
+       write(*,*) "Unknown Grid: Size a=(", size(a,2), ",", size(a,3), ",", size(a,4), ") &
+            &and local_ewn and local_nsn = ", local_ewn, ",", local_nsn
+         call parallel_stop(__FILE__,__LINE__)
+    endif
+
+    if (outflow_bc) then
+
+       a(:,:,:lhalo,1+lhalo:local_nsn-uhalo) = 0.d0
+       a(:,:,local_ewn-uhalo+1:,1+lhalo:local_nsn-uhalo) = 0.d0
+       a(:,:,:,:lhalo) = 0.d0
+       a(:,:,:,local_nsn-uhalo+1:) = 0.d0
+
+    elseif (no_ice_bc) then
+
+       a(:,:,:lhalo+1,1+lhalo:local_nsn-uhalo) = 0.d0
+       a(:,:,local_ewn-uhalo:,1+lhalo:local_nsn-uhalo) = 0.d0
+       a(:,:,:,:lhalo+1) = 0.d0
+       a(:,:,:,local_nsn-uhalo:) = 0.d0
+
+    else    ! periodic BC
+
+       ecopy(:,:,:,:) = a(:,:,local_ewn-uhalo-lhalo+1:local_ewn-uhalo,1+lhalo:local_nsn-uhalo)
+       wcopy(:,:,:,:) = a(:,:,1+lhalo:1+lhalo+uhalo-1,1+lhalo:local_nsn-uhalo)
+       a(:,:,:lhalo,1+lhalo:local_nsn-uhalo) = ecopy(:,:,:,:)
+       a(:,:,local_ewn-uhalo+1:,1+lhalo:local_nsn-uhalo) = wcopy(:,:,:,:)
+
+       ncopy(:,:,:,:) = a(:,:,:,local_nsn-uhalo-lhalo+1:local_nsn-uhalo)
+       scopy(:,:,:,:) = a(:,:,:,1+lhalo:1+lhalo+uhalo-1)
+       a(:,:,:,:lhalo) = ncopy(:,:,:,:)
+       a(:,:,:,local_nsn-uhalo+1:) = scopy(:,:,:,:)
+
+    endif
+
+    end associate
+
+  end subroutine parallel_halo_real8_4d
 
 !=======================================================================
 

--- a/libglimmer/parallel_slap.F90
+++ b/libglimmer/parallel_slap.F90
@@ -2403,6 +2403,42 @@ contains
 
 !=======================================================================
 
+  subroutine parallel_global_edge_mask(global_edge_mask, parallel)
+
+    ! Create a mask = 1 in locally owned cells at the edge of the global domain,
+    ! = 0 elsewhere
+
+    integer, dimension(:,:), intent(out) :: global_edge_mask
+    type(parallel_type) :: parallel
+
+    associate(  &
+         local_ewn   => parallel%local_ewn,    &
+         local_nsn   => parallel%local_nsn)
+
+    ! Check array dimensions
+
+    ! unknown grid
+    if (size(global_edge_mask,1)/=local_ewn .or. size(global_edge_mask,2)/=local_nsn) then
+       write(*,*) "Unknown Grid: Size a=(", size(global_edge_mask,1), ",", size(global_edge_mask,2), &
+            ") and local_ewn and local_nsn = ", local_ewn, ",", local_nsn
+       call parallel_stop(__FILE__,__LINE__)
+    endif
+
+    ! Identify cells at the edge of the global domain
+
+    global_edge_mask = 0
+
+    global_edge_mask(lhalo+1,:) = 1
+    global_edge_mask(local_ewn-uhalo,:) = 1
+    global_edge_mask(:,lhalo+1) = 1
+    global_edge_mask(:,local_nsn-uhalo) = 1
+
+    end associate
+
+  end subroutine parallel_global_edge_mask
+
+!=======================================================================
+
   !TODO - Is function parallel_globalID still needed? No longer called except from glissade_test_halo.
 
   function parallel_globalID(locns, locew, upstride, parallel)

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1945,6 +1945,7 @@ contains
        call glissade_bwat_flux_routing(&
             model%general%ewn,       model%general%nsn,       &
             model%numerics%dew*len0, model%numerics%dns*len0, &  ! m
+            model%parallel,                                   &
             itest, jtest, rtest,                              &
             model%options%ho_flux_routing_scheme,             &
             model%numerics%thklim_temp*thk0,                  &  ! m

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -457,7 +457,11 @@ contains
     ! handle relaxed/equilibrium topo
     ! Initialise isostasy first
 
-    call init_isostasy(model)
+    if (model%options%isostasy == ISOSTASY_COMPUTE) then
+
+       call init_isostasy(model)
+
+    endif
 
     select case(model%isostasy%whichrelaxed)
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -117,8 +117,8 @@ contains
     use glissade_inversion, only: glissade_init_inversion, verbose_inversion
     use glissade_bmlt_float, only: glissade_bmlt_float_thermal_forcing_init, verbose_bmlt_float
     use glissade_grounding_line, only: glissade_grounded_fraction
-    use glissade_utils, only: &
-         glissade_adjust_thickness, glissade_smooth_topography, glissade_adjust_topography
+    use glissade_utils, only: glissade_adjust_thickness, glissade_smooth_usrf, &
+         glissade_smooth_topography, glissade_adjust_topography
     use glissade_utils, only: glissade_stdev
     use felix_dycore_interface, only: felix_velo_init
 
@@ -396,7 +396,15 @@ contains
        call glissade_adjust_thickness(model)
     endif
 
-    ! Optionally, smooth the input topography with a 9-point Laplacian smoother.
+    ! Optionally, smooth the input surface elevation with a Laplacian smoother.
+    ! This subroutine does not change the topg, but returns thck consistent with the new usrf.
+    ! If the initial usrf is rough, then multiple smoothing passes may be needed to stabilize the flow.
+
+    if (model%options%smooth_input_usrf .and. model%options%is_restart == RESTART_FALSE) then
+       call glissade_smooth_usrf(model, nsmooth = 5)
+    endif   ! smooth_input_usrf
+
+    ! Optionally, smooth the input topography with a Laplacian smoother.
 
     if (model%options%smooth_input_topography .and. model%options%is_restart == RESTART_FALSE) then
        call glissade_smooth_topography(model)
@@ -625,17 +633,17 @@ contains
     if (make_ice_domain_mask) then
 
        where (model%geometry%thck > 0.0d0 .or. model%geometry%topg > 0.0d0)
+!!       where (model%geometry%thck > 0.0d0)  ! uncomment for terrestrial margins
           model%general%ice_domain_mask = 1
        elsewhere
           model%general%ice_domain_mask = 0
        endwhere
 
-       ! Extend the mask a couple of cells in each direction to be on the safe side.
+       ! Extend the mask a few cells in each direction to be on the safe side.
        ! The number of buffer layers could be made a config parameter.
 
        allocate(ice_domain_mask(model%general%ewn,model%general%nsn))
 
-!!       do k = 1, 2
        do k = 1, 3
           call parallel_halo(model%general%ice_domain_mask, parallel)
           ice_domain_mask = model%general%ice_domain_mask   ! temporary copy
@@ -1924,23 +1932,22 @@ contains
     if (model%options%which_ho_bwat == HO_BWAT_FLUX_ROUTING) then
 
        !WHL - Temporary code for debugging: Make up a simple basal melt field.
-       model%basal_hydro%head(:,:) = &
-            model%geometry%thck(:,:)*thk0 + (rhow/rhoi)*model%geometry%topg(:,:)*thk0
-       head_max = maxval(model%basal_hydro%head)  ! max on local processor
-       head_max = parallel_reduce_max(head_max)   ! global max
-       do j = 1, model%general%nsn
-          do i = 1, model%general%ewn
-             if (head_max - model%basal_hydro%head(i,j) < 1000.d0) then
+!       model%basal_hydro%head(:,:) = &
+!            model%geometry%thck(:,:)*thk0 + (rhow/rhoi)*model%geometry%topg(:,:)*thk0
+!       head_max = maxval(model%basal_hydro%head)  ! max on local processor
+!       head_max = parallel_reduce_max(head_max)   ! global max
+!       do j = 1, model%general%nsn
+!          do i = 1, model%general%ewn
+!             if (head_max - model%basal_hydro%head(i,j) < 1000.d0) then
 !!             if (head_max - model%basal_hydro%head(i,j) < 200.d0) then
-                bmlt_ground_unscaled(i,j) = 1.0d0/scyr    ! units are m/s
-             else
-                bmlt_ground_unscaled(i,j) = 0.0d0
-             endif
-          enddo
-       enddo
+!                bmlt_ground_unscaled(i,j) = 1.0d0/scyr    ! units are m/s
+!             else
+!                bmlt_ground_unscaled(i,j) = 0.0d0
+!             endif
+!          enddo
+!       enddo
 
        ! Compute some masks needed below
-
 
        call glissade_get_masks(&
             model%general%ewn,    model%general%nsn,      &
@@ -1979,34 +1986,6 @@ contains
              bwat_mask = 0
           endwhere
        endif
-
-       !WHL - debug
-       print*, ' '
-       print*, 'edge_mask:'
-       write(6,'(a6)',advance='no') '      '
-       do i = itest-5, itest+5
-          write(6,'(i5)',advance='no') i
-       enddo
-       write(6,*) ' '
-       do j = jtest+5, jtest-5, -1
-          write(6,'(i6)',advance='no') j
-          do i = itest-5, itest+5
-             write(6,'(i5)',advance='no') model%general%global_edge_mask(i,j)
-          enddo
-          write(6,*) ' '
-       enddo
-       print*, ' '
-       print*, ' '
-       print*, 'overwrite_acab_mask:'
-       write(6,*) ' '
-       do j = jtest+5, jtest-5, -1
-          write(6,'(i6)',advance='no') j
-          do i = itest-5, itest+5
-             write(6,'(i5)',advance='no') model%climate%overwrite_acab_mask(i,j)
-          enddo
-          write(6,*) ' '
-       enddo
-       print*, ' '
 
        call parallel_halo(bwat_mask, parallel)
 
@@ -3202,6 +3181,14 @@ contains
        ! Note: Currently hardwired to include 13 of the 16 ISMIP6 basins.
        !       Does not include the three largest shelves (Ross, Filchner-Ronne, Amery)
 
+       call glissade_get_masks(nx,                       ny,                         &
+                               parallel,                                             &
+                               model%geometry%thck*thk0, model%geometry%topg*thk0,   &
+                               model%climate%eus*thk0,   0.0d0,                      &  ! thklim = 0
+                               ice_mask,                                             &
+                               floating_mask = floating_mask,                        &
+                               land_mask = land_mask)
+
        if (init_calving .and. model%options%expand_calving_mask) then
 
           ! Identify basins whose floating ice will be added to the calving mask
@@ -3218,14 +3205,6 @@ contains
                 print*, bn, mask_basin(bn)
              enddo
           endif
-
-          call glissade_get_masks(nx,                       ny,                         &
-                                  parallel,                                             &
-                                  model%geometry%thck*thk0, model%geometry%topg*thk0,   &
-                                  model%climate%eus*thk0,   0.0d0,                      &  ! thklim = 0
-                                  ice_mask,                                             &
-                                  floating_mask = floating_mask,                        &
-                                  land_mask = land_mask)
 
           if (verbose_calving .and. this_rank==rtest) then
              print*, ' '
@@ -3623,6 +3602,12 @@ contains
     ! halo updates
     call parallel_halo(model%geometry%thck, parallel)   ! Updated halo values of thck are needed below in calclsrf
 
+    ! update the upper and lower surfaces
+
+    call glide_calclsrf(model%geometry%thck, model%geometry%topg,       &
+                        model%climate%eus,   model%geometry%lsrf)
+    model%geometry%usrf(:,:) = max(0.d0, model%geometry%thck(:,:) + model%geometry%lsrf(:,:))
+
     if (verbose_calving .and. this_rank == rtest) then
        print*, ' '
        print*, 'Final calving_thck (m), itest, jtest, rank =', itest, jtest, rtest
@@ -3642,13 +3627,16 @@ contains
           enddo
           write(6,*) ' '
        enddo
+       print*, ' '
+       print*, 'Final usrf (m):'
+       do j = jtest+3, jtest-3, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') model%geometry%usrf(i,j) * thk0
+          enddo
+          write(6,*) ' '
+       enddo
     endif  ! verbose_calving
-
-    ! update the upper and lower surfaces
-
-    call glide_calclsrf(model%geometry%thck, model%geometry%topg,       &
-                        model%climate%eus,   model%geometry%lsrf)
-    model%geometry%usrf(:,:) = max(0.d0, model%geometry%thck(:,:) + model%geometry%lsrf(:,:))
 
   end subroutine glissade_calving_solve
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -737,10 +737,6 @@ contains
 
     if (model%climate%overwrite_acab_value /= 0 .and. model%options%is_restart == RESTART_FALSE) then
 
-       !WHL - debug
-       if (main_task) print*, 'overwrite_acab value (m/yr):', &
-            model%climate%overwrite_acab_value * scyr*thk0/tim0
-
        call glissade_overwrite_acab_mask(model%options%overwrite_acab,          &
                                          model%climate%acab,                    &
                                          model%geometry%thck,                   &
@@ -1986,6 +1982,11 @@ contains
              bwat_mask = 0
           endwhere
        endif
+
+       !WHL - debug - Set mask = 0 where thck = 0 for dome test
+!       where (model%geometry%thck == 0)
+!          bwat_mask = 0
+!       endwhere
 
        call parallel_halo(bwat_mask, parallel)
 

--- a/libglissade/glissade_basal_traction.F90
+++ b/libglissade/glissade_basal_traction.F90
@@ -699,7 +699,7 @@ contains
 
   subroutine calc_effective_pressure (which_effecpress,             &
                                       ewn,           nsn,           &
-                                      basal_physics,                &
+                                      basal_physics, basal_hydro,   &
                                       ice_mask,      floating_mask, &
                                       thck,          topg,          &
                                       eus,                          &
@@ -725,6 +725,10 @@ contains
     type(glide_basal_physics), intent(inout) :: &
          basal_physics       ! basal physics object
                              ! includes effecpress, effecpress_stag and various parameters
+
+    type(glide_basal_hydro), intent(inout) :: &
+         basal_hydro         ! basal hydro object
+                             ! includes bwat and various parameters
 
     integer, dimension(:,:), intent(in) :: &
          ice_mask,         & ! = 1 where ice is present (thk > thklim), else = 0
@@ -858,19 +862,19 @@ contains
 
                 if (bwat(i,j) > 0.0d0) then
 
-                   relative_bwat = max(0.0d0, min(bwat(i,j)/basal_physics%bwat_till_max, 1.0d0))
+                   relative_bwat = max(0.0d0, min(bwat(i,j)/basal_hydro%bwat_till_max, 1.0d0))
 
                    ! Eq. 23 from Bueler & van Pelt (2015)
-                   basal_physics%effecpress(i,j) = basal_physics%N_0  &
-                        * (basal_physics%effecpress_delta * overburden(i,j) / basal_physics%N_0)**relative_bwat  &
-                        * 10.d0**((basal_physics%e_0/basal_physics%C_c) * (1.0d0 - relative_bwat))
+                   basal_physics%effecpress(i,j) = basal_hydro%N_0  &
+                        * (basal_physics%effecpress_delta * overburden(i,j) / basal_hydro%N_0)**relative_bwat  &
+                        * 10.d0**((basal_hydro%e_0/basal_hydro%C_c) * (1.0d0 - relative_bwat))
 
                    ! The following line (if uncommented) would implement Eq. 5 of Aschwanden et al. (2016).
                    ! Results are similar to Bueler & van Pelt, but the dropoff in N from P_0 to delta*P_0 begins
                    !  with a larger value of bwat (~0.7*bwat_till_max instead of 0.6*bwat_till_max).
 
 !!                 basal_physics%effecpress(i,j) = basal_physics%effecpress_delta * overburden(i,j)  &
-!!                      * 10.d0**((basal_physics%e_0/basal_physics%C_c) * (1.0d0 - relative_bwat))
+!!                      * 10.d0**((basal_hydro%e_0/basal_hydro%C_c) * (1.0d0 - relative_bwat))
 
                    !WHL - Uncomment to try a linear ramp in place of the Bueler & van Pelt relationship.
                    !      This might lead to smoother variations in N with spatial variation in bwat.

--- a/libglissade/glissade_basal_traction.F90
+++ b/libglissade/glissade_basal_traction.F90
@@ -440,9 +440,12 @@ contains
        !       If this factor is not present in the input file, it is set to 1 everywhere.
 
        ! Compute beta
-       ! gn = Glen's n from physcon module
-       beta(:,:) = coulomb_c * basal_physics%effecpress_stag(:,:) * speed(:,:)**(1.0d0/gn - 1.0d0) * &
-            (speed(:,:) + basal_physics%effecpress_stag(:,:)**gn * big_lambda)**(-1.0d0/gn)
+       ! Note: Where this equation has powerlaw_m, we used to have Glen's flow exponent n,
+       !       following the notation of Leguy et al. (2014).
+       !       Changed to powerlaw_m to be consistent with the Schoof and Tsai laws.
+       m = basal_physics%powerlaw_m
+       beta(:,:) = coulomb_c * basal_physics%effecpress_stag(:,:) * speed(:,:)**(1.0d0/m - 1.0d0) * &
+            (speed(:,:) + basal_physics%effecpress_stag(:,:)**m * big_lambda)**(-1.0d0/m)
 
        ! If c_space_factor /= 1.0 everywhere, then multiply beta by c_space_factor
        if (maxval(abs(basal_physics%c_space_factor_stag(:,:) - 1.0d0)) > tiny(0.0d0)) then

--- a/libglissade/glissade_basal_water.F90
+++ b/libglissade/glissade_basal_water.F90
@@ -24,20 +24,29 @@
 !
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-!TODO - Support Jesse's water-routing code (or something similar) in parallel?
+!TODO - Test and parallelize Jesse's water-routing code.
 !       Currently supported only for serial Glide runs, in module glide_bwater.F90
 
 module glissade_basal_water
 
    use glimmer_global, only: dp
+   use glimmer_paramets, only: eps11
+   use glimmer_log
    use glide_types
+   use parallel_mod, only: main_task, this_rank, parallel_type, parallel_halo
 
    implicit none
 
    private
-   public :: glissade_basal_water_init, glissade_calcbwat
+   public :: glissade_basal_water_init, glissade_calcbwat, glissade_bwat_flux_routing
+
+   logical, parameter :: verbose_bwat = .true.
+
+   integer, parameter :: pdiag = 5  ! range for diagnostic prints
 
 contains
+
+!==============================================================
 
   subroutine glissade_basal_water_init(model)
 
@@ -50,14 +59,15 @@ contains
     ! HO_BWAT_NONE:         basal water depth = 0
     ! HO_BWAT_CONSTANT:     basal water depth = prescribed constant
     ! HO_BWAT_LOCAL_TILL:   local basal till model with prescribed drainage rate
+    ! HO_BWAT_FLUX_ROUTING: steady-state water routing with flux calculation
 
     case(HO_BWAT_CONSTANT)
 
        ! Set a constant water thickness where ice is present
        where (model%geometry%thck > model%numerics%thklim)
-          model%temper%bwat(:,:) = model%basal_physics%const_bwat / thk0
+          model%basal_hydro%bwat(:,:) = model%basal_hydro%const_bwat / thk0
        elsewhere
-          model%temper%bwat(:,:) = 0.0d0
+          model%basal_hydro%bwat(:,:) = 0.0d0
        endwhere
 
     case default
@@ -68,9 +78,10 @@ contains
 
   end subroutine glissade_basal_water_init
 
+!==============================================================
 
   subroutine glissade_calcbwat(which_ho_bwat,    &
-                               basal_physics,    &
+                               basal_hydro,      &
                                dt,               &
                                thck,             &
                                thklim,           &
@@ -87,7 +98,7 @@ contains
     integer, intent(in) :: &
          which_ho_bwat     !> basal water options
 
-    type(glide_basal_physics), intent(in)   :: basal_physics      ! basal physics object
+    type(glide_basal_hydro), intent(inout) :: basal_hydro ! basal hydro object
 
     real(dp), intent(in) :: &
          dt,             & !> time step (s) 
@@ -113,6 +124,7 @@ contains
     ! HO_BWAT_NONE:         basal water depth = 0
     ! HO_BWAT_CONSTANT:     basal water depth = prescribed constant
     ! HO_BWAT_LOCAL_TILL:   local basal till model with prescribed drainage rate
+    ! HO_BWAT_FLUX_ROUTING: steady-state water routing with flux calculation (handled in a different subroutine)
 
     case(HO_BWAT_NONE)
 
@@ -122,7 +134,7 @@ contains
 
        ! Use a constant water thickness where ice is present, to force Tbed = Tpmp
        where (thck > thklim)
-          bwat(:,:) = basal_physics%const_bwat
+          bwat(:,:) = basal_hydro%const_bwat
        elsewhere
           bwat(:,:) = 0.0d0
        endwhere
@@ -137,11 +149,11 @@ contains
 
               ! compute new bwat, given source (bmlt) and sink (drainage)
               ! Note: bmlt > 0 for ice melting. Freeze-on will reduce bwat.
-              dbwat_dt = bmlt(i,j)*rhoi/rhow - basal_physics%c_drainage/scyr  ! convert c_drainage from m/yr to m/s
+              dbwat_dt = bmlt(i,j)*rhoi/rhow - basal_hydro%c_drainage/scyr  ! convert c_drainage from m/yr to m/s
               bwat(i,j) = bwat(i,j) + dbwat_dt*dt
 
               ! limit to the range [0, bwat_till_max]
-              bwat(i,j) = min(bwat(i,j), basal_physics%bwat_till_max)
+              bwat(i,j) = min(bwat(i,j), basal_hydro%bwat_till_max)
               bwat(i,j) = max(bwat(i,j), 0.0d0)
 
            enddo
@@ -151,4 +163,1715 @@ contains
 
   end subroutine glissade_calcbwat
 
+!==============================================================
+
+  subroutine glissade_bwat_flux_routing(&
+       nx,            ny,      &
+       dx,            dy,      &
+       itest, jtest,  rtest,   &
+       flux_routing_scheme,    &
+       thklim,                 &
+       thck,                   &
+       topg,                   &
+       bmlt,                   &
+       floating_mask,          &
+       bwat,                   &
+       bwatflx,                &
+       head)
+
+    ! This subroutine is a recoding of Jesse Johnson's steady-state water routing scheme in Glide.
+    ! Needs to be parallelized for Glissade.
+
+    use glimmer_physcon, only: scyr
+    use glimmer_log
+    use parallel_mod, only: tasks   ! while code is serial only
+
+    ! Input/output arguments
+
+    integer, intent(in) ::  &
+         nx, ny,             &      ! number of grid cells in each direction
+         itest, jtest, rtest        ! coordinates of diagnostic point
+
+    real(dp), intent(in) ::  &
+         dx, dy                     ! grid cell size (m)
+
+    integer, intent(in) ::  &
+         flux_routing_scheme        ! flux routing scheme: D8, Dinf or FD8; see subroutine route_basal_water
+
+    real(dp), intent(in) ::  &
+         thklim                     ! minimum ice thickness for basal melt and hydropotential calculations (m)
+
+    real(dp), dimension(nx,ny), intent(in) ::  &
+         thck,               &      ! ice thickness (m)
+         topg,               &      ! bed topography (m)
+         bmlt                       ! basal melt rate (m/s)
+
+    integer, dimension(nx,ny), intent(in) :: &
+         floating_mask              ! = 1 if ice is present (thck > thklim) and floating, else = 0
+
+    real(dp), dimension(nx,ny), intent(inout) ::  &
+         bwat                       ! basal water depth (m)
+
+    real(dp), dimension(nx,ny), intent(out) ::  &
+         bwatflx,                 & ! basal water flux (m^3/s)
+         head                       ! hydraulic head (m)
+
+    ! Local variables
+
+    integer :: i, j, p
+
+    !TODO - Make effecpress in/out?
+    real(dp), dimension(nx, ny) ::  &
+         effecpress,    & ! effective pressure
+         lakes            ! difference between filled head and original head (m)
+
+    integer, dimension(nx,ny) :: &
+         bwat_mask        ! mask to identify cells through which basal water is routed;
+                          ! = 1 if ice is present (thck > thklim) and not floating, else = 0
+
+    ! parameters related to effective pressure
+    real(dp), parameter :: &
+         c_effective_pressure = 0.0d0                   ! for now estimated as N = c/bwat
+
+    ! parameters related to subglacial fluxes
+    ! The basal water flux is given by Sommers et al. (2018), Eq. 5:
+    !
+    !           q = (b^3*g)/[(12*nu)*(1 + omega*Re)] * (-grad(h))
+    !
+    ! where q = basal water flux per unit width (m^2/s) = bwatflx/dx
+    !       b = water depth (m) = bwat
+    !       g = gravitational constant (m/s^2) = grad
+    !      nu = kinematic viscosity of water (m^2/s)= visc_water
+    !   omega = parameter controlling transition between laminar and turbulent flow
+    !      Re = Reynolds number (large for turbulent flow)
+    !       h = hydraulic head (m)
+    !
+    ! By default, we set Re = 0, which means the flow is purely laminar, as in Sommers et al. (2018), Eq. 6.
+
+    ! Optionally, one or more of these parameters could be made a config parameter in the basal_hydro type
+    real(dp), parameter ::  &
+         visc_water = 1.787e-6,                       & ! kinematic viscosity of water (m^2/s); Sommers et al. (2018), Table 2
+         omega_hydro = 1.0d-3,                        & ! omega (unitless) in Sommers et al (2018), Eq. 6
+         Reynolds = 0.0d0                               ! Reynolds number (unitless), = 0 for pure laminar flow
+
+    real(dp), parameter ::  &
+         c_flux_to_depth = 1.0d0/((12.0d0*visc_water)*(1.0d0 + omega_hydro*Reynolds)), & ! proportionality coefficient in Eq. 6
+         p_flux_to_depth = 2.0d0,                     & ! exponent for water depth; = 2 if q is proportional to b^3
+         q_flux_to_depth = 1.0d0                        ! exponent for potential gradient; = 1 if q is linearly proportional to grad(h)
+
+
+    ! WHL - debug fix_flats subroutine
+    logical :: test_fix_flats = .false.
+!!    logical :: test_fix_flats = .true.
+    integer :: nx_test, ny_test
+    real(dp), dimension(:,:), allocatable :: phi_test
+    integer,  dimension(:,:), allocatable :: mask_test
+
+    !WHL - debug
+    if (test_fix_flats) then
+
+       ! Solve the example problem of Garbrecht & Martz (1997)
+       ! Their problem is 7x7, but easier to solve if padded with a row of low numbers.
+
+       nx_test = 9
+       ny_test = 9
+       allocate (phi_test(nx_test,ny_test))
+       allocate (mask_test(nx_test,ny_test))
+
+       mask_test = 1
+       do j = 1, ny_test
+          do i = 1, nx_test
+             if (i == 1 .or. i == nx_test .or. j == 1 .or. j == ny_test) then
+                mask_test(i,j) = 0
+             endif
+          enddo
+       enddo
+
+       phi_test(:,9) = (/ 1.d0, 1.d0,1.d0,1.d0,1.d0,1.d0,1.d0,1.d0, 1.d0 /)
+       phi_test(:,8) = (/ 1.d0, 9.d0,9.d0,9.d0,9.d0,9.d0,9.d0,9.d0, 1.d0 /)
+       phi_test(:,7) = (/ 1.d0, 9.d0,6.d0,6.d0,6.d0,6.d0,6.d0,9.d0, 1.d0 /)
+       phi_test(:,6) = (/ 1.d0, 8.d0,6.d0,6.d0,6.d0,6.d0,6.d0,9.d0, 1.d0 /)
+       phi_test(:,5) = (/ 1.d0, 8.d0,6.d0,6.d0,6.d0,6.d0,6.d0,9.d0, 1.d0 /)
+       phi_test(:,4) = (/ 1.d0, 7.d0,6.d0,6.d0,6.d0,6.d0,6.d0,8.d0, 1.d0 /)
+       phi_test(:,3) = (/ 1.d0, 7.d0,6.d0,6.d0,6.d0,6.d0,6.d0,8.d0, 1.d0 /)
+       phi_test(:,2) = (/ 1.d0, 7.d0,7.d0,5.d0,7.d0,7.d0,8.d0,8.d0, 1.d0 /)
+       phi_test(:,1) = (/ 1.d0, 1.d0,1.d0,1.d0,1.d0,1.d0,1.d0,1.d0, 1.d0 /)
+
+       call fix_flats(&
+            nx_test, ny_test,  &
+            5,  5,   rtest,    &
+            phi_test,          &
+            mask_test)
+
+       deallocate(phi_test, mask_test)
+
+    endif
+
+    !WHL - debug
+    if (main_task) print*, 'In glissade_bwat_flux_routing: rtest, itest, jtest =', rtest, itest, jtest
+
+    if (tasks > 1) then
+       call write_log('Flux routing not yet supported for tasks > 1', GM_FATAL)
+    endif
+
+
+    ! Compute effective pressure N as a function of water depth
+    call effective_pressure(&
+         bwat,                 &
+         c_effective_pressure, &
+         effecpress)
+
+    ! Compute the hydraulic head
+    call compute_head(&
+         nx,     ny,    &
+         thck,          &
+         topg,          &
+         effecpress,    &
+         thklim,        &
+         floating_mask, &
+         head)
+
+    p = pdiag
+
+    if (verbose_bwat .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'thck (m):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') thck(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'topg (m):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') topg(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'effecpress (Pa):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') effecpress(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'bmlt (m/yr):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') bmlt(i,j) * scyr
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'Before fill: head (m):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') head(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! Compute a mask: = 1 where ice is present and not floating
+    where (thck > thklim .and. floating_mask == 0)
+       bwat_mask = 1
+    elsewhere
+       bwat_mask = 0
+    endwhere
+
+    ! Route basal water down the gradient of hydraulic head, giving a water flux
+    call route_basal_water(&
+         nx,      ny,            &
+         dx,      dy,            &
+         itest, jtest, rtest,    &
+         flux_routing_scheme,    &
+         head,                   &
+         bmlt,                   &
+         bwat_mask,              &
+         bwatflx,                &
+         lakes)
+
+    ! Convert the water flux to a basal water depth
+    call flux_to_depth(&
+         nx,       ny,           &
+         dx,       dy,           &
+         itest,    jtest, rtest, &
+         bwatflx,                &
+         head,                   &
+         c_flux_to_depth,        &
+         p_flux_to_depth,        &
+         q_flux_to_depth,        &
+         bwat_mask,              &
+         bwat)
+
+    if (verbose_bwat .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'bwatflx (m^3/s):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') bwatflx(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'bwat (mm):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') bwat(i,j) * 1000.d0
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+  end subroutine glissade_bwat_flux_routing
+
+!==============================================================
+
+  subroutine effective_pressure(&
+       bwat,                    &
+       c_effective_pressure,    &
+       effecpress)
+
+    ! Compute the effective pressure: the part of ice overburden not balanced by water pressure
+    ! TODO: Try c_effective_pressure > 0, or call calc_effecpress instead
+
+    real(dp),dimension(:,:),intent(in)  ::  bwat                  ! water depth
+    real(dp)               ,intent(in)  ::  c_effective_pressure  ! constant of proportionality
+    real(dp),dimension(:,:),intent(out) ::  effecpress            ! effective pressure
+
+    ! Note: By default, c_effective_pressure = 0
+    !       This implies N = 0; full support of the ice by water at the bed
+    !       Alternatively, could call the standard glissade subroutine, calc_effective_pressure
+
+    where (bwat > 0.d0)
+        effecpress = c_effective_pressure / bwat
+    elsewhere
+        effecpress = 0.d0
+    endwhere
+
+  end subroutine effective_pressure
+
+!==============================================================
+
+  subroutine compute_head(&
+       nx,      ny,   &
+       thck,          &
+       topg,          &
+       effecpress,    &
+       thklim,        &
+       floating_mask, &
+       head)
+
+    !  Compute the hydraulic head as the bed elevation plus the scaled water pressure:
+    !
+    !     head = z_b + p_w / (rhow*g)
+    !
+    !  where z_b = bed elevation (m) = topg
+    !        p_w = water pressure (Pa) = p_i - N
+    !        p_i = ice overburden pressure = rhoi*g*H
+    !          N = effective pressure (Pa) = part of overburden not supported by water
+    !          H = ice thickness (m)
+    !
+    !  If we make the approximation p_w =~ p_i, then
+    !
+    !     head =~ z_b + (rhoi/rhow) * H
+
+    use glimmer_physcon, only : rhoi, rhow, grav
+    implicit none
+
+    ! Input/output variables
+
+    integer, intent(in) ::  &
+         nx, ny                   ! number of grid cells in each direction
+
+    real(dp), dimension(nx,ny), intent(in) ::  &
+         thck,                  & ! ice thickness (m)
+         topg,                  & ! bed elevation (m)
+         effecpress               ! effective pressure (Pa)
+
+    real(dp), intent(in) ::  &
+         thklim                   ! minimum ice thickness for bmlt and head calculations
+
+    integer, dimension(nx,ny), intent(in) ::  &
+         floating_mask            ! = 1 if ice is present (thck > thklim) and floating, else = 0
+
+    real(dp), dimension(nx,ny), intent(out) ::  &
+         head                     ! hydraulic head (m)
+
+    where (thck > thklim .and. floating_mask /= 1)
+       head = topg + (rhoi/rhow)*thck - effecpress/(rhow*grav)
+    elsewhere
+       head = max(topg, 0.0d0)
+    endwhere
+
+  end subroutine compute_head
+
+!==============================================================
+
+  subroutine route_basal_water(&
+         nx,         ny,         &
+         dx,         dy,         &
+         itest, jtest, rtest,    &
+         flux_routing_scheme,    &
+         head,                   &
+         bmlt,                   &
+         bwat_mask,              &
+         bwatflx,                &
+         lakes)
+
+    ! Route water from the basal melt field to its destination, recording the water flux along the route.
+    ! Water flow direction is determined according to the gradient of the hydraulic head.
+    ! For the algorithm to function properly, surface depressions must be filled,
+    !  so that all cells have an outlet to the ice sheet margin.
+    !> This results in the lakes field, which is the difference between the filled head and the original head.
+    !> The method used is by Quinn et. al. (1991).
+    !>
+    !> Based on code by Jesse Johnson (2005), adapted from the glimmer_routing file by Ian Rutt.
+
+    !TODO: This is a serial subroutine.
+    !      To run in Glissade, we need to add a global gather/scatter.
+    !      Ultimately, the goal is to make it fully parallel.
+
+    implicit none
+
+    integer, intent(in) ::  &
+         nx, ny,               & ! number of grid cells in each direction
+         itest, jtest, rtest     ! coordinates of diagnostic point
+
+    real(dp), intent(in) ::  &
+         dx, dy                  ! grid spacing in each direction (m)
+
+    integer, intent(in) ::  &
+         flux_routing_scheme     ! flux routing scheme: D8, Dinf or FD8
+                                 ! D8: Flow is downhill toward the single cell with the lowest elevation.
+                                 ! Dinf: Flow is downhill toward the two cells with the lowest elevations.
+                                 ! FD8: Flow is downhill toward all cells with lower elevation.
+                                 ! D8 scheme gives the narrowest flow, and FD8 gives the most diffuse flow.
+
+    real(dp), dimension(nx,ny), intent(in)  ::  &
+         bmlt                    ! basal melt beneath grounded ice (m/s)
+
+    real(dp), dimension(nx,ny), intent(inout)  ::  &
+         head                    ! hydraulic head (m)
+                                 ! intent inout because it can be filled and adjusted below
+
+    integer, dimension(nx,ny), intent(in)  ::  &
+         bwat_mask               ! mask to identify cells through which basal water is routed;
+                                 ! = 1 where ice is present and not floating
+
+    real(dp), dimension(nx,ny), intent(out) ::  &
+         bwatflx,             &  ! water flux through a grid cell (m^3/s)
+         lakes                   ! lakes field, difference between filled and original head
+
+    ! Local variables
+
+    integer :: i, j, k, nn, ii, jj, ip, jp
+    integer :: i1, j1, i2, j2, itmp, jtmp
+    integer :: p
+
+    integer,  dimension(:,:), allocatable ::  &
+         sorted            ! i and j indices of all cells, sorted from low to high potential
+
+    real(dp), dimension(nx,ny) ::  &
+         head_filled       ! head after depressions are filled (m)
+
+    integer, dimension(nx,ny) ::  &
+         flats             !
+
+    real(dp), dimension(-1:1,-1:1) ::  &
+         dists,         &  ! distance (m) to adjacent grid cell
+         slope             ! slope of head between adjacent grid cells
+
+    real(dp) ::  &
+         slope1,        &  ! largest value of slope array
+         slope2,        &  ! second largest value of slope array
+         sum_slope,     &  ! slope1 + slope2
+         slope_tmp         ! temporary slope value
+
+    logical :: flag
+
+    real(dp) :: &
+         total_flux_in, &  ! total input flux (m^3/s), computed as sum of bmlt*dx*dy
+         total_flux_out, & ! total output flux (m^3/s), computed as sum of bwatflx at ice margin
+         flux_unrouted     ! total flux (m^3/s) that is not routed downhill (should = 0)
+
+    integer, dimension(nx,ny) ::  &
+         margin_mask       ! = 1 for cells at the margin, as defined by bwat_mask
+
+
+    ! Compute distances to adjacent grid cells for slope determination
+
+    dists(-1,:) = (/ sqrt(dx**2 + dy**2), dy, sqrt(dx**2 + dy**2) /)
+    dists(0,:) = (/ dx, 0.0d0, dx /)
+    dists(1,:) = dists(-1,:)
+
+    ! Allocate local arrays
+
+    nn = nx*ny   ! For parallel code, change to locally owned cells only
+    allocate(sorted(nn,2))
+
+    ! Initialize the filled field
+    head_filled = head
+
+    ! Fill depressions in head, so that no interior cells are sinks
+    call fill_depressions(&
+         nx,          ny,    &
+         head_filled,        &
+         bwat_mask)
+
+
+    ! Raise the head slightly in flat regions, so that all cells have downslope outlets
+
+    call fix_flats(&
+         nx,    ny,            &
+         itest, jtest, rtest,  &
+         head_filled,          &
+         bwat_mask)
+
+    lakes = head_filled - head
+
+    p = pdiag
+    if (verbose_bwat .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'After fill: head_filled (m):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') head_filled(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'lakes (m):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.3)',advance='no') lakes(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! Update head with the filled values
+    head = head_filled
+
+    ! Sort heights.
+    ! The 'sorted' array contains the i and j index for each cell, from lowest to highest value of the filled potential.
+    call heights_sort(&
+         nx,           ny,     &
+         itest, jtest, rtest,  &
+         head,         sorted)
+
+    if (verbose_bwat .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'sorted, from the top:'
+       do k = nx*ny, nx*ny-10, -1
+          i = sorted(k,1)
+          j = sorted(k,2)
+          print*, i, j, head(i,j)
+       enddo
+    endif
+
+    ! Initialise the water flux with the local basal melt, which will then be redistributed.
+    ! Multiply by area, so units are m^3/s.
+
+    bwatflx = bmlt * dx * dy
+
+    ! Compute total input of meltwater (m^3/s)
+    total_flux_in = sum(bwatflx)  ! need global sum for parallel code
+    if (verbose_bwat .and. main_task) then
+       print*, ' '
+       print*, 'total input basal melt flux (m^3/s):', total_flux_in
+    endif
+
+    flux_unrouted = 0.0d0
+
+    ! Begin loop over points, highest first
+    !TODO: need to parallelize this loop somehow
+
+    do k = nn,1,-1
+
+       ! Get x and y indices of current point
+       i = sorted(k,1)
+       j = sorted(k,2)
+
+       ! If the flux to this cell is nonzero, then route it to adjacent downhill cells
+       if (bwat_mask(i,j) == 1 .and. bwatflx(i,j) > 0.0d0) then
+
+          slope = 0.0d0
+
+          ! Loop over adjacent points and calculate slope
+          do jj = -1,1
+             do ii = -1,1
+                ! If this is the centre point, ignore
+                if (ii == 0 .and. jj == 0) then
+                   continue
+                else  ! compute slope
+                   ip = i + ii
+                   jp = j + jj
+                   if (ip >= 1 .and. ip <= nx .and. jp > 1 .and. jp <= ny) then
+                      if (head(ip,jp) < head(i,j)) then
+                         slope(ii,jj) = (head(i,j) - head(ip,jp)) / dists(ii,jj)
+                      endif
+                   endif
+                endif
+             enddo
+          enddo
+
+          !WHL - debug
+          if (this_rank == rtest .and. i == itest .and. j == jtest) then
+             print*, ' '
+             print*, 'slope: task, i, j =', rtest, i, j
+             print*, slope(:,1)
+             print*, slope(:,0)
+             print*, slope(:,-1)
+             print*, 'sum(slope) =', sum(slope)
+          endif
+
+          ! If there are places for the water to drain, distribute it according to the flux-routing scheme:
+          !  to the lowest-elevation neighbor (D8), the two lowest-elevation neighbors (Dinf), or
+          !  all lower-elevation neighbors (FD8).
+          ! The D8 and FD8 schemes have been tested with a simple dome problem.
+          ! Dinf is less suited for the dome problem because there are many ties for 2nd greatest slope,
+          !  so i2 and j2 for slope2 are not well defined.
+          ! Note that the flux in the source cell is not zeroed.
+
+          if (flux_routing_scheme == HO_FLUX_ROUTING_D8) then
+
+             ! route to the adjacent cell with the lowest elevation
+             slope1 = 0.0d0
+             if (sum(slope) > 0.d0) then
+                i1 = 0; j1 = 0
+                do jj = -1,1
+                   do ii = -1,1
+                      ip = i + ii
+                      jp = j + jj
+                      if (slope(ii,jj) > slope1) then
+                         slope1 = slope(ii,jj)
+                         i1 = ip
+                         j1 = jp
+                      endif
+                   enddo
+                enddo
+             endif
+
+             if (slope1 > 0.0d0) then
+                bwatflx(i1,j1) = bwatflx(i1,j1) + bwatflx(i,j)
+             else
+                flux_unrouted = flux_unrouted + bwatflx(i,j)
+                print*, 'Warning: Cell with no downhill neighbors, i, j, bwatflx =', &
+                     i, j, bwatflx(i,j)
+             endif
+
+             if (this_rank == rtest .and. i == itest .and. j == jtest) then
+                print*, 'i1, j1, slope1 =', i1, j1, slope1
+             endif
+
+          !TODO - Remove Dinf scheme?
+          elseif (flux_routing_scheme == HO_FLUX_ROUTING_DINF) then
+
+             ! route to the two adjacent cells with the lowest elevation
+             i1 = 0; j1 = 0
+             i2 = 0; j2 = 0
+             slope1 = 0.0d0
+             slope2 = 0.0d0
+             do jj = -1,1
+                do ii = -1,1
+                   ip = i + ii
+                   jp = j + jj
+                   if (slope(ii,jj) > slope1) then
+                      slope_tmp = slope1
+                      itmp = i1
+                      jtmp = j1
+                      slope1 = slope(ii,jj)
+                      i1 = ip
+                      j1 = jp
+                      slope2 = slope_tmp
+                      i2 = itmp
+                      j2 = itmp
+                   elseif (slope(ii,jj) > slope2) then
+                      slope2 = slope(ii,jj)
+                      i2 = ip
+                      j2 = jp
+                   endif
+                enddo
+             enddo
+
+             sum_slope = slope1 + slope2
+             if (sum_slope > 0.0d0) then    ! divide the flux between cells (i1,j1) and (i2,j2)
+                if (slope1 > 0.0d0) then
+                   bwatflx(i1,j1) = bwatflx(i1,j1) + bwatflx(i,j)*slope1/sum_slope
+                endif
+                if (slope2 > 0.0d0) then
+                   bwatflx(i2,j2) = bwatflx(i2,j2) + bwatflx(i,j)*slope2/sum_slope
+                endif
+             else
+                print*, 'Warning: Cell with no downhill neighbors, i, j =', i, j
+             endif
+
+             if (this_rank == rtest .and. i == itest .and. j == jtest) then
+                print*, 'i1, j1, slope1:', i1, j1, slope1
+                print*, 'i2, j2, slope2:', i2, j2, slope2
+             endif
+
+          elseif (flux_routing_scheme == HO_FLUX_ROUTING_FD8) then
+
+             ! route to all adjacent downhill cells in proportion to grad(head)
+             if (sum(slope) > 0.d0) then
+                slope = slope / sum(slope)
+                do jj = -1,1
+                   do ii = -1,1
+                      ip = i + ii
+                      jp = j + jj
+                      if (slope(ii,jj) > 0.d0) then
+                         bwatflx(ip,jp) = bwatflx(ip,jp) + bwatflx(i,j)*slope(ii,jj)
+                      endif
+                   enddo
+                enddo
+             endif  ! sum(slope) > 0
+
+          endif   ! flux_routing_scheme
+
+       endif  ! bwat_mask = 1 and bwatflx > 0
+
+    enddo  ! loop from high to low
+
+    ! Identify cells just beyond the ice sheet margin, which can receive from upstream but not send downstream
+    margin_mask = 0
+    do j = 1, ny
+       do i = 1, nx
+          if (bwat_mask(i,j) == 0 .and. bwatflx(i,j) > 0.0d0) then
+             margin_mask(i,j) = 1
+          endif
+       enddo
+    enddo
+
+    ! Compute total output of meltwater (m^3/s)
+
+    !WHL - debug
+!    print*, ' '
+!    print*, 'Margin cells: i, j, bwatflx:'
+    total_flux_out = 0.0d0
+    do j = 1, ny
+       do i = 1, nx
+          if (margin_mask(i,j) == 1) then
+             total_flux_out = total_flux_out + bwatflx(i,j)
+          endif
+       enddo
+    enddo
+
+    if (verbose_bwat .and. main_task) then
+       print*, ' '
+       print*, 'total output basal melt flux (m^3/s):', total_flux_out
+       print*, 'total unrouted flux (m^3/s):', flux_unrouted
+       print*, 'Sum:', total_flux_out + flux_unrouted
+    endif
+
+    !TODO - Add a bug check; should be equal
+
+    ! clean up
+    deallocate(sorted)
+
+  end subroutine route_basal_water
+
+!==============================================================
+
+  subroutine flux_to_depth(&
+         nx,       ny,           &
+         dx,       dy,           &
+         itest,    jtest, rtest, &
+         bwatflx,                &
+         head,                   &
+         c_flux_to_depth,        &
+         p_flux_to_depth,        &
+         q_flux_to_depth,        &
+         bwat_mask,              &
+         bwat)
+
+    !  Assuming that the flow is steady state, this function simply solves
+    !               flux = depth * velocity
+    !  for the depth, assuming that the velocity is a function of depth,
+    !  and pressure potential. This amounts to assuming a Weertman film,
+    !  or Manning flow, both of which take the form of a constant times water
+    !  depth to a power, times grad(head) to a power.
+
+    use glimmer_physcon, only : grav
+    use glissade_grid_operators, only: glissade_gradient_at_edges
+
+    ! Input/ouput variables
+
+    integer, intent(in) ::  &
+         nx, ny,               & ! number of grid cells in each direction
+         itest, jtest, rtest     ! coordinates of diagnostic point
+
+    real(dp), intent(in) ::  &
+         dx, dy                   ! grid spacing in each direction
+
+    real(dp), dimension(nx,ny), intent(in) :: &
+         bwatflx,               & ! basal water flux (m^3/s)
+         head                     ! hydraulic head (m)
+
+    real(dp), intent(in) ::  &
+         c_flux_to_depth,       & ! constant of proportionality
+         p_flux_to_depth,       & ! exponent for water depth
+         q_flux_to_depth          ! exponent for potential_gradient
+
+    integer, dimension(nx,ny), intent(in)  ::  &
+         bwat_mask               ! mask to identify cells through which basal water is routed;
+                                 ! = 1 where ice is present and not floating
+
+    real(dp), dimension(nx,ny), intent(out)::  &
+         bwat                     ! water depth
+
+    ! Local variables
+
+    integer :: i, j, p
+
+    real(dp), dimension(nx,ny) ::  &
+         grad_head                ! gradient of hydraulic head (m/m), averaged to cell centers
+
+    real(dp), dimension(nx-1,ny) ::  &
+         dhead_dx                 ! gradient component on E edges
+
+    real(dp), dimension(nx,ny-1) ::  &
+         dhead_dy                 ! gradient component on N edges
+
+    real(dp) ::  &
+         dhead_dx_ctr, dhead_dy_ctr, & ! gradient components averaged to cell centers
+         p_exponent                    ! p-dependent exponent in bwat expression
+
+    integer, dimension(nx,ny) ::  &
+         ice_mask                 ! mask passed to glissade_gradient_at edges; = 1 everywhere
+
+    ice_mask = 1
+
+    ! Compute gradient components at cell edges
+    ! HO_GRADIENT_MARGIN_LAND: Use all field values when computing the gradient, including values in ice-free cells.
+
+    call glissade_gradient_at_edges(&
+         nx,       ny,       &
+         dx,       dy,       &
+         head,               &
+         dhead_dx, dhead_dy, &
+         ice_mask,           &
+         gradient_margin_in = HO_GRADIENT_MARGIN_LAND)
+
+    grad_head = 0.0d0  ! will remain 0 in outer row of halo cells
+    do j = 2, ny-1
+       do i = 2, nx-1
+          dhead_dx_ctr = 0.5d0 * (dhead_dx(i-1,j) + dhead_dx(i,j))
+          dhead_dy_ctr = 0.5d0 * (dhead_dy(i,j-1) + dhead_dy(i,j))
+          grad_head(i,j) = sqrt(dhead_dx_ctr**2 + dhead_dy_ctr**2)
+       enddo
+    enddo
+
+    !TODO - If a halo update is needed for grad_head, then pass in 'parallel'.  But may not be needed.
+!!    call parallel_halo(grad_head, parallel)
+
+    !WHL - debug
+    p = 5
+    if (verbose_bwat .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'grad(head):'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(e10.3)',advance='no') grad_head(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    p_exponent = 1.d0 / (p_flux_to_depth + 1.d0)
+
+    ! Note: In Sommers et al. (2018), Eq. 6, the basal water flux q (m^2/s) is
+    !              q = (b^3 * g) / [(12*nu)(1 + omega*Re)] * (-grad(h))
+    !       where nu = kinematic viscosity of water = 1.787d-06 m^2/s
+    !          omega = 0.001
+    !             Re = Reynolds number
+    !
+    ! Following Aleah's formulation:
+    !          F = b^3 * c * g * dx * -grad(h) where c = 1/[(12*nu)(1 + omega*Re)]
+    !        b^3 = F / [c * g * dx * -grad(h)]
+    !          b = { F / [c * g * dx * -grad(h)] }^(1/3)
+    !
+    ! In the context of a formulation with general exponents,
+    ! we have q_flux_to_depth = 1 and p_flux_to_depth = 2 (so p_exponent = 1/3)
+    !
+    ! Jesse's Glimmer code has this:
+    !       bwat = ( bwatflx / (c_flux_to_depth * scyr * dy * grad_wphi**q_flux_to_depth) ) ** exponent
+    ! which is missing the grav term and seems to have an extra scyr term.
+    ! Also, c_flux_to_depth = 1 / (12 * 1.6d-3) in Jesse's code.  Note exponent of d-3 instead of d-6 for nu.
+    !
+    ! Note: Assuming dx = dy
+    ! TODO: Modify for the case dx /= dy?
+
+    where (grad_head /= 0.d0 .and. bwat_mask == 1)
+       bwat = ( bwatflx / (c_flux_to_depth * grav * dy * grad_head**q_flux_to_depth) ) ** p_exponent
+    elsewhere
+       bwat = 0.d0
+    endwhere
+
+  end subroutine flux_to_depth
+
+!==============================================================
+
+  subroutine fill_depressions(&
+       nx,   ny,    &
+       phi,         &
+       phi_mask)
+
+    ! Fill depressions in the input field phi
+
+    implicit none
+
+    ! Input/output variables
+
+    integer, intent(in) ::  &
+         nx, ny              ! number of grid cells in each direction
+
+    real(dp), dimension(nx,ny), intent(inout) :: &
+         phi                 ! input field with depressions to be filled
+
+    integer, dimension(nx,ny), intent(in) ::  &
+         phi_mask            ! = 1 in the domain where depressions need to be filled, else = 0
+                             ! corresponds to the grounded ice sheet for the flux-routing problem
+
+    ! Local variables --------------------------------------
+
+    real(dp), dimension(nx,ny) ::  &
+         old_phi,          & ! old value of phi
+         pool                ! identifies cells that need to be filled
+
+    real(dp) :: pvs(9), max_val
+
+    real(dp), parameter :: null = 1.d+20   ! large number
+    integer :: flag, i, j
+
+    integer :: count
+    integer, parameter :: count_max = 200
+
+!!    logical, parameter :: verbose_depressions = .false.
+    logical, parameter :: verbose_depressions = .true.
+
+
+    ! initialize
+
+    flag = 1
+    count = 0
+
+    do while (flag == 1)
+
+       count = count + 1
+       if (verbose_depressions .and. main_task) then
+          print*, ' '
+          print*, 'fill_depressions, count =', count
+       endif
+
+       flag = 0
+       old_phi = phi
+
+       do j = 2, ny-1
+          do i = 2, nx-1
+             if (phi_mask(i,j) == 1) then
+
+                if (any(old_phi(i-1:i+1,j-1:j+1) < old_phi(i,j))) then
+                   pool(i,j) = 0
+                else
+                   pool(i,j) = 1
+                end if
+
+                if (pool(i,j) == 1) then
+                   flag = 1
+                   pvs = (/ old_phi(i-1:i+1,j-1), old_phi(i-1:i+1,j+1), old_phi(i-1:i+1,j) /)
+
+                   where (pvs == old_phi(i,j))  ! equal to the original phi
+                      pvs = null
+                   end where
+
+                   max_val = minval(pvs)
+
+                   if (max_val /= null) then
+                      phi(i,j) = max_val
+                   else
+                      flag = 0
+                   end if
+
+                   if (verbose_depressions) then
+                      print*, 'flag, i, j, old phi, new phi:', flag, i, j, old_phi(i,j), phi(i,j)
+                   endif
+
+                end if   ! pool = 1
+
+             end if   ! phi_mask = 1
+          end do   ! i
+       end do   ! j
+
+       if (count > count_max) then
+          call write_log('Hydrology error: too many iterations in fill_depressions', GM_FATAL)
+       endif
+
+    end do   ! flag = 1
+
+  end subroutine fill_depressions
+
+!==============================================================
+
+  subroutine fix_flats(&
+       nx,    ny,            &
+       itest, jtest, rtest,  &
+       phi,                  &
+       phi_mask)
+
+    ! Add a small increment to flat regions in the input field phi,
+    !  so that all cells have a downhill outlet.
+    !
+    ! Use the algorithm of Garbrecht & Mertz:
+    ! Garbrecht, J., and L. W. Mertz (1997), The assignment of drainage direction
+    !    over flat surfaces in raster digital elevation models, J. Hydrol., 193,
+    !    204-213.
+
+    implicit none
+
+    ! Input/output variables
+
+    integer, intent(in) ::  &
+         nx, ny,               & ! number of grid cells in each direction
+         itest, jtest, rtest     ! coordinates of diagnostic point
+
+    real(dp), dimension(nx,ny), intent(inout) :: &
+         phi                    ! input field with flat regions to be fixed
+
+    integer, dimension(nx,ny), intent(in) ::  &
+         phi_mask               ! = 1 where any flat regions of phi will need to be fixed, else = 0
+                                ! corresponds to the grounded ice sheet (bmlt_mask) for the flux-routing problem
+
+    ! Local variables --------------------------------------
+
+    real(dp), dimension(nx,ny) ::  &
+         phi_input,           & ! input value of phi, before any corrections
+         phi_new,             & ! new value of phi, after incremental corrections
+         dphi1,               & ! sum of increments applied in step 1
+         dphi2                  ! sum of increments applied in step 2
+
+    integer, dimension(nx,ny) :: &
+         flat_mask,           & ! = 1 for cells with phi_mask = 1 and without a downslope gradient, else = 0
+         flat_mask_input,     & ! flat_mask as computed from phi_input
+         n_uphill,            & ! number of uphill neighbors for each cell, as computed from input phi
+         n_downhill             ! number of downhill neighbors for each cell, as computed from input phi
+
+    logical, dimension(nx,ny) :: &
+         incremented,         & ! = T for cells that have already been incremented (in step 2)
+         incremented_neighbor   ! = T for cells that have not been incremented, but have an incremented neighbor
+ 
+    logical :: finished         ! true when a loop has finished
+
+    real(dp), parameter :: &
+         phi_increment = 2.0d-5    ! fractional increment in phi (Garbrecht & Martz use 2.0e-5)
+
+    integer :: i, j, ii, jj, ip, jp, p
+    integer :: count
+    integer, parameter :: count_max = 50
+
+    !WHL - debug
+!!    logical, parameter :: verbose_fix_flats = .false.
+    logical, parameter :: verbose_fix_flats = .true.
+
+    p = pdiag
+
+    if (verbose_fix_flats .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'In fix_flats, rtest, itest, jtest =', rtest, itest, jtest
+       print*, ' '
+       print*, 'input phi:'
+       write(6,'(a3)',advance='no') '   '
+       do i = itest-p, itest+p
+          write(6,'(i10)',advance='no') i
+       enddo
+       write(6,*) ' '
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.5)',advance='no') phi(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       write(6,*) ' '
+       print*, 'mask:'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(i10)',advance='no') phi_mask(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! initialize
+
+    phi_input = phi
+
+    ! For use in Step 2, count the uphill and downhill neighbors of each cell.
+
+    n_uphill = 0
+    n_downhill = 0
+
+    do j = 2, ny-1
+       do i = 2, nx-1
+          if (phi_mask(i,j) == 1) then
+             do jj = -1,1
+                do ii = -1,1
+                   ! If this is the centre point, ignore
+                   if (ii == 0 .and. jj == 0) then
+                      continue
+                   else  ! check for nonzero elevation gradients
+                      ip = i + ii
+                      jp = j + jj
+                      if (phi(ip,jp) - phi(i,j) > eps11) then  ! uphill neighbor
+                         n_uphill(i,j) = n_uphill(i,j) + 1
+                      elseif (phi(i,j) - phi(ip,jp) > eps11) then  ! downhill neighbor
+                         n_downhill(i,j) = n_downhill(i,j) + 1
+                      endif
+                   endif
+                enddo   ! ii
+             enddo   ! jj
+          endif   ! phi_mask = 1
+       enddo   ! i
+    enddo   ! j
+
+    ! Identify the flat regions in the input field.
+    ! This includes all cells with phi_mask = 1 and without downslope neighbors.
+
+    call find_flats(&
+         nx,    ny,           &
+         itest, jtest, rtest, &
+         phi_input,           &
+         phi_mask,            &
+         flat_mask_input)
+
+    if (verbose_fix_flats .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'n_uphill:'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(i10)',advance='no') n_uphill(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'n_downhill:'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(i10)',advance='no') n_downhill(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'input flat_mask:'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(i10)',advance='no') flat_mask_input(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! Step 1: Gradient toward lower terrain
+
+    dphi1 = 0.0d0
+    flat_mask = flat_mask_input
+    finished = .false.
+    count = 0
+
+    ! Increment phi in all cells with flat_mask = 1 (no downslope gradient).
+    ! Repeat until all cells have a downslope gradient.
+
+    do while(.not.finished)
+
+       count = count + 1
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'step 1, count =', count
+       endif
+
+       do j = 2, ny-1
+          do i = 2, nx-1
+             if (flat_mask(i,j) == 1) then
+                dphi1(i,j) = dphi1(i,j) + phi_increment
+             endif
+          enddo
+       enddo
+
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'Updated dphi1/phi_increment:'
+          do j = jtest+p, jtest-p, -1
+             write(6,'(i6)',advance='no') j
+             do i = itest-p, itest+p
+                write(6,'(f10.1)',advance='no') dphi1(i,j)/ phi_increment
+             enddo
+             write(6,*) ' '
+          enddo
+       endif
+
+       ! From the original flat region, identify cells that still have no downslope gradient.
+
+       phi_new = phi_input + dphi1
+
+       call find_flats(&
+            nx,    ny,             &
+            itest, jtest, rtest,   &
+            phi_new,               &
+            flat_mask_input,       &
+            flat_mask)
+
+!       call parallel_halo(flat_mask, parallel)
+
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'Updated flat_mask:'
+          do j = jtest+p, jtest-p, -1
+             write(6,'(i6)',advance='no') j
+             do i = itest-p, itest+p
+                write(6,'(i10)',advance='no') flat_mask(i,j)
+             enddo
+             write(6,*) ' '
+          enddo
+       endif
+
+       ! If any flat cells remain, then repeat; else exit
+       finished = .true.
+       if (sum(flat_mask) > 0) then
+          finished = .false.
+       endif
+
+       if (count > count_max) then
+          call write_log('Hydrology error: abort in step 1 of fix_flats', GM_FATAL)
+       endif
+
+    enddo   ! step 1 finished
+
+    ! Step 2: Gradient away from higher terrain
+
+    dphi2 = 0.0d0
+    incremented = .false.
+    finished = .false.
+    count = 0
+
+    ! In the first pass, increment the elevation in all cells of the input flat region that are
+    !  adjacent to higher terrain and have no adjacent downhill cell.
+
+    do j = 2, ny-1
+       do i = 2, nx-1
+          if (flat_mask_input(i,j) == 1) then
+             if (n_uphill(i,j) >= 1 .and. n_downhill(i,j) == 0) then
+                dphi2(i,j) = dphi2(i,j) + phi_increment
+                incremented(i,j) = .true.
+             endif
+          endif
+       enddo
+    enddo
+
+!    call parallel_halo(incremented, parallel)
+
+    if (verbose_fix_flats .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'step 2, input flat_mask:'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(i10)',advance='no') flat_mask_input(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'Updated dphi2/phi_increment'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.1)',advance='no') dphi2(i,j)/phi_increment
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! If no cells are incremented in the first pass, then skip step 2.
+    ! This will be the case if the flat region lies at the highest elevation in the domain.
+
+    if (.not.any(incremented)) then
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'No cells to increment; skip step 2'
+       endif
+       finished = .true.
+    endif
+
+    ! In subsequent passes, increment the elevation in the following cells:
+    !  (1) all cells that have been previously incremented; and
+    !  (2) all cells in the input flat region that have not been previously incremented,
+    !      are adjacent to an incremented cell, and are not adjacent to a cell downhill
+    !      from the input flat region.
+    ! Repeat until no unincremented cells remain on the input flat region.
+    ! Note: This iterated loop uses flat_mask_input, which is not incremented.
+
+    do while(.not.finished)
+
+       count = count + 1
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'step 2, count =', count
+       endif
+
+       ! Identify cells that have not been incremented, but are adjacent to incremented cells
+       incremented_neighbor = .false.
+       do j = 2, ny-1
+          do i = 2, nx-1
+             if (flat_mask_input(i,j) == 1 .and. .not.incremented(i,j)) then
+                do jj = -1,1
+                   do ii = -1,1
+                      ! If this is the centre point, ignore
+                      if (ii == 0 .and. jj == 0) then
+                         continue
+                      else  ! check for an incremented neighbor
+                         ip = i + ii
+                         jp = j + jj
+                         if (incremented(ip,jp)) then
+                            incremented_neighbor(i,j) = .true.
+                         endif
+                      endif
+                   enddo   ! ii
+                enddo   ! jj
+             endif   ! flat_mask = 1 and incremented = F
+          enddo   ! i
+       enddo   ! j
+
+!       call parallel_halo(incremended_neighbor, parallel)
+
+       ! Increment cells of type (1) and (2)
+       ! Note: n_downhill was computed before step 1.
+
+       do j = 2, ny-1
+          do i = 2, nx-1
+             if (incremented(i,j)) then
+                dphi2(i,j) = dphi2(i,j) + phi_increment
+             elseif (n_downhill(i,j) == 0 .and. incremented_neighbor(i,j)) then
+                dphi2(i,j) = dphi2(i,j) + phi_increment
+                incremented(i,j) = .true.
+             endif
+          enddo
+       enddo
+
+!       call parallel_halo(incremented, parallel)
+
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'incremented_neighbor:'
+          do j = jtest+p, jtest-p, -1
+             write(6,'(i6)',advance='no') j
+             do i = itest-p, itest+p
+                write(6,'(L10)',advance='no') incremented_neighbor(i,j)
+             enddo
+             write(6,*) ' '
+          enddo
+          print*, 'Updated dphi2/phi_increment'
+          do j = jtest+p, jtest-p, -1
+             write(6,'(i6)',advance='no') j
+             do i = itest-p, itest+p
+                write(6,'(f10.1)',advance='no') dphi2(i,j)/phi_increment
+             enddo
+             write(6,*) ' '
+          enddo
+       endif
+
+       ! Check for cells that are in the input flat region and have not been incremented.
+       ! If there are no such cells, then exit the loop.
+       finished = .true.
+       do j = 2, ny-1
+          do i = 2, nx-1
+             if (flat_mask_input(i,j) == 1 .and. .not.incremented(i,j)) then
+                finished = .false.
+                exit
+             endif
+          enddo
+       enddo
+
+       if (count > count_max) then
+          call write_log('Hydrology error: abort in step 2 of fix_flats', GM_FATAL)
+       endif
+
+    enddo   ! step 2 finished
+
+
+    ! Step 3:
+
+    ! Add the increments from steps 1 and 2
+    ! The result is a surface with gradients both toward lower terrain and away from higher terrain.
+
+    phi = phi + dphi1 + dphi2
+
+    ! Check for cells with flat_mask = 1 (no downslope gradient).
+    ! Such cells are possible because of cancelling dphi1 and dphi2.
+
+    count = 0
+    finished = .false.
+
+    do while (.not.finished)
+
+       count = count + 1
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, ' '
+          print*, 'step 3, count =', count
+       endif
+
+       ! Identify cells without downslope neighbors
+
+       call find_flats(&
+            nx,    ny,           &
+            itest, jtest, rtest, &
+            phi,                 &
+            phi_mask,            &
+            flat_mask)
+
+       ! Add a half increment to any cells without downslope neighbors.
+       ! If all cells have downslope neighbors, then exit.
+
+       if (verbose_fix_flats .and. this_rank == rtest) then
+          print*, 'sum(flat_mask) =', sum(flat_mask)
+       endif
+
+       if (sum(flat_mask) > 0) then
+          where (flat_mask == 1)
+             phi = phi + 0.5d0 * phi_increment
+          endwhere
+          finished = .false.
+       else
+          finished = .true.
+       endif
+
+       if (count > count_max) then
+          call write_log('Hydrology error: abort in step 3 of fix_flats', GM_FATAL)
+       endif
+
+    enddo   ! step 3 finished
+
+    if (verbose_fix_flats .and. this_rank == rtest) then
+       print*, ' '
+       print*, 'Final phi:'
+       do j = jtest+p, jtest-p, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-p, itest+p
+             write(6,'(f10.5)',advance='no') phi(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+  end subroutine fix_flats
+
+!==============================================================
+
+  subroutine find_flats(&
+       nx,     ny,             &
+       itest,  jtest,  rtest,  &
+       phi,    phi_mask,       &
+       flat_mask)
+
+    ! Compute a mask that = 1 for cells in flat regions.
+    ! These are defined as cells with phi_mask = 1 and without a downslope gradient.
+    ! Note: This definition includes some cells that have the same elevation as
+    !       adjacent cells in the flat region, but have a nonzero downslope gradient.
+
+    ! Input/output arguments
+
+    integer, intent(in) ::  &
+         nx, ny,               & ! number of grid cells in each direction
+         itest, jtest, rtest     ! coordinates of diagnostic point
+
+    real(dp), dimension(nx,ny), intent(inout) :: &
+         phi                     ! elevation field with potential flat regions
+
+    integer, dimension(nx,ny), intent(in) :: &
+         phi_mask               ! = 1 for cells in the region where flats need to be identified
+
+    integer, dimension(nx,ny), intent(out) :: &
+         flat_mask               ! = 1 for cells with phi_mask = 1 and without a downslope gradient
+
+    ! Local variables
+
+    integer :: i, j, ii, jj, ip, jp
+
+    where (phi_mask == 1)
+       flat_mask = 1   ! assume flat until shown otherwise
+    elsewhere
+       flat_mask = 0
+    endwhere
+
+    ! Identify cells that have no downslope neighbors, and mark them as flat.
+
+    do j = 2, ny-1
+       do i = 2, nx-1
+          if (phi_mask(i,j) == 1) then
+             !TODO - Add an exit statement?
+             do jj = -1,1
+                do ii = -1,1
+                   ! If this is the centre point, ignore
+                   if (ii == 0 .and. jj == 0) then
+                      continue
+                   else  ! check for a downslope gradient
+                      ip = i + ii
+                      jp = j + jj
+                      if (phi(i,j) - phi(ip,jp) > eps11) then
+                         flat_mask(i,j) = 0
+                      endif
+                   endif
+                enddo   ! ii
+             enddo   ! jj
+          endif   ! phi_mask = 1
+       enddo   ! i
+    enddo   ! j
+
+!    call parallel_halo(flat_mask, parallel)
+
+  end subroutine find_flats
+
+!==============================================================
+
+  subroutine heights_sort(&
+       nx,    ny,            &
+       itest, jtest, rtest,  &
+       head,  sorted)
+
+    ! Create an array with the x and y location of each cell, sorted from from low to high values of head.
+    ! TODO: Adapt for parallel code.  Sort only the locally owned grid cells?
+
+    ! Input/output arguments
+
+    integer, intent(in) ::  &
+         nx, ny,               & ! number of grid cells in each direction
+         itest, jtest, rtest     ! coordinates of diagnostic point
+
+    real(dp), dimension(nx,ny), intent(in) :: &
+         head                    ! hydraulic head (m), to be sorted from low to high
+
+    integer, dimension(nx*ny,2), intent(inout) :: &
+         sorted                  ! i and j indices of each cell, sorted from from low to high head
+
+    ! Local variables
+
+    integer :: nn, i, j, k
+    real(dp), dimension(nx*ny) :: vect
+    integer, dimension(nx*ny) :: ind
+
+    nn = nx*ny
+
+    ! Fill a work vector with head values
+    k = 1
+    do i = 1, nx
+       do j = 1, ny
+          vect(k) = head(i,j)
+          k = k + 1
+       enddo
+    enddo
+
+    ! Sort the vector from low to high values
+    call indexx(vect, ind)
+
+    ! Fill the 'sorted' array with the i and j values of each cell
+    do k = 1, nn
+       sorted(k,1) = floor(real(ind(k)-1)/real(ny)) + 1
+       sorted(k,2) = mod(ind(k)-1,ny)+1
+    enddo
+
+    ! Fill the 'vect' array with head values
+    ! Note: This array is not an output field; used only for a bug check
+
+    do k = 1, nn
+       vect(k) = head(sorted(k,1), sorted(k,2))
+    enddo
+
+    !WHL - debug
+    if (verbose_bwat .and. this_rank == rtest) then
+!!       print*, ' '
+!!       print*, 'k, x, y, head:'
+       do k = nn-20, nn
+          vect(k) = head(sorted(k,1), sorted(k,2))
+!!          print*, k, sorted(k,1), sorted(k,2), vect(k)
+       enddo
+    endif
+
+  end subroutine heights_sort
+
+!==============================================================
+
+  !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  !
+  ! The following two subroutines perform an index-sort of an array.
+  ! They are a GPL-licenced replacement for the Numerical Recipes routine indexx.
+  ! They are not derived from any NR code, but are based on a quicksort routine by
+  ! Michael Lamont (http://linux.wku.edu/~lamonml/kb.html), originally written
+  ! in C, and issued under the GNU General Public License. The conversion to
+  ! Fortran 90, and modification to do an index sort was done by Ian Rutt.
+  !
+  !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+  subroutine indexx(array, index)
+
+    use glimmer_log
+
+    !> Performs an index sort of \texttt{array} and returns the result in
+    !> \texttt{index}. The order of elements in \texttt{array} is unchanged.
+    !>
+    !> This is a GPL-licenced replacement for the Numerical Recipes routine indexx.
+    !> It is not derived from any NR code, but are based on a quicksort routine by
+    !> Michael Lamont (http://linux.wku.edu/~lamonml/kb.html), originally written
+    !> in C, and issued under the GNU General Public License. The conversion to
+    !> Fortran 90, and modification to do an index sort was done by Ian Rutt.
+
+    real(dp),dimension(:) :: array !> Array to be indexed.
+    integer, dimension(:) :: index !> Index of elements of \texttt{array}.
+    integer :: i
+
+    if (size(array) /= size(index)) then
+       call write_log('ERROR: INDEXX size mismatch.',GM_FATAL,__FILE__,__LINE__)
+    endif
+
+    do i = 1,size(index)
+       index(i) = i
+    enddo
+
+    call q_sort_index(array, index, 1, size(array))
+
+  end subroutine indexx
+
+!==============================================================
+
+  recursive subroutine q_sort_index(numbers, index, left, right)
+
+    !> This is the recursive subroutine actually used by \texttt{indexx}.
+    !>
+    !> This is a GPL-licenced replacement for the Numerical Recipes routine indexx.
+    !> It is not derived from any NR code, but are based on a quicksort routine by
+    !> Michael Lamont (http://linux.wku.edu/~lamonml/kb.html), originally written
+    !> in C, and issued under the GNU General Public License. The conversion to
+    !> Fortran 90, and modification to do an index sort was done by Ian Rutt.
+
+    implicit none
+
+    real(dp),dimension(:) :: numbers !> Numbers being sorted
+    integer, dimension(:) :: index   !> Returned index
+    integer :: left, right           !> Limit of sort region
+
+    integer :: ll, rr
+    integer :: pv_int, l_hold, r_hold, pivpos
+    real(dp) :: pivot
+
+    ll = left
+    rr = right
+
+    l_hold = ll
+    r_hold = rr
+    pivot = numbers(index(ll))
+    pivpos = index(ll)
+
+    do
+       if (.not.(ll < rr)) exit
+
+       do
+          if  (.not.((numbers(index(rr)) >= pivot) .and. (ll < rr))) exit
+          rr = rr - 1
+       enddo
+
+       if (ll /= rr) then
+          index(ll) = index(rr)
+          ll = ll + 1
+       endif
+
+       do
+          if (.not.((numbers(index(ll)) <= pivot) .and. (ll < rr))) exit
+          ll = ll + 1
+       enddo
+
+       if (ll /= rr) then
+          index(rr) = index(ll)
+          rr = rr - 1
+       endif
+    enddo
+
+    index(ll) = pivpos
+    pv_int = ll
+    ll = l_hold
+    rr = r_hold
+    if (ll < pv_int)  call q_sort_index(numbers, index,ll, pv_int-1)
+    if (rr > pv_int)  call q_sort_index(numbers, index,pv_int+1, rr)
+
+  end subroutine q_sort_index
+
+!==============================================================
+
 end module glissade_basal_water
+
+!==============================================================

--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -1392,6 +1392,7 @@ contains
     real(dp),  dimension(nx,ny) ::  &
          thck_calving_front    ! effective ice thickness at the calving front
 
+    !TODO - Make this a config parameter?
     real(dp), parameter :: &   ! threshold for counting cells as grounded
          f_ground_threshold = 0.10d0
 
@@ -1632,7 +1633,7 @@ contains
          ocean_plus_thin_ice_mask         ! = 1 for ocean cells and cells with thin floating ice
 
     ! Both floating and weakly grounded cells can be identified as isthmuses and removed;
-    !  isthmuses_f_ground_threshold is used to identify weakly grounded cells.
+    !  isthmus_f_ground_threshold is used to identify weakly grounded cells.
     real(dp), parameter :: &   ! threshold for counting cells as grounded
          isthmus_f_ground_threshold = 0.50d0
 

--- a/libglissade/glissade_grid_operators.F90
+++ b/libglissade/glissade_grid_operators.F90
@@ -578,6 +578,9 @@ contains
     !
     !--------------------------------------------------------
 
+    ! TODO - Make HO_GRADIENT_MARGIN_LAND the default, since it is simple and requires no optional arguments?
+    ! TODO - Make ice_mask an optional argument, = 1 everywhere by default.
+
     if (present(gradient_margin_in)) then
        gradient_margin = gradient_margin_in
     else
@@ -585,7 +588,6 @@ contains
     endif
 
     ! Set logical edge mask based on gradient_margin.
-
     edge_mask_x(:,:) = .false.
     edge_mask_y(:,:) = .false.
 

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -1640,10 +1640,11 @@ module glissade_therm
     ! At each temperature point, compute the temperature part of the enthalpy.
     ! enth_T = enth for cold ice, enth_T < enth for temperate ice
 
-    enth_T(0) = rhoi*shci*temp(0)  !WHL - not sure enth_T(0) is needed
-    do up = 1, upn
+    do up = 1, upn-1
        enth_T(up) = (1.d0 - waterfrac(up)) * rhoi*shci*temp(up)
     enddo
+    enth_T(0) = rhoi*shci*temp(0)
+    enth_T(up) = rhoi*shci*temp(up)
 
 !WHL - debug
     if (verbose_column) then
@@ -2250,8 +2251,7 @@ module glissade_therm
     ! Compute the dissipation source term associated with strain heating,
     ! based on the shallow-ice approximation.
     
-    use glimmer_physcon, only : gn   ! Glen's n
-    use glimmer_physcon, only: rhoi, shci, grav
+    use glimmer_physcon, only: rhoi, shci, grav, n_glen
 
     integer, intent(in) :: ewn, nsn, upn   ! grid dimensions
 
@@ -2267,11 +2267,13 @@ module glissade_therm
     real(dp), dimension(:,:,:), intent(out) ::  &
          dissip       ! interior heat dissipation (deg/s)
     
-    integer, parameter :: p1 = gn + 1  
-
     integer :: ew, ns
     real(dp), dimension(upn-1) :: sia_dissip_fact  ! factor in SIA dissipation calculation
     real(dp) :: geom_fact         ! geometric factor
+
+    real(dp) :: p1                ! exponent = n_glen + 1
+
+    p1 = n_glen + 1.0d0
 
     ! Two methods of doing this calculation: 
     ! 1. find dissipation at u-pts and then average

--- a/libglissade/glissade_transport.F90
+++ b/libglissade/glissade_transport.F90
@@ -1092,7 +1092,8 @@
          maxvel = maxvvel
          indices_adv = maxloc(abs(vvel_layer(:,xs:xe,ys:ye)))
       endif
-      indices_adv(2:3) = indices_adv(2:3) + staggered_lhalo  ! want the i,j coordinates WITH the halo present - we got indices into the slice of owned cells
+      indices_adv(2:3) = indices_adv(2:3) + staggered_lhalo  ! want the i,j coordinates WITH the halo present -
+                                                             ! we got indices into the slice of owned cells
       ! Finally, determine maximum allowable time step based on advectice CFL condition.
       my_allowable_dt_adv = dew / (maxvel + 1.0d-20)
 

--- a/libglissade/glissade_transport.F90
+++ b/libglissade/glissade_transport.F90
@@ -1670,9 +1670,10 @@
     use glide_types
 
     ! If overwrite_acab /=0 , then set overwrite_acab_mask = 1 for grid cells
-    !  where acab is to be overwritten.  Currently, two options are supported:
+    !  where acab is to be overwritten.  Currently, three options are supported:
     ! (1) Overwrite acab where the input acab = 0 at initialization
     ! (2) Overwrite acab where the input thck <= overwrite_acab_minthck at initialization
+    ! (3) Overwrite acab based on an input mask
     !
     ! Note: This subroutine should be called only on initialization, not on restart.
 
@@ -1691,6 +1692,7 @@
 
     integer :: ewn, nsn
     integer :: i, j
+    integer :: max_mask_local, max_mask_global
 
     ewn = size(overwrite_acab_mask,1)
     nsn = size(overwrite_acab_mask,2)
@@ -1723,6 +1725,25 @@
 
           enddo
        enddo
+
+    elseif (overwrite_acab == OVERWRITE_ACAB_INPUT_MASK) then
+
+       ! Make sure a mask was read in with some nonzero values
+       ! If not, then write a warning
+
+       max_mask_local = maxval(overwrite_acab_mask)
+       max_mask_global = parallel_reduce_max(max_mask_local)
+       if (main_task) then
+          print*, 'rank, max_mask_local, max_mask_global:', &
+               this_rank, max_mask_local, max_mask_global
+       endif
+       if (max_mask_global == 1) then
+          ! continue
+       elseif (max_mask_global == 0) then
+          call write_log('Using overwrite_acab_mask without any values > 0', GM_WARNING)
+       else
+          call write_log('Using overwrite_acab_mask with values other than 0 and 1', GM_FATAL)
+       endif
 
     endif  ! overwrite_acab
 

--- a/libglissade/glissade_utils.F90
+++ b/libglissade/glissade_utils.F90
@@ -38,7 +38,8 @@ module glissade_utils
   implicit none
 
   private
-  public :: glissade_adjust_thickness, glissade_smooth_topography, glissade_adjust_topography
+  public :: glissade_adjust_thickness, glissade_smooth_usrf, &
+       glissade_smooth_topography, glissade_adjust_topography
   public :: glissade_stdev, verbose_stdev
 
   logical, parameter :: verbose_stdev = .true.
@@ -207,6 +208,187 @@ contains
     endif   ! usrf_max > tiny
 
   end subroutine glissade_adjust_thickness
+
+!****************************************************************************
+
+  subroutine glissade_smooth_usrf(model, nsmooth)
+
+    ! Use a Laplacian smoother to smooth the upper surface elevation,
+    !  and compute a thickness consistent with this new elevation.
+    ! This can be useful if the input thickness and topography are inconsistent,
+    !  such that their sum has large gradients.
+
+    use glimmer_paramets, only: thk0
+    use glide_thck, only: glide_calclsrf
+    use glissade_masks, only: glissade_get_masks
+    use glissade_grid_operators, only: glissade_laplacian_smoother
+    use cism_parallel, only: parallel_halo
+
+    !----------------------------------------------------------------
+    ! Input-output arguments
+    !----------------------------------------------------------------
+
+    type(glide_global_type), intent(inout) :: model   ! derived type holding ice-sheet info
+
+    integer, intent(in), optional :: nsmooth     ! number of smoothing passes
+
+    ! local variables
+
+    real(dp), dimension(model%general%ewn, model%general%nsn) :: &
+         topg,               &  ! bed topography (m)
+         thck,               &  ! thickness (m)
+         usrf,               &  ! surface elevation (m)
+         usrf_smoothed          ! surface elevation after smoothing
+
+    integer, dimension(model%general%ewn, model%general%nsn) :: &
+         ice_mask,           &  ! = 1 if ice is present (thck > 0, else = 0
+         floating_mask,      &  ! = 1 if ice is present (thck > 0) and floating, else = 0
+         ocean_mask             ! = 1 if topg < 0 and ice is absent, else = 0
+
+    integer :: n_smoothing_passes   ! local version of nsmooth
+    integer :: i, j, n
+    integer :: nx, ny
+    integer :: itest, jtest, rtest
+
+!    logical, parameter :: verbose_smooth_usrf = .false.
+    logical, parameter :: verbose_smooth_usrf = .true.
+
+    ! Initialize
+
+    if (present(nsmooth)) then
+       n_smoothing_passes = nsmooth
+    else
+       n_smoothing_passes = 1
+    endif
+
+    ! Copy some model variables to local variables
+
+    nx = model%general%ewn
+    ny = model%general%nsn
+
+    rtest = -999
+    itest = 1
+    jtest = 1
+    if (this_rank == model%numerics%rdiag_local) then
+       rtest = model%numerics%rdiag_local
+       itest = model%numerics%idiag_local
+       jtest = model%numerics%jdiag_local
+    endif
+
+    ! compute the initial upper surface elevation
+    call glide_calclsrf(model%geometry%thck, model%geometry%topg, model%climate%eus, model%geometry%lsrf)
+    model%geometry%usrf = max(0.d0, model%geometry%thck + model%geometry%lsrf)
+
+    ! Save input fields
+    topg = (model%geometry%topg - model%climate%eus) * thk0
+    thck = model%geometry%thck * thk0
+    usrf = model%geometry%usrf * thk0
+
+    if (verbose_smooth_usrf .and. this_rank == rtest) then
+       i = itest
+       j = jtest
+       print*, ' '
+       print*, 'itest, jtest, rank =', itest, jtest, rtest
+       print*, ' '
+       print*, 'Before Laplacian smoother, topg (m):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') topg(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'Before Laplacian smoother, usrf (m):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') usrf(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'Before Laplacian smoother, thck (m):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') thck(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! compute initial masks
+    call glissade_get_masks(nx,                  ny,                    &
+                            model%parallel,                             &
+                            model%geometry%thck, model%geometry%topg,   &
+                            model%climate%eus,   0.0d0,                 &  ! thklim = 0
+                            ice_mask,                                   &
+                            floating_mask = floating_mask,              &
+                            ocean_mask = ocean_mask)
+
+    do n = 1, n_smoothing_passes
+
+       call glissade_laplacian_smoother(nx,     ny,              &
+                                        usrf,   usrf_smoothed,   &
+                                        npoints_stencil = 9)
+
+       ! Force usrf = topg on ice-free land
+       where (topg > 0.0d0 .and. ice_mask == 0) usrf_smoothed = topg
+
+       ! Force usrf = unsmoothed value for floating ice and ice-free ocean, to avoid advancing the calving front
+       where (floating_mask == 1 .or. ocean_mask == 1)
+          usrf_smoothed = usrf
+       endwhere
+
+       ! Force usrf >= topg
+       usrf_smoothed = max(usrf_smoothed, topg)
+
+       usrf = usrf_smoothed
+       call parallel_halo(usrf, model%parallel)
+
+    enddo
+
+    ! Given the smoothed usrf, adjust the input thickness such that topg is unchanged.
+    ! Do this only where ice is present.  Elsewhere, usrf = topg.
+
+    where (usrf > topg)     ! ice is present
+       where (topg < 0.0d0)    ! marine-based ice
+          where (topg*(1.0d0 - rhoo/rhoi) > usrf)  ! ice is floating
+             thck = usrf / (1.0d0 - rhoi/rhoo)
+          elsewhere   ! ice is grounded
+             thck = usrf - topg
+          endwhere
+       elsewhere   ! land-based ice
+          thck = usrf - topg
+       endwhere
+    endwhere
+
+    ! Copy the new thickness and usrf to the model derived type
+    model%geometry%thck = thck/thk0
+    model%geometry%usrf = usrf/thk0
+
+    if (verbose_smooth_usrf .and. this_rank == rtest) then
+       i = itest
+       j = jtest
+       print*, ' '
+       print*, 'itest, jtest, rank =', itest, jtest, rtest
+       print*, ' '
+       print*, 'After Laplacian smoother, usrf (m):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') usrf(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'After Laplacian smoother, thck (m):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') thck(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+  end subroutine glissade_smooth_usrf
 
 !****************************************************************************
 

--- a/libglissade/glissade_velo.F90
+++ b/libglissade/glissade_velo.F90
@@ -43,9 +43,6 @@ contains
 
       ! Glissade higher-order velocity driver
 
-      use glimmer_global, only : dp
-      use glimmer_physcon, only: gn, scyr
-      use glimmer_paramets, only: thk0, len0, vel0, vis0, tau0, evs0
       use glimmer_log
       use glide_types
       use glissade_velo_higher, only: glissade_velo_higher_solve

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -1108,7 +1108,7 @@
      beta_internal => model%velocity%beta_internal(:,:)
      bfricflx => model%temper%bfricflx(:,:)
      bpmp     => model%temper%bpmp(:,:)
-     bwat     => model%temper%bwat(:,:)
+     bwat     => model%basal_hydro%bwat(:,:)
      bmlt     => model%basal_melt%bmlt(:,:)
 
      uvel     => model%velocity%uvel(:,:,:)
@@ -2016,12 +2016,14 @@
     ! Note: Ideally, bpmp and temp(nz) are computed after the transport solve,
     !       just before the velocity solve. Then they will be consistent with the
     !       current thickness field.
+    ! TODO: Move this call to a higher level.  Does not need any velocity information.
     !------------------------------------------------------------------------------
 
     !TODO - Use btemp_ground instead of temp(nz)?
     call calc_effective_pressure(whicheffecpress,              &
                                  nx,            ny,            &
                                  model%basal_physics,          &
+                                 model%basal_hydro,            &
                                  ice_mask,      floating_mask, &
                                  thck,          topg,          &
                                  eus,                          &

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -200,8 +200,8 @@
 !    logical :: verbose = .true.  
     logical :: verbose_init = .false.   
 !    logical :: verbose_init = .true.   
-!    logical :: verbose_solver = .false.
-    logical :: verbose_solver = .true.
+    logical :: verbose_solver = .false.
+!    logical :: verbose_solver = .true.
     logical :: verbose_Jac = .false.
 !    logical :: verbose_Jac = .true.
     logical :: verbose_residual = .false.

--- a/libglissade/glissade_velo_higher_pcg.F90
+++ b/libglissade/glissade_velo_higher_pcg.F90
@@ -63,14 +63,6 @@
        module procedure global_sum_staggered_2d_real8_nvar       
     end interface
 
-    ! linear solver settings
-    !TODO - Pass in these solver settings as arguments?
-!    integer, parameter ::    &
-!       maxiters = 200          ! max number of linear iterations before quitting
-                               ! TODO - change to maxiters_default?
-!    real(dp), parameter ::   &
-!       tolerance = 1.d-08    ! tolerance for linear solver
-
     logical, parameter :: verbose_pcg = .false.
     logical, parameter :: verbose_tridiag = .false.
 !!    logical, parameter :: verbose_pcg = .true.

--- a/libglissade/glissade_velo_sia.F90
+++ b/libglissade/glissade_velo_sia.F90
@@ -205,7 +205,7 @@
     usrf     => model%geometry%usrf(:,:)
     topg     => model%geometry%topg(:,:)
 
-    bwat     => model%temper%bwat(:,:)
+    bwat     => model%basal_hydro%bwat(:,:)
     btrc     => model%velocity%btrc(:,:)
     bfricflx => model%temper%bfricflx(:,:)
     temp     => model%temper%temp(:,:,:)

--- a/libglissade/glissade_velo_sia.F90
+++ b/libglissade/glissade_velo_sia.F90
@@ -55,7 +55,7 @@
   module glissade_velo_sia
 
     use glimmer_global, only: dp
-    use glimmer_physcon, only: gn, rhoi, grav, scyr
+    use glimmer_physcon, only: n_glen, rhoi, grav, scyr
     use glimmer_paramets, only: thk0, len0, vel0, vis0, tau0
 !    use glimmer_log, only: write_log
 
@@ -881,16 +881,15 @@
           
           if (stagthck(i,j) > thklim) then
 
-             siafact = 2.d0 * (rhoi*grav)**gn * stagthck(i,j)**(gn+1)             &
-                             * (dusrf_dx(i,j)**2 + dusrf_dy(i,j)**2) ** ((gn-1)/2)
-
+             siafact = 2.d0 * (rhoi*grav)**n_glen * stagthck(i,j)**(n_glen+1)             &
+                             * (dusrf_dx(i,j)**2 + dusrf_dy(i,j)**2) ** ((n_glen-1)/2)
              vintfact(nz,i,j) = 0.d0
 
              do k = nz-1, 1, -1
 
-                vintfact(k,i,j) = vintfact(k+1,i,j) -                             &
-                                  siafact * stagflwa(k,i,j)                       &
-                                          * ((sigma(k) + sigma(k+1))/2.d0) ** gn  &
+                vintfact(k,i,j) = vintfact(k+1,i,j) -                                 &
+                                  siafact * stagflwa(k,i,j)                           &
+                                          * ((sigma(k) + sigma(k+1))/2.d0) ** n_glen  &
                                           * (sigma(k+1) - sigma(k))
 
              enddo   ! k

--- a/tests/slab/README.md
+++ b/tests/slab/README.md
@@ -1,18 +1,88 @@
 Slab test case
 ==============
 
-WARNING: THIS TEST CASE IS IN DEVELOPMENT AND HAS NOT BEEN SCIENTIFICALLY VALIDATED.
-USE AT YOUR OWN RISK!
-
-
 This directory contains python scripts for running an experiment involving a
-uniform and infinite ice sheet ("slab") on an inclined plane.
+uniform, infinite ice sheet ("slab") on an inclined plane.
 
-The test case is described in sections 5.1-2 of:
-    J.K. Dukoqicz, 2012. Reformulating the full-Stokes ice sheet model for a
-    more efficient computational solution. The Cryosphere, 6, 21-34.
-    www.the-cryosphere.net/6/21/2012/
+The test case is described in sections 5.1-5.2 of:
+    Dukowicz, J. K., 2012, Reformulating the full-Stokes ice sheet model for a
+    more efficient computational solution. The Cryosphere, 6, 21-34,
+    doi:10.5194/tc-6-21-2012.
 
-Blatter-Pattyn First-order solution is described in J.K. Dukowicz, manuscript
-in preparation.
+Some results from this test case are described in Sect. 3.4 of:
+    Robinson, A., D. Goldberg, and W. H. Lipscomb, A comparison of the performance
+    of depth-integrated ice-dynamics solvers. Submitted to The Cryosphere, Aug. 2021.
+
+The test case consists of an ice slab of uniform thickness moving down an
+inclined plane by a combination of sliding and shearing.
+Analytic Stokes and first-order velocity solutions exist for all values of Glen's n >= 1.
+The solutions for n = 1 are derived in Dukowicz (2012), and solutions for n > 1
+are derived in an unpublished manuscript by Dukowicz (2013).
+
+The original scripts, runSlab.py and plotSlab.py, were written by Matt Hoffman
+with support for Glens' n = 1.  They came with warnings that the test is not supported.
+The test is now supported, and the scripts include some new features:
+
+* The user may specify any n >= 1 (not necessarily an integer).
+  The tests assume which_ho_efvs = 2 (nonlinear viscosity) with flow_law = 0 (constant A).
+* Physics parameters are no longer hard-coded.  The user can enter the ice thickness,
+  beta, viscosity coefficient (mu_n), and slope angle (theta) on the command line.
+* The user can specify time parameters dt (the dynamic time step) and nt (number of steps).
+  The previous version did not support transient runs.
+* The user can specify a small thickness perturbation dh, which is added to the initial
+  uniform thickness via random sampling from a Gaussian distribution.
+  The perturbation will grow or decay, depending on the solver stability for given dx and dt.
+
+The run script is executed by a command like the following:
+
+> python runSlab.py -n 4 -a DIVA -theta 0.0375 -thk 1000. -mu 1.e5 -beta 1000.
+
+In this case, the user runs on 4 processors with the DIVA solver, a slope angle of 0.0375 degrees,
+Glen's n = 1 (the default), slab thickness H = 1000 m, sliding coefficient beta = 1000 Pa (m/yr)^{-1},
+and viscosity coefficient 1.e5 Pa yr.
+These parameters correspond to the thick shearing test case described by Robinson et al. (2021).
+
+To see the full set of command-line options, type 'python runSlab.py -h'.
+
+Notes on effective viscosity:
+   * For n = 1, the viscosity coefficient mu_1 has a default value of 1.e6 Pa yr in the relation
+     mu = mu_1 * eps((1-n)/n), where eps is the effective strain rate.
+   * For n > 1, the user can specify a coefficient mu_n; otherwise the run script computes mu_n
+     such that the basal and surface speeds are nearly the same as for an n = 1 case with the
+     mu_1 = 1.e6 Pa yr and the same values of thickness, beta, and theta.
+   * There is a subtle difference between the Dukowicz and CISM definitions of the
+     effective strain rate; the Dukowicz value is twice as large. Later, it might be helpful
+     to make the Dukowicz convention consistent with CISM.)
+
+The plotting script, plotSlab.py, is run by typing 'python plotSlab.py'.  It creates two plots.
+The first plot shows the vertical velocity profile in nondimensional units and in units of m/yr.
+There is excellent agreement between higher-order CISM solutions and the analytic solution
+for small values of the slope angle theta.  For steep slopes, the answers diverge as expected.
+
+For the second plot, the extent of the y-axis is wrong. This remains to be fixed.
+
+This directory also includes a new script, stabilitySlab.py, to carry out the stability tests
+described in Robinson et al. (2021).
+
+For a given set of physics parameters and stress-balance approximation (DIVA, L1L2, etc.),
+the script launches multiple CISM runs at a range of grid resolutions.
+At each grid resolution, the script determines the maximum stable time step.
+A run is deemed stable when the standard deviation of an initial small thickness perturbation
+is reduced over the course of 100 time steps.  A run is unstable if the standard deviation
+increases or if the model aborts (usually with a CFL violation).
+
+To run the stability script, type a command like the following:
+
+> python stabilitySlab.py -n 4 -a DIVA -theta 0.0375 -thk 1000. -mu 1.e5 -beta 1000.  \
+  -dh 0.1 -nt 100 -nr 12 -rmin 10. -rmax 40000.
+
+Here, the first few commands correspond to the thick shearing test case and are passed repeatedly
+to the run script.  The remaining commands specify that each run will be initialized
+with a Gaussian perturbation of amplitude 0.1 m and run for 100 timesteps.
+The maximum stable timestep will be determined at 12 resolutions ranging from 10m to 40 km.
+This test takes several minutes to complete on a Macbook Pro with 4 cores.
+
+To see the full set of commmand line options, type 'python stabilitySlab.py -h'.
+
+For questions, please contact Willian Lipscomb (lipscomb@ucar.edu) or Gunter Leguy (gunterl@ucar.edu).
 

--- a/tests/slab/plotSlab.py
+++ b/tests/slab/plotSlab.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python2
 
-
 """
 This script plots the results of an experiment with an ice "slab" on an
 inclined plane. Test case is described in sections 5.1-2 of:
-    J.K. Dukoqicz, 2012. Reformulating the full-Stokes ice sheet model for a
+    J.K. Dukowicz, 2012. Reformulating the full-Stokes ice sheet model for a
     more efficient computational solution. The Cryosphere, 6, 21-34.
     www.the-cryosphere.net/6/21/2012/
 
@@ -12,13 +11,12 @@ Blatter-Pattyn First-order solution is described in J.K. Dukowicz, manuscript
 in preparation.
 """
 #FIXME: Manuscript likely not in prep anymore -- JHK, 08/07/2015
+#       Not published as of July 2021 -- WHL
 
 # Written by Matt Hoffman, Dec. 16, 2013
 # Reconfigured by Joseph H Kennedy at ORNL on August 7, 2015 to work with the regression testing
 #     NOTE: Did not adjust inner workings except where needed.
-
-
-#NOTE: this script is assuming n=3, but more general solutions are available.
+# Revised by William Lipscomb in 2021 to support more options, including general values of Glen's n.
 
 import os
 import sys
@@ -28,8 +26,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from netCDF import *
-from math import tan, pi, sin, cos
-from runSlab import n, rhoi, grav, theta, beta, efvs, thickness  # Get the values used to run the experiment
+from math import tan, pi, sin, cos, atan
+
+# Get hard-coded parameters from the run script.
+from runSlab import rhoi, grav
+
+import ConfigParser
 
 import argparse
 parser = argparse.ArgumentParser(description=__doc__,
@@ -46,16 +48,15 @@ parser.add_argument('-f', '--output-file',
         help="The tests output file you would like to plot. If a path is" \
         +"passed via this option, the -o/--output-dir option will be ignored.")
 
+parser.add_argument('-c','--config-file',
+        help="The configure file used to set up the test case and run CISM")
+
 
 # ===========================================================
 # Define some variables and functions used in the main script
 # ===========================================================
 
-# Calculate scales from Ducowicz unpub. man.
-eta = beta * thickness * efvs**-n * (rhoi * grav * thickness)**(n-1) 
-velscale = (rhoi * grav * thickness / efvs)**n * thickness
-thetar = theta * pi/180.0  # theta in radians
-
+#WHL args.output-file with a hyphen?
 def get_in_file():
     if args.output_file:
         out_d, out_f = os.path.split(args.output_file)
@@ -76,7 +77,7 @@ def get_in_file():
             newest = max(matching, key=os.path.getmtime)
             print("\nWARNING: MULTIPLE *.out.nc FILES DETECTED!")
             print(  "==========================================")
-            print(  "Ploting the most recently modified file in the output directory:")
+            print(  "Plotting the most recently modified file in the output directory:")
             print(  "    "+newest)
             print(  "To plot another file, specify it with the -f/--outfile option.\n")
             
@@ -94,6 +95,25 @@ def get_in_file():
      
     return filein
 
+def split_file_name(file_name):
+    """
+    Get the root name, size, and number of processors from an out.nc filename.
+    #WHL - Adapted from plotISMIP_HOM.py
+    """
+    root = ''
+    size = ''
+    proc = ''
+
+    file_details = file_name.replace('.out.nc','') .split('.')
+#    print(file_details)
+#    print('len = ' + str(len(file_details)))
+
+    if len(file_details) > 2:
+        proc = '.'+file_details[2]
+    size = '.'+file_details[1]
+    root = file_details[0]
+
+    return (root, size, proc)
 
 # =========================
 # Actual script starts here
@@ -103,10 +123,7 @@ def main():
     Plot the slab test results.
     """
 
-    print("WARNING: THIS TEST CASE IS IN DEVELOPMENT. USE AT YOUR OWN RISK!")
-
-
-    filein = get_in_file()    
+    filein = get_in_file()
 
     # Get needed variables from the output file
     x1 = filein.variables['x1'][:]
@@ -120,28 +137,96 @@ def main():
     # use integer floor division operator to get an index close to the center 
     xp = len(x0)//2
     yp = len(y0)//2
-    #yp = 15
-    #xp = 15
     # =====================================================================
-    print 'Using x index of '+str(xp)+'='+str(x0[xp])
-    print 'Using y index of '+str(yp)+'='+str(y0[yp])
+
+    print('Using x index of '+str(xp)+'='+str(x0[xp]))
+    print('Using y index of '+str(yp)+'='+str(y0[yp]))
 
     thk = filein.variables['thk'][:]
     if netCDF_module == 'Scientific.IO.NetCDF':
-       thk = thk * filein.variables['thk'].scale_factor
+        thk = thk * filein.variables['thk'].scale_factor
     topg = filein.variables['topg'][:]
     if netCDF_module == 'Scientific.IO.NetCDF':
-       topg = topg * filein.variables['topg'].scale_factor
+        topg = topg * filein.variables['topg'].scale_factor
     uvel = filein.variables['uvel'][:]
     if netCDF_module == 'Scientific.IO.NetCDF':
-       uvel = uvel * filein.variables['uvel'].scale_factor
+        uvel = uvel * filein.variables['uvel'].scale_factor
+    beta_2d = filein.variables['beta'][:]
+    if netCDF_module == 'Scientific.IO.NetCDF':
+        beta_2d = beta_2d * filein.variables['beta'].scale_factor
 
+    # Get the name of the config file
+    # If not entered on the command line, then construct from the output filename
+
+    if not args.config_file:
+        root, size, proc = split_file_name(args.output_file)
+        args.config_file = root + size + proc + '.config'
+
+    configpath = os.path.join(args.output_dir, args.config_file)
+    print('configpath = ' + configpath)
+
+    # Get gn and default_flwa from the config file
+
+    try:
+        config_parser = ConfigParser.SafeConfigParser()
+        config_parser.read( configpath )
+
+        gn = float(config_parser.get('parameters','n_glen'))
+        flwa = float(config_parser.get('parameters', 'default_flwa'))
+
+    except ConfigParser.Error as error:
+        print("Error parsing " + args.config )
+        print("   "),
+        print(error)
+        sys.exit(1)
+
+    # Derive the viscosity constant mu_n from flwa
+    # This expression is derived in the comments on flwa in runSlab.py.
+    mu_n = 1.0 / (2.0**((1.0+gn)/(2.0*gn)) * flwa**(1.0/gn))
+
+    # Get the ice thickness from the output file.
+    # If thickness = constant (i.e., the optional perturbation dh = 0), it does not matter where we sample.
+    # Note: In general, this thickness will differ from the baseline 'thk' that is used in runSlab.py
+    #        to create the input file.
+    #       This is because the baseline value is measured perpendicular to the sloped bed,
+    #        whereas the CISM value is in the vertical direction, which is not perpendicular to the bed.
+    thickness = thk[0,yp,xp]
+
+    # Get beta from the output file.
+    # Since beta = constant, it does not matter where we sample.
+    beta = beta_2d[0,yp,xp]
+
+    # Derive theta from the output file as atan(slope(topg))
+    # Since the slope is constant, it does not matter where we sample.
+    slope = (topg[0,yp,xp] - topg[0,yp,xp+1]) / (x0[xp+1] - x0[xp])
+    thetar = atan(slope)
+    theta = thetar * 180.0/pi
+
+    # Compute the dimensionless parameter eta and the velocity scale,
+    # which appear in the scaled velocity solution.
+    eta = (beta * thickness / mu_n**gn) * (rhoi * grav * thickness)**(gn-1)
+    velscale = (rhoi * grav * thickness / mu_n)**gn * thickness
+
+    print('gn   = ' + str(gn))
+    print('rhoi = ' + str(rhoi))
+    print('grav = ' + str(grav))
+    print('thck = ' + str(thickness))
+    print('mu_n = ' + str(mu_n))
+    print('flwa = ' + str(flwa))
+    print('beta = ' + str(beta))
+    print('eta  = '  + str(eta))
+    print('theta= ' + str(theta))
+    print('velscale = ' + str(velscale))
 
     # === Plot the results at the given location ===
     # Note we are not plotting like in Fig 3 of paper.
     # That figure plotted a profile against zprime.
     # It seemed more accurate to plot a profile against z to avoid interpolating model results (analytic solution can be calculated anywhere).
-    # Also, the analytic solution calculates the bed-parallel u velocity, but CISM calculates u as parallel to the geoid, so we need to transform the analytic solution to the CISM coordinate system.
+    # Also, the analytic solution calculates the bed-parallel u velocity, but CISM calculates u as parallel to the geoid,
+    #  so we need to transform the analytic solution to the CISM coordinate system.
+
+    #WHL - I think the analytic solution is actually for u(z'), which is not bed-parallel.
+    #      The bed-parallel solution would be u'(z'), with w'(z') = 0.
 
     fig = plt.figure(1, facecolor='w', figsize=(12, 6))
 
@@ -151,24 +236,23 @@ def main():
     x = (x0-x0[xp]) / thickness
     # calculate rotated zprime coordinates for this column (we assume the solution truly is spatially uniform)
     zprime = x[xp] * sin(thetar) + z * cos(thetar)
-    #print 'zprime', zprime
 
     # Calculate analytic solution for x-component of velocity (eq. 39 in paper) for the CISM-column
-    #uvelStokesAnalyticScaled =  sin(theta * pi/180.0) * cos(theta * pi/180.0) * (0.5 * zprime**2 - zprime - 1.0/eta)
-    uvelStokesAnalyticScaled = (-1)**n * 2**((1.0-n)/2.0) * sin(thetar)**n * cos(thetar) / (n+1) \
-                    * ( (zprime - 1.0)**(n+1) - (-1.0)**(n+1) ) + sin(thetar) * cos(thetar) / eta
+    uvelStokesAnalyticScaled = sin(thetar) * cos(thetar) / eta   \
+        - 2**((1.0-gn)/2.0) * sin(thetar)**gn * cos(thetar) / (gn+1) * ( (1.0 - zprime)**(gn+1) - 1.0 )
 
-    # Calculate the BP FO solution for x-component of velocity (Ducowicz, in prep. paper, Eq.30, n=3)
-    #uvelFOAnalyticScaled = (tan(theta * pi/180.0))**3 / (8.0 * (1.0 + 3.0 * (sin(theta * pi/180.0)**2))**2) \
-    uvelFOAnalyticScaled = (-1)**n * 2**((1.0-n)/2.0) * tan(thetar)**n /  \
-                           ( (n + 1) * (1.0 + 3.0 * sin(thetar)**2)**((n+1.0)/2.0) )  \
-                           * ( (zprime - 1.0)**(n+1) - (-1.0)**(n+1) ) + tan(thetar) / eta
+    # Calculate the BP FO solution for x-component of velocity (Dukowicz, in prep. paper, Eq.30, n=3)
+    uvelFOAnalyticScaled = + tan(thetar) / eta  \
+                           -  2**((1.0-gn)/2.0) * tan(thetar)**gn /  \
+                           ( (gn + 1) * (1.0 + 3.0 * sin(thetar)**2)**((gn+1.0)/2.0) )  \
+                           * ( (1.0 - zprime)**(gn+1) - 1.0 )
 
     ### 1. Plot as nondimensional variables
     # Plot analytic solution 
     fig.add_subplot(1,2,1)
     plt.plot(uvelStokesAnalyticScaled, z, '-kx', label='Analytic Stokes')
     plt.plot(uvelFOAnalyticScaled, z, '-ko', label='Analytic FO')
+
     # Plot model results
     plt.plot(uvel[0,:,yp,xp] / velscale, z, '--ro', label='CISM') 
     plt.ylim((-0.05, 1.05))
@@ -191,7 +275,16 @@ def main():
     plt.title('Velocity profile at x=' + str(x0[xp]) + ' m, y=' + str(y0[yp]) + ' m\n(Unscaled coordinates)')
 
     #################
+#    print('y0_min:')
+#    print(y0.min())
+#    print('y0_max:')
+#    print(y0.max())
+
     # Now plot maps to show if the velocities vary over the domain (they should not)
+    # For some reason, the y-axis has a greater extent than the range (y0.min, y0.max).
+    #TODO - Fix the y-axis extent.  Currently, the extent is too large for small values of ny.
+    #TODO - Plot the thickness relative to the initial thickness.
+
     fig = plt.figure(2, facecolor='w', figsize=(12, 6))
     fig.add_subplot(1,2,1)
     uvelDiff = uvel[0,0,:,:] - uvel[0,0,yp,xp]
@@ -224,13 +317,10 @@ def main():
     #plt.plot(level, tan(thetar)**3 / (8.0 * (1.0 + 3.0 * sin(thetar)**2)**2) * (1.0 - (level-1.0)**4 ) + tan(thetar)/eta, 'b--' , label='nonlinear fo')
     #plt.ylim((0.0, 0.04)); plt.xlabel("z'"); plt.ylabel('u'); plt.legend()
 
-
     plt.draw()
     plt.show()
 
     filein.close()
-
-    print("WARNING: THIS TEST CASE IS IN DEVELOPMENT. USE AT YOUR OWN RISK!")
 
 # Run only if this is being run as a script.
 if __name__=='__main__':
@@ -240,4 +330,3 @@ if __name__=='__main__':
     
     # run the script
     sys.exit(main())
-

--- a/tests/slab/runSlab.py
+++ b/tests/slab/runSlab.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python2
 
-#FIXME: More detailed description of this test case!!!
 """
 Run an experiment with an ice "slab". 
 """
@@ -8,10 +7,12 @@ Run an experiment with an ice "slab".
 # Authors
 # -------
 # Modified from dome.py by Matt Hoffman, Dec. 16, 2013
-#    Test case described in sections 5.1-2 of:
-#    J.K. Dukoqicz, 2012. Reformulating the full-Stokes ice sheet model for a 
-#    more efficient computational solution. The Cryosphere, 6, 21-34. www.the-cryosphere.net/6/21/2012/
-# Reconfigured by Joseph H Kennedy at ORNL on April 27, 2015 to work with the regression testing
+#    Test case described in sections 5.1- 5.2 of:
+#    J.K. Dukowicz, 2012. Reformulating the full-Stokes ice sheet model for a
+#    more efficient computational solution. The Cryosphere, 6, 21-34,
+#    https://doi.org/10.5194/tc-6-21-2012.
+# Reconfigured by Joseph H Kennedy at ORNL on April 27, 2015 to work with the regression testing.
+# Revised by William Lipscomb in 2021 to support more options.
 
 import os
 import sys
@@ -19,10 +20,10 @@ import errno
 import subprocess
 import ConfigParser 
 
-import numpy
+import numpy as np
 import netCDF
-from math import sqrt, tan, pi, cos
 
+from math import sqrt, sin, cos, tan, pi
 
 # Parse the command line options
 # ------------------------------
@@ -56,11 +57,36 @@ parser.add_argument('-q', '--quiet', action='store_true',
 parser.add_argument('-s','--setup-only', action='store_true',
         help="Set up the test, but don't actually run it.")
 
-
-# Additional test specific options:
-#parser.add_argument('--scale', type=unsigned_int, default=0, 
-#        help="Scales the problem size by 2**SCALE. SCALE=0 creates a 31x31 grid, SCALE=1 " 
-#            +"creates a 62x62 grid, and SCALE=2 creates a 124x124 grid.")
+# Additional options to set grid, solver, physics parameters, etc.:
+#Note: The default mu_n = 0.0 is not actually used.
+#      Rather, mu_n is computed below, unless mu_n > 0 is specified in the command line.
+#      For n = 1, the default is mu_1 = 1.0e6 Pa yr.
+parser.add_argument('-a','--approx', default='BP',
+        help="Stokes approximation (SIA, SSA, BP, L1L2, DIVA)")
+parser.add_argument('-beta','--beta', default=2000.0,
+        help="Friction parameter beta (Pa (m/yr)^{-1})")
+parser.add_argument('-dh','--delta_thck', default=0.0,
+        help="Thickness perturbation (m)")
+parser.add_argument('-dt','--tstep', default=0.01,
+        help="Time step (yr)")
+parser.add_argument('-gn','--glen_exponent', default=1,
+        help="Exponent in Glen flow law")
+parser.add_argument('-l','--levels', default=10,
+        help="Number of vertical levels")
+parser.add_argument('-mu','--mu_n', default=0.0,
+        help="Viscosity parameter mu_n (Pa yr^{1/n})")
+parser.add_argument('-nt','--n_tsteps', default=0,
+        help="Number of timesteps")
+parser.add_argument('-nx','--nx_grid', default=50,
+        help="Number of grid cells in x direction")
+parser.add_argument('-ny','--ny_grid', default=5,
+        help="Number of grid cells in y direction")
+parser.add_argument('-r','--resolution', default=100.0,
+        help="Grid resolution (m)")
+parser.add_argument('-theta','--theta', default=5.0,
+        help="Slope angle (deg)")
+parser.add_argument('-thk','--thickness', default=1000.0,
+        help="Ice thickness (m)")
 
 
 # Some useful functions
@@ -112,28 +138,11 @@ def prep_commands(args, config_name):
 
     return commands
 
-
-# Hard coded test specific parameters
 # -----------------------------------
-#FIXME: Some of these could just be options!
-
-# Physical parameters 
-n = 1 # flow law parameter - only the n=1 case is currently supported
-# (implementing the n=3 case would probably require implementing a new efvs option in CISM)
-rhoi = 910.0 # kg/m3
-grav = 9.1801 # m^2/s
-
-# Test case parameters
-theta = 18  # basal inclination angle (degrees)  unpub. man. uses example with theta=18
-thickness = 1000.0  # m  thickness in the rotated coordinate system, not in CISM coordinates
+# Hard-cosed test case parameters
+rhoi = 917.0     # kg/m^3
+grav = 9.81      # m^2/s
 baseElevation = 1000.0 # arbitrary height to keep us well away from sea level
-
-efvs = 2336041.42829      # hardcoded in CISM for constant viscosity setting (2336041.42829 Pa yr)
-
-eta = 10.0   # unpub. man. uses example with eta=10.0
-beta = eta / thickness / efvs**-n / (rhoi * grav * thickness)**(n-1)  # Pa yr m^-1
-# Note: Fig. 3 in Ducowicz (2013) uses eta=18, where eta=beta*H/efvs
-  
   
 # the main script function
 # ------------------------
@@ -142,24 +151,24 @@ def main():
     Run the slab test.
     """
 
-    print("WARNING: THIS TEST CASE IS IN DEVELOPMENT. USE AT YOUR OWN RISK!")
-
     # check that file name modifier, if it exists, starts with a '-'
     if not (args.modifier == '') and not args.modifier.startswith('-') :
         args.modifier = '-'+args.modifier
          
     # get the configuration
     # ---------------------
+
+    dx = float(args.resolution)
+    dy = dx
+    nx = int(args.nx_grid)
+    ny = int(args.ny_grid)
+    nz = int(args.levels)
+    dt = float(args.tstep)
+    tend = float(args.n_tsteps) * dt
+
     try:
         config_parser = ConfigParser.SafeConfigParser()
         config_parser.read( args.config )
-        
-        nz = int(config_parser.get('grid','upn'))
-        nx = int(config_parser.get('grid','ewn'))
-        ny = int(config_parser.get('grid','nsn'))
-        dx = float(config_parser.get('grid','dew'))
-        dy = float(config_parser.get('grid','dns'))
-        
         file_name = config_parser.get('CF input', 'name')
         root, ext = os.path.splitext(file_name)
 
@@ -169,7 +178,8 @@ def main():
         print(error)
         sys.exit(1)
     
-    res = str(nx).zfill(4)
+    res=str(int(dx)).zfill(5)  # 00100 for 100m, 01000 for 1000m, etc.
+
     if args.parallel > 0:
         mod = args.modifier+'.'+res+'.p'+str(args.parallel).zfill(3)
     else:
@@ -180,31 +190,145 @@ def main():
     out_name = root+mod+'.out'+ext
 
     
-    # Setup the domain
+    # Set up the domain
     # ----------------
-    offset = 1.0 * float(nx)*dx * tan(theta * pi/180.0)
 
-
-    # create the new config file
+    # Create the new config file
     # --------------------------
     if not args.quiet: 
         print("\nCreating config file: "+config_name)
     
+    # Set grid and time parameters
     config_parser.set('grid', 'upn', str(nz))
     config_parser.set('grid', 'ewn', str(nx))
     config_parser.set('grid', 'nsn', str(ny))
     config_parser.set('grid', 'dew', str(dx))
     config_parser.set('grid', 'dns', str(dy))
+    config_parser.set('time', 'dt',  str(dt))
+    config_parser.set('time', 'tend',str(tend))
+
+    # Set physics parameters that are needed to create the config file and the input netCDF file.
+    # Note: rhoi and grav are hardwired above.
+
+    # ice thickness
+    thickness = float(args.thickness)
+
+    # friction parameter beta (Pa (m/yr)^{-1})
+    beta = float(args.beta)
+
+    # basal inclination angle (degrees)
+    theta = float(args.theta)
+    theta_rad = theta * pi/180.0   # convert to radians
+
+    # flow law exponent
+    # Any value n >= 1 is supported.
+    gn = float(args.glen_exponent)
+
+    # Note: Fig. 3 in Dukowicz (2012) uses eta = 18 and theta = 18 deg.
+    #       This gives u(1) = 10.0 * u(0), where u(1) = usfc and u(0) = ubas.
+
+    # viscosity coefficient mu_n, dependent on n (Pa yr^{1/n})
+    #      The nominal default is mu_n = 0.0, but this value is never used.
+    #      If a nonzero value is specified on the command line, it is used;
+    #        else, mu_n is computed here.  The goal is to choose a value mu_n(n) that
+    #        will result in vertical shear similar to a default case with n = 1 and mu_1,
+    #        provided we have similar values of H and theta.
+    #      In the Dukowicz unpublished manuscript, the viscosity mu is given by
+    #             mu = mu_n * eps_e^[(1-n)/n], where eps_e is the effective strain rate.
+    #      For n = 1, we choose a default value of 1.0e6 Pa yr.
+    #      For n > 1, we choose mu_n (units of Pa yr^{1/n}) to match the surface velocity
+    #       we would have with n = 1 and the same values of H and theta.
+    #      The general velocity solution is
+    #      u(z') = u_b + du(z')
+    #        where u_b = rhoi * grav * sin(theta) * cos(theta) / beta
+    #          and du(z') = 2^{(1-n)/2}/(n+1) * sin^n(theta) * cos(theta)
+    #                     * (rhoi*grav*H/mu_n)^n * H * [1 - (1 - z'/H)^{n+1}]
+    #      For z' = H and general n, we have
+    #             du_n(H) = 2^{(1-n)/2}/(n+1) * sin^n(theta) * cos(theta)
+    #                     * (rhoi*grav*H/mu_n)^n * H
+    #      For z' = H and n = 1, we have
+    #             du_1(H) = (1/2) * sin(theta) * cos(theta) * (rhoi*grav*H/mu_1) * H
+    #      If we equate du_n(H) with du_1(H), we can solve for mu_n:
+    #              mu_n = [ 2^{(3-n)/(2n)}/(n+1) * sin^{n-1}(theta) * (rhoi*grav*H)^{n-1} * mu_1 ]^{1/n}
+    #              with units Pa yr^{1/n}
+    #      This value should give nearly the same shearing velocity du(H) for exponent n > 1
+    #        as we would get for n = 1, given mu_1 and the same values of H and theta.
+
+    if float(args.mu_n) > 0.0:
+        mu_n = float(args.mu_n)
+        mu_n_pwrn = mu_n**gn
+    else:
+        mu_1 = 1.0e6   # default value for mu_1 (Pa yr)
+        mu_n_pwrn = 2.0**((3.0-gn)/2.0)/(gn+1.0) * sin(theta_rad)**(gn-1.0) \
+                  * (rhoi*grav*thickness)**(gn-1.0) * mu_1   # (mu_n)^n
+        mu_n = mu_n_pwrn**(1.0/gn)
+
+    # Given mu_n, compute the temperature-independent flow factor A = 1 / [2^((1+n)/2) * mu_n^n].
+    # This is how CISM incorporates a prescribed mu_n (with flow_law = 0, i.e. constant flwa).
+    # Note: The complicated exponent of 2 in the denominator results from CISM and the Dukowicz papers
+    #       having different conventions for the squared effective strain rate, eps_sq.
+    #       In CISM:     mu = 1/2 * A^(-1/n) * eps_sq_c^((1-n)/(2n))
+    #        where eps_sq_c = 1/2 * eps_ij * eps_ij
+    #                eps_ij = strain rate tensor
+    #       In Dukowicz: mu = mu_n * eps_sq_d^((1-n)/(2n))
+    #        where eps_sq_d = eps_ij * eps_ij = 2 * eps_sq_c
+    #       Equating the two values of mu, we get mu_n * 2^((1-n)/(2n)) = 1/2 * A^(-1/n),
+    #        which we solve to find A = 1 / [2^((1+n)/2) * mu_n^n]
+    #       Conversely, we have  mu_n = 1 / [2^((1+n)/(2n)) * A^(1/n)]
+    #TODO: Modify the Dukowicz derivations to use the same convention as CISM.
+    flwa = 1.0 / (2.0**((1.0+gn)/2.0) * mu_n_pwrn)
+
+    # Find the dimensionless parameter eta
+    # This is diagnostic only; not used directly by CISM
+    eta = (beta * thickness / mu_n**gn) * (rhoi * grav * thickness)**(gn-1)
+
+    # periodic offset; depends on theta and dx
+    offset = 1.0 * float(nx)*dx * tan(theta_rad)
+
+    # Print some values
+    print('nx   = ' + str(nx))
+    print('ny   = ' + str(ny))
+    print('nz   = ' + str(nz))
+    print('dt   = ' + str(dt))
+    print('tend = ' + str(tend))
+    print('rhoi = ' + str(rhoi))
+    print('grav = ' + str(grav))
+    print('thck = ' + str(thickness))
+    print('beta = ' + str(beta))
+    print('gn   = ' + str(gn))
+    print('mu_n = ' + str(mu_n))
+    print('flwa = ' + str(flwa))
+    print('eta  = ' + str(eta))
+    print('theta   = ' + str(theta))
+    print('offset  = ' + str(offset))
+
+    # Write some options and parameters to the config file
 
     config_parser.set('parameters', 'periodic_offset_ew', str(offset))
-    
+    config_parser.set('parameters', 'rhoi', str(rhoi))
+    config_parser.set('parameters', 'grav', str(grav))
+    config_parser.set('parameters', 'n_glen', str(gn))
+    config_parser.set('parameters', 'default_flwa', str(flwa))
+
+    if (args.approx == 'SIA'):
+        approx = 0
+    elif (args.approx == 'SSA'):
+        approx = 1
+    elif (args.approx == 'BP'):
+        approx = 2
+    elif (args.approx == 'L1L2'):
+        approx = 3
+    elif (args.approx == 'DIVA'):
+        approx = 4
+    config_parser.set('ho_options', 'which_ho_approx', str(approx))
+
     config_parser.set('CF input', 'name', file_name)
     config_parser.set('CF output', 'name', out_name)
     config_parser.set('CF output', 'xtype', 'double')
-    
+    config_parser.set('CF output', 'frequency', str(tend))    # write output at start and end of run
+
     with open(config_name, 'wb') as config_file:
         config_parser.write(config_file)
-
 
     # create the input netCDF file
     # ----------------------------
@@ -222,8 +346,8 @@ def main():
     nc_file.createDimension('x0',nx-1) # staggered grid 
     nc_file.createDimension('y0',ny-1)
 
-    x = dx*numpy.arange(nx,dtype='float32')
-    y = dx*numpy.arange(ny,dtype='float32')
+    x = dx*np.arange(nx,dtype='float32')
+    y = dx*np.arange(ny,dtype='float32')
 
     nc_file.createVariable('time','f',('time',))[:] = [0]
     nc_file.createVariable('x1','f',('x1',))[:] = x
@@ -231,19 +355,48 @@ def main():
     nc_file.createVariable('x0','f',('x0',))[:] = dx/2 + x[:-1] # staggered grid
     nc_file.createVariable('y0','f',('y0',))[:] = dy/2 + y[:-1]
 
-
     # Calculate values for the required variables.
-    thk  = numpy.zeros([1,ny,nx],dtype='float32')
-    topg = numpy.zeros([1,ny,nx],dtype='float32')
-    artm = numpy.zeros([1,ny,nx],dtype='float32')
-    unstagbeta = numpy.zeros([1,ny,nx],dtype='float32')
+    thk  = np.zeros([1,ny,nx],dtype='float32')
+    topg = np.zeros([1,ny,nx],dtype='float32')
+    artm = np.zeros([1,ny,nx],dtype='float32')
+    unstagbeta = np.zeros([1,ny,nx],dtype='float32')
 
     # Calculate the geometry of the slab of ice
-    thk[:] = thickness / cos(theta * pi/180.0)
+    # Note: Thickness is divided by cos(theta), since thck in CISM is the vertical distance
+    #       from bed to surface.  On a slanted bed, this is greater than the distance measured
+    #       in the direction perpendicular to the bed.
+    #      Why does topg use a tan function?  Is the bed slanted?
+    #      Do we need unstagbeta instead of beta?  Compare to ISMIP-HOM tests.
+
+    thk[:] = thickness / cos(theta_rad)
     xmax = x[:].max()
     for i in range(nx):
-        topg[0,:,i] = (xmax - x[i]) * tan(theta * pi/180.0) + baseElevation
+        topg[0,:,i] = (xmax - x[i]) * tan(theta_rad) + baseElevation
     unstagbeta[:] = beta
+
+    # Optionally, add a small perturbation to the thickness field
+
+    if args.delta_thck:
+        dh = float(args.delta_thck)
+        for i in range(nx):
+
+            # Apply a Gaussian perturbation, using the Box-Mueller algorithm:
+            # https://en.wikipedia.org/wiki/Normal_distribution#Generating_values_from_normal_distribution
+
+            mu = 0.0      # mean of normal distribution
+            sigma = 1.0   # stdev of normal distribution
+
+            rnd1 = np.random.random()   # two random numbers between 0 and 1
+            rnd2 = np.random.random()
+
+            # Either of the next two lines will sample a number at random from a normal distribution
+            rnd_normal = mu + sigma * sqrt(-2.0 * np.log(rnd1)) * cos(2.0*pi*rnd2)
+#            rnd_normal = mu + sigma * sqrt(-2.0 * np.log(rnd2)) * sin(2.0*pi*rnd1)
+
+            dthk = dh * rnd_normal
+            thk[0,:,i] = thk[0,:,i] + dthk
+            print(i, dthk, thk[0,ny/2,i])
+            thk_in = thk   # for comparing later to final thk
 
     # Create the required variables in the netCDF file.
     nc_file.createVariable('thk', 'f',('time','y1','x1'))[:] = thk
@@ -274,6 +427,8 @@ def main():
             print("\nRunning CISM slab test")
             print(  "======================\n")
 
+            print('command_list =' + str(command_list))
+
         process = subprocess.check_call(str.join("; ",command_list), shell=True)
    
         try:
@@ -289,6 +444,7 @@ def main():
         if not args.quiet: 
             print("\nFinished running the CISM slab test")
             print(  "===================================\n")
+
     else:
         run_script = args.output_dir+os.sep+root+mod+".run" 
         
@@ -304,7 +460,6 @@ def main():
             print(  "======================================")
             print(  "   To run the test, use: "+run_script)
 
-    print("WARNING: THIS TEST CASE IS IN DEVELOPMENT. USE AT YOUR OWN RISK!")
 
 # Run only if this is being run as a script.
 if __name__=='__main__':
@@ -314,4 +469,3 @@ if __name__=='__main__':
     
     # run the script
     sys.exit(main())
-

--- a/tests/slab/slab.config
+++ b/tests/slab/slab.config
@@ -1,30 +1,34 @@
 [grid]
-upn = 50
+upn = 20
 ewn = 30
-nsn = 20
+nsn = 5
 dew = 50
 dns = 50
 
 [time]
 tstart = 0.
 tend = 0.
-dt = 1.
+dt = 0.01
+dt_diag = 0.01
+idiag = 15
+jdiag = 5
 
 [options]
-dycore = 2              # 1 = glam, 2 = glissade
-flow_law = 0            # 0 = constant
+dycore = 2              # 2 = glissade
+flow_law = 0            # 0 = constant flwa (default = 1.e-16 Pa-n yr-1)
 evolution = 3           # 3 = remapping
-temperature = 1         # 1 = prognostic, 3 = enthalpy
+temperature = 1         # 1 = prognostic
+basal_mass_balance = 0  # 0 = basal mbal not in continuity eqn
 
 [ho_options]
 which_ho_babc = 5       # 5 = externally-supplied beta(required by test case)
-which_ho_efvs = 0       # 0 = constant (required by test case - makes n effectively 1)
-which_ho_sparse = 3     # 1 = SLAP GMRES, 3 = glissade parallel PCG, 4 = Trilinos for linear solver
+which_ho_sparse = 3     # 1 = SLAP GMRES, 3 = glissade parallel PCG
 which_ho_nonlinear = 0  # 0 = Picard, 1 = accelerated Picard
+which_ho_approx = 4     # 2 = BP, 3 = L1L2, 4 = DIVA
 
 [parameters]
 ice_limit = 1.          # min thickness (m) for dynamics
-periodic_offset_ew = 487.379544349
+geothermal = 0.
 
 [CF default]
 comment = created with slab.py

--- a/tests/slab/stabilitySlab.py
+++ b/tests/slab/stabilitySlab.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+"""
+This script runs a series of CISM experiments at different resolutions.
+At each resolution, it determines the maximum stable time step.
+A run is deemed to be stable if the standard deviation of a small thickness perturbation
+decreases during a transient run (100 timesteps by default).
+ 
+Used to obtain the CISM stability results described in:
+Robinson, A., D. Goldberg, and W. H. Lipscomb, A comparison of the performance
+of depth-integrated ice-dynamics solvers, to be submitted.
+"""
+
+# Authors
+# -------
+# Created by William Lipscomb, July 2021
+
+import os
+import sys
+import errno
+import subprocess
+import ConfigParser
+
+import numpy as np
+import netCDF
+from math import sqrt, log10
+
+# Parse the command line options                                                                                                                   
+# ------------------------------                                                                                                                   
+import argparse
+parser = argparse.ArgumentParser(description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+# small helper function so argparse will understand unsigned integers                                                                              
+def unsigned_int(x):
+    x = int(x)
+    if x < 1:
+        raise argparse.ArgumentTypeError("This argument is an unsigned int type! Should be an integer greater than zero.")
+    return x
+
+# The following command line arguments determine the set of resolutions to run the slab test.
+# At each resolution, we aim to find the maximum stable time step.
+# Note: If args.n_resolution > 1, then args.resolution (see below) is ignored.
+
+parser.add_argument('-nr','--n_resolution', default=1,
+        help="number of resolutions")
+parser.add_argument('-rmin','--min_resolution', default=10.0,
+        help="minimum resolution (m)")
+parser.add_argument('-rmax','--max_resolution', default=40000.0,
+        help="minimum resolution (m)")
+
+# The following command line arguments are the same as in runSlab.py.
+# Not sure how to avoid code repetition.
+
+parser.add_argument('-c','--config', default='./slab.config', 
+        help="The configure file used to setup the test case and run CISM")
+parser.add_argument('-e','--executable', default='./cism_driver', 
+        help="The CISM driver")
+parser.add_argument('-m', '--modifier', metavar='MOD', default='',
+        help="Add a modifier to file names. FILE.EX will become FILE.MOD.EX")
+parser.add_argument('-n','--parallel', metavar='N', type=unsigned_int, default=0, 
+        help="Run in parallel using N processors.")
+parser.add_argument('-o', '--output_dir',default='./output',
+        help="Write all created files here.")
+parser.add_argument('-a','--approx', default='BP',
+        help="Stokes approximation (SIA, SSA, BP, L1L2, DIVA)")
+parser.add_argument('-beta','--beta', default=2000.0,
+        help="Friction parameter beta (Pa (m/yr)^{-1})")
+parser.add_argument('-dh','--delta_thck', default=0.0,
+        help="Thickness perturbation (m)")
+parser.add_argument('-dt','--tstep', default=0.01,
+        help="Time step (yr)")
+parser.add_argument('-gn','--glen_exponent', default=1,
+        help="Exponent in Glen flow law")
+parser.add_argument('-l','--levels', default=10,
+        help="Number of vertical levels")
+parser.add_argument('-mu','--mu_n', default=0.0,
+        help="Viscosity parameter mu_n (Pa yr^{1/n})")
+parser.add_argument('-nt','--n_tsteps', default=0,
+        help="Number of timesteps")
+parser.add_argument('-nx','--nx_grid', default=50,
+       help="Number of grid cells in x direction")
+parser.add_argument('-ny','--ny_grid', default=5,
+        help="Number of grid cells in y direction")
+parser.add_argument('-r','--resolution', default=100.0,
+        help="Grid resolution (m)")
+parser.add_argument('-theta','--theta', default=5.0,
+        help="Slope angle (deg)")
+parser.add_argument('-thk','--thickness', default=1000.0,
+        help="Ice thickness")
+
+                        ############
+                        # Functions #
+                        ############
+
+def reading_file(inputFile):
+
+    #Check whether a netCDF file exists, and return a list of times in the file
+
+    ReadVarFile = True 
+    try:
+        filein = netCDF.NetCDFFile(inputFile,'r')
+        time = filein.variables['time'][:]
+        filein.close()
+        print('Was able to read file ' + inputFile)
+        print(time)
+    except:
+        ReadVarFile = False
+        time = [0.]
+        print('Was not able to read file' + inputFile)
+
+    return time, ReadVarFile
+
+
+def check_output_file(outputFile, time_end):
+
+    # Check that the output file exists with the expected final time slice
+
+    # Path to experiment
+    path_to_slab_output = './output/'
+
+    # File to check
+    filename = path_to_slab_output + outputFile
+
+    # Read the output file
+    print('Reading file ' + str(filename))
+    time_var, VarRead = reading_file(filename)
+
+#    print(time_var)
+
+    # Checking that the last time entry is the same as we expect from time_end
+    # Allow for a small roundoff difference.
+    if abs(time_var[-1] - time_end) < 1.0e-7:
+        check_time_var = True
+    else:
+        check_time_var = False
+
+    print('time_end = ' + str(time_end))
+    print('last time in file = ' + str(time_var[-1]))
+
+    # Creating the status of both checks 
+    check_passed = check_time_var and VarRead
+
+    if check_passed:
+        print('Found output file with expected file time slice')
+    else:
+        if (not VarRead):
+            print('Output file cannot be read')
+        else:
+            if not check_time_var:
+                print('Output file is missing time slices')
+    
+    return check_passed
+
+
+def main():
+
+    print('In main')
+
+    """
+    For each of several values of the horizontal grid resolution, determine the maximum
+    stable time step for a given configuration of the slab test.
+    """
+
+    resolution = []
+
+    # Based on the input arguments, make a list of resolutions at which to run the test.
+    # The formula and the default values of rmin and rmax give resolutions agreeing with
+    #  those used by Alex Robinson for Yelmo, for the case nres = 12:
+    #  resolution = [10., 21., 45., 96., 204., 434., 922., 1960., 4170., 8850., 18800., 40000.]
+
+    print('Computing resolutions')
+    print(args.n_resolution)
+    if int(args.n_resolution) > 1:
+        nres = int(args.n_resolution)
+        resolution = [0. for n in range(nres)]
+        rmin = float(args.min_resolution)
+        rmax = float(args.max_resolution)
+        for n in range(nres):
+            res = 10.0**(log10(rmin) + (log10(rmax) - log10(rmin))*float(n)/float(nres-1))
+            # Round to 3 significant figures (works for log10(res) < 5)
+            if log10(res) > 4.:
+                resolution[n] = round(res, -2)
+            elif log10(res) > 3.:
+                resolution[n] = round(res, -1)
+            else:
+                resolution[n] = round(res)
+    else:
+        nres = 1
+        resolution.append(float(args.resolution))
+
+    print('nres = ' + str(nres))
+    print(resolution)
+
+    # Create an array to store max time step for each resolution
+    rows, cols = (nres, 2)
+    res_tstep = [[0. for i in range(cols)] for j in range(rows)]
+    for n in range(nres):
+        res_tstep[n][0] = resolution[n]
+
+    for n in range(nres):
+
+        print('output_dir: ' + args.output_dir)
+
+        # Construct the command for calling the main runSlab script
+        run_command = 'python runSlab.py'
+        run_command = run_command + ' -c '  + args.config
+        run_command = run_command + ' -e '  + args.executable
+        if args.parallel > 0:
+            run_command = run_command + ' -n '  + str(args.parallel)
+        run_command = run_command + ' -o '  + args.output_dir
+        run_command = run_command + ' -a '  + args.approx
+        run_command = run_command + ' -beta ' + str(args.beta)
+        run_command = run_command + ' -dh ' + str(args.delta_thck)
+        run_command = run_command + ' -gn ' + str(args.glen_exponent)
+        run_command = run_command + ' -l '  + str(args.levels)
+        run_command = run_command + ' -mu ' + str(args.mu_n)
+        run_command = run_command + ' -nt ' + str(args.n_tsteps)
+        run_command = run_command + ' -nx ' + str(args.nx_grid)
+        run_command = run_command + ' -ny ' + str(args.ny_grid)
+        run_command = run_command + ' -theta '+ str(args.theta)
+        run_command = run_command + ' -thk '+ str(args.thickness)
+
+        tend = float(args.n_tsteps) * args.tstep
+
+        res = resolution[n]
+        run_command = run_command + ' -r '  + str(res)
+         
+        # Choose the time step.
+        # Start by choosing a very small timestep that can be assumed stable
+        #  and a large step that can be assumed unstable.
+        # Note: SIA-type solvers at 10m resolution can require dt <~ 1.e-6 yr.
+
+        tstep_lo = 1.0e-7
+        tstep_hi = 1.0e+5
+        tstep_log_precision = 1.0e-4
+        print('Initial tstep_lo = ' + str(tstep_lo))
+        print('Initial tstep_hi = ' + str(tstep_hi))
+        print('Log precision = ' + str(tstep_log_precision))
+
+        while (log10(tstep_hi) - log10(tstep_lo)) > tstep_log_precision:
+
+            # Compute the time step as the geometric mean of the tstep_lo and tstep_hi.
+            # tstep_lo is the largest time step known to be stable.
+            # tstep_hi is the smallest time step known to be unstable.
+
+            tstep = sqrt(tstep_lo*tstep_hi)
+    
+            run_command_full = run_command + ' -dt ' + str(tstep)
+
+            print("\nRunning CISM slab test...")
+            print('resolution = ' + str(res))
+            print('tstep = ' + str(tstep))
+            print('run_command = ' + run_command_full)
+
+            process = subprocess.check_call(run_command_full, shell=True)
+
+            print("\nFinished running the CISM slab test")
+
+            # Determine the name of the output file.
+            # Must agree with naming conventions in runSlab.py
+
+            file_name = args.config
+            root, ext = os.path.splitext(file_name)
+
+            res=str(int(res)).zfill(5)  # 00100 for 100m, 01000 for 1000m, etc.
+
+            if args.parallel > 0:
+                mod = args.modifier + '.' + res + '.p' + str(args.parallel).zfill(3)
+            else:
+                mod = args.modifier + '.' + res
+
+            outputFile = root + mod + '.out.nc'
+
+            # Check whether the output file exists with the desired final time slice.
+
+            time_end = float(args.n_tsteps) * tstep
+
+            print('outputFile = ' + str(outputFile))
+            print('n_tsteps = ' + str(float(args.n_tsteps)))
+            print('tstep = ' + str(tstep))
+            print('time_end = ' + str(time_end))
+
+            check_passed = check_output_file(outputFile, time_end)
+
+            if check_passed:
+
+                print('Compute stdev of initial and final thickness for j = ny/2')
+                nx = int(args.nx_grid)
+                ny = int(args.ny_grid)
+
+                # Read initial and final thickness from output file
+                outpath = os.path.join(args.output_dir, outputFile)
+                print('outpath = ' + outpath)
+                filein = netCDF.NetCDFFile(outpath,'r')
+                thk = filein.variables['thk'][:]
+
+                j = ny/2
+                thk_in = thk[0,j,:]
+                thk_out = thk[1,j,:]
+
+                # Compute <H>
+                Hav_in = 0.0
+                Hav_out = 0.0
+                for i in range(nx):
+                    Hav_in = Hav_in + thk_in[i]
+                    Hav_out = Hav_out + thk_out[i]
+                Hav_in = Hav_in / nx
+                Hav_out = Hav_out / nx
+
+                # Compute <H^2>
+                H2av_in = 0.0
+                H2av_out = 0.0
+                for i in range(nx):
+                    H2av_in = H2av_in + thk_in[i]**2
+                    H2av_out = H2av_out + thk_out[i]**2
+                H2av_in = H2av_in / nx
+                H2av_out = H2av_out / nx
+
+                print('H2av_out =' + str(H2av_out))
+                print('Hav_out^2 =' + str(Hav_out**2))
+
+                # Compute stdev = sqrt(<H^2> - <H>^2)
+                var_in  = H2av_in  - Hav_in**2
+                var_out = H2av_out - Hav_out**2
+
+                if var_in > 0.:
+                    stdev_in = sqrt(H2av_in - Hav_in**2)
+                else:
+                    stdev_in = 0.
+
+                if var_out > 0.:
+                    stdev_out = sqrt(H2av_out - Hav_out**2)
+                else:
+                    stdev_out = 0.
+
+                if stdev_in > 0.:
+                    ratio = stdev_out/stdev_in
+                else:
+                    ratio = 0.
+
+                print('stdev_in  = ' + str(stdev_in))
+                print('stdev_out = ' + str(stdev_out))
+                print('ratio = ' + str(ratio))
+
+                # Determine whether the run was stable.
+                # A run is defined to be stable if the final standard deviation of thickness
+                #  is less than the initial standard deviation
+
+                if ratio < 1.:
+                    tstep_lo = max(tstep_lo, tstep)
+                    print('Stable, new tstep_lo =' + str(tstep_lo))
+                else:
+                    tstep_hi = min(tstep_hi, tstep)
+                    print('Unstable, new tstep_hi =' + str(tstep_hi))
+
+            else:   # check_passed = F; not stable
+                tstep_hi = min(tstep_hi, tstep)
+                print('Unstable, new tstep_hi =' + str(tstep_hi))
+
+            print('Latest tstep_lo = ' + str(tstep_lo))
+            print('Latest tstep_hi = ' + str(tstep_hi))
+
+            # Add to the array containing the max stable timestep at each resolution.
+            # Take the max stable timestep to be the average of tstep_lo and tstep_hi.
+            res_tstep[n][1] = 0.5 * (tstep_lo + tstep_hi)
+
+            print('New res_tstep, res #' + str(n))
+            print(res_tstep)
+
+    # Print a table containing the max timestep for each resolution
+    for n in range(nres):
+        float_res = res_tstep[n][0]
+        float_dt  = res_tstep[n][1]
+        formatted_float_res = "{:8.1f}".format(float_res)
+        formatted_float_dt =  "{:.3e}".format(float_dt)  # exponential notation with 3 decimal places
+        print(formatted_float_res + '    ' + formatted_float_dt)
+
+# Run only if this is being run as a script.                                                                                                       
+if __name__=='__main__':
+
+    # get the command line arguments                                                                                                               
+    args = parser.parse_args()
+
+    # run the script
+    sys.exit(main())


### PR DESCRIPTION
These commits add a steady-state flux routing hydrology scheme.  It routes basal water conservatively down the hydraulic gradient from source cells (where bmlt > 0) to the ice sheet boundary.  It is fully parallel, adapted from a similar serial scheme that was written some years ago for Glimmer.  By conserving basal water and allowing the water to flow through cells with basal temperature below the pressure melting point, this scheme improves on the current local till model used in many Greenland simulations.  To use the new scheme with Glissade, the user sets which_ho_bwat = 3 = HO_BWAT_FLUX_ROUTING in the config file.  The driver is subroutine glissade_bwat_flux_routing, in module glissade_basal_water.F90.

The main computational difficulties arise from interior depressions that can be sinks for meltwater.  These regions are handled using the algorithm of Planchon and Darboux (2001).  In depressions, the value of the hydraulic potential is raised just enough to give every cell a downhill route to the ice sheet boundary, and no farther.  This algorithm parallelizes fairly efficiently.

The scheme computes the steady-state water flux through each cell.  Given this flux and an expression for water velocity, it is easy to compute basal water depth.  However, these depths are small (~ 1 mm or less).  It is unclear whether effective pressure should depend on the flux or the nominal depth.

From a given cell, water can be routed downhill to one down-gradient neighbor, two neighbors, or up to eight neighbors depending on the value of ho_flux_routing_scheme, a new config option.  More testing is needed to determine which routing scheme is most realistic.

The scheme has been tested by Sarah Bradley and colleagues in LGM runs with a North American Ice Sheet, and shown to give rise to ice streams where none were present before.  It will next be tested for Greenland and Antarctica.    

Answers are BFB, apart from runs that use the new hydrology scheme
