### PR TITLE
Removed redundant 'use' statements that slowed the Intel build

### DIFF
--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -39,8 +39,15 @@ module NAME_io
   ! template for creating subsystem specific I/O routines
   ! written by Magnus Hagdorn, 2004
 
+  !WHL, Sept. 2023
+  ! Moved some 'use' statements to the top to avoid redundant statements that slow the build,
+  ! particularly on the Intel compiler
+
   use DATAMOD
   use glimmer_ncdf
+  use glimmer_paramets
+  use glimmer_physcon
+  use glimmer_scales
 
   implicit none
 
@@ -69,8 +76,6 @@ contains
   !*****************************************************************************
   subroutine NAME_io_createall(model,data,outfiles)
     ! open all netCDF files for output
-    use DATAMOD
-    use glide_types
     use glimmer_ncio
     implicit none
     type(glide_global_type) :: model
@@ -94,8 +99,6 @@ contains
 
   subroutine NAME_io_writeall(data,model,atend,outfiles,time)
     ! if necessary write to netCDF files
-    use DATAMOD
-    use glide_types
     use glimmer_ncio
     implicit none
     type(DATATYPE) :: data
@@ -142,14 +145,9 @@ contains
 
     use cism_parallel, only: parallel_type, &
          parallel_def_dim, parallel_inq_dimid, parallel_def_var, parallel_inq_varid, parallel_put_att
-    use glide_types
-    use DATAMOD
     use glimmer_ncio
     use glimmer_map_types
     use glimmer_log
-    use glimmer_paramets
-    use glimmer_physcon
-    use glimmer_scales
     implicit none
     type(glimmer_nc_output), pointer :: outfile
     type(glide_global_type) :: model
@@ -238,10 +236,6 @@ contains
   subroutine NAME_io_write(outfile,data)
 
     use cism_parallel, only: parallel_type, parallel_inq_varid, distributed_put_var, parallel_put_var
-    use DATAMOD
-    use glimmer_paramets
-    use glimmer_physcon
-    use glimmer_scales
     implicit none
     type(glimmer_nc_output), pointer :: outfile
     ! structure containg output netCDF descriptor
@@ -387,8 +381,6 @@ contains
   !*****************************************************************************  
   subroutine NAME_io_readall(data, model, filetype)
     ! read from netCDF file
-    use DATAMOD
-    use glide_types
     use glimmer_ncio
     implicit none
     type(DATATYPE) :: data
@@ -425,7 +417,6 @@ contains
 
     ! Read data from forcing files
     use glimmer_log
-    use glide_types
     use cism_parallel, only: main_task
 
     implicit none
@@ -520,9 +511,6 @@ contains
     use cism_parallel, only: parallel_type, &
          parallel_inq_varid, parallel_get_att, distributed_get_var, parallel_get_var
     use glimmer_log
-    use DATAMOD
-    use glimmer_paramets
-    use glimmer_scales
     implicit none
     type(glimmer_nc_input), pointer :: infile
     ! structure containg output netCDF descriptor
@@ -547,8 +535,6 @@ contains
     ! check if dimension sizes in file match dims of model
     use cism_parallel, only: parallel_type, parallel_inq_dimid, parallel_inquire_dimension
     use glimmer_log
-    use glide_types
-    use DATAMOD
     implicit none
     type(glimmer_nc_input), pointer :: infile
     ! structure containg output netCDF descriptor
@@ -575,8 +561,6 @@ contains
     ! TODO: Write code to check for doubly listed tavg variables and throw a fatal error.
 
     use cism_parallel, only: parallel_inq_varid
-    use glide_types
-    use DATAMOD
     implicit none
     type(glimmer_nc_output), pointer :: outfile
     ! structure containg output netCDF descriptor
@@ -597,7 +581,6 @@ contains
   subroutine NAME_avg_reset(outfile,data)
 
     use cism_parallel, only: parallel_inq_varid
-    use DATAMOD
     implicit none
     type(glimmer_nc_output), pointer :: outfile
     ! structure containg output netCDF descriptor

--- a/utils/build/generate_ncvars.py
+++ b/utils/build/generate_ncvars.py
@@ -614,10 +614,6 @@ class PrintNC_template(PrintVars):
         if not is_dimvar(var) and dimlen<3 and AVERAGE_SUFFIX not in var['name']:
             # get
             self.stream.write("  subroutine %s_get_%s(data,outarray)\n"%(module['name'],var['name']))
-            self.stream.write("    use glimmer_scales\n")
-            self.stream.write("    use glimmer_paramets\n")
-            self.stream.write("    use glimmer_physcon\n")
-            self.stream.write("    use %s\n"%module['datamod'])
             self.stream.write("    implicit none\n")
             self.stream.write("    type(%s) :: data\n"%module['datatype'])
             if var['type'] == 'int':
@@ -639,10 +635,6 @@ class PrintNC_template(PrintVars):
             # only creating set routine if the variable is not derived
             if len(var['data'].split('data'))<3:
                 self.stream.write("  subroutine %s_set_%s(data,inarray)\n"%(module['name'],var['name']))
-                self.stream.write("    use glimmer_scales\n")
-                self.stream.write("    use glimmer_paramets\n")
-                self.stream.write("    use glimmer_physcon\n")
-                self.stream.write("    use %s\n"%module['datamod'])
                 self.stream.write("    implicit none\n")
                 self.stream.write("    type(%s) :: data\n"%module['datatype'])
                 if var['type'] == 'int':


### PR DESCRIPTION
Bill Lipscomb says: "The Intel compiler has been taking a long time to build glide_io.F90. Some testing showed that this is because 'use glide_types' and three other use statements were repeated in each of a large number of accessor subroutines. For some reason, this hasn't been an issue on the Gnu compiler.

I modified ../utils/generate_ncvars.py and ../libglimmer/ncdf_template.in so that these 'use' statements appear only at the top of the glide_io module.

With this change, the Intel build time on derecho with 8 cores ('make -j 8') decreases from about 4:40 to 1:10, a welcome improvement."