### PR TITLE
reduce debug output in production mode

### DIFF
--- a/libglimmer-solve/SLAP/xersla.f
+++ b/libglimmer-solve/SLAP/xersla.f
@@ -29,7 +29,8 @@ c                 handling package', sand82-0800, sandia laboratories,
 c                 1982.
 c***routines called  (none)
 c***end prologue  xerabt
-      dimension messg(nmessg)
+c      dimension messg(nmessg)
+      character *(*) messg
 c***first executable statement  xerabt
       stop 1
       end
@@ -397,8 +398,11 @@ c           print number of other errors
    60    continue
          if (nmessg.lt.0) return
 c        clear the error tables
-         do 70 i=1,10
-   70       kount(i) = 0
+c         do 70 i=1,10
+c   70       kount(i) = 0
+         do i=1,10
+            kount(i) = 0
+         enddo
          kountx = 0
          return
    80 continue

--- a/libglimmer/glimmer_log.F90
+++ b/libglimmer/glimmer_log.F90
@@ -170,10 +170,11 @@ contains
     ! and maybe to std out
     ! Note: Messages are written only from the main task, unless the error is fatal.
     !       For fatal errors, a message is also written from the task where the error occurred.
+#ifdef DEBUG
     if (local_type /= 0) then
        if ( (main_task .and. gm_show(local_type)) .or. local_type == GM_FATAL) write(*,*) trim(msg)
     end if
-
+#endif
     ! stop logging if we encountered a fatal error
     if (local_type == GM_FATAL) then
        write(*,*) "Exiting with fatal error: this_rank =", this_rank
@@ -252,7 +253,7 @@ contains
     if (present(unit)) then
        glimmer_unit = unit
     end if
-
+    
     call date_and_time(date,time)
     call write_log_div
     if (main_task) write(unit=glimmer_unit,fmt="(a,a4,'-',a2,'-',a2,' ',a2,':',a2,':',a6)") &

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -167,9 +167,9 @@ contains
     real(dp), dimension(:,:), allocatable :: topg_global, topg_stdev_global
     integer, parameter :: grid_ratio = 8   ! ratio between no. of grid cells on the input grid and
                                            ! the grid on which we want to compute topg_stdev; typically 2, 4, or 8
-
+#ifdef DEBUG
     if (main_task) print*, 'In glissade_initialise'
-
+#endif
     if (present(evolve_ice)) then
        l_evolve_ice = evolve_ice
     else
@@ -868,6 +868,7 @@ contains
        endif
 
        !WHL - debug
+#ifdef DEBUG
        if (this_rank == rtest) then
           i = itest
           j = jtest
@@ -889,7 +890,7 @@ contains
              write(6,*) ' '
           enddo
        endif
-
+#endif
     endif   ! force_retreat
 
     !TODO - Move to an init_calving subroutine
@@ -1011,9 +1012,9 @@ contains
     deallocate(floating_mask)
     deallocate(land_mask)
     deallocate(ocean_mask)
-
+#ifdef DEBUG
     if (main_task) print*, 'Done in glissade_initialise'
-
+#endif
   end subroutine glissade_initialise
   
 !=======================================================================

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -200,8 +200,8 @@
 !    logical :: verbose = .true.  
     logical :: verbose_init = .false.   
 !    logical :: verbose_init = .true.   
-!    logical :: verbose_solver = .false.
-    logical :: verbose_solver = .true.
+    logical :: verbose_solver = .false.
+!    logical :: verbose_solver = .true.
     logical :: verbose_Jac = .false.
 !    logical :: verbose_Jac = .true.
     logical :: verbose_residual = .false.
@@ -3573,7 +3573,7 @@
                 write(6,*) ' '
              enddo
 
-          else	 ! 3D velocity solve
+          else   ! 3D velocity solve
 
              print*, ' '
              print*, 'Basal uvel field, itest, jtest, rank =', itest, jtest, rtest
@@ -3995,7 +3995,7 @@
        if (whichsparse /= HO_SPARSE_TRILINOS) then
           ! niters isn't set when using the trilinos solver
           if (main_task .and. verbose_solver) then
-             print*, 'Solved the linear system, niters, err =', niters, err
+             print*,'Solved the linear system, niters, err =', niters, err
           endif
        end if
 


### PR DESCRIPTION
Trying to reduce the amount of output written to cesm.log.
CISM is a primary culprit here and there is much more to be done.

I also provide a change again in file SLAP/xersla.f needed for compatibility with cray compiler. 