### PR TITLE
Development to support the slab test

### DIFF
--- a/libglide/felix_dycore_interface.F90
+++ b/libglide/felix_dycore_interface.F90
@@ -146,7 +146,7 @@ contains
    subroutine felix_velo_driver(model)
 
       use glimmer_global, only : dp
-      use glimmer_physcon, only: gn, scyr
+      use glimmer_physcon, only: scyr
       use glimmer_paramets, only: thk0, len0, vel0, vis0
       use glimmer_log
       use glide_types

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -160,7 +160,7 @@ contains
   subroutine glide_scale_params(model)
     !> scale parameters
     use glide_types
-    use glimmer_physcon,  only: scyr, gn
+    use glimmer_physcon,  only: scyr
     use glimmer_paramets, only: thk0, tim0, len0, vel0, vis0, acc0, tau0
 
     implicit none
@@ -1996,7 +1996,7 @@ contains
     use glimmer_config
     use glide_types
     use glimmer_log
-    use glimmer_physcon, only: rhoi, rhoo, grav, shci, lhci, trpt
+    use glimmer_physcon, only: rhoi, rhoo, grav, shci, lhci, trpt, n_glen
 
     implicit none
     type(ConfigSection), pointer :: section
@@ -2021,6 +2021,7 @@ contains
     call GetValue(section,'lhci', lhci)
     call GetValue(section,'trpt', trpt)
 #endif
+    call GetValue(section,'n_glen', n_glen)
 
     loglevel = GM_levels-GM_ERROR
     call GetValue(section,'log_level',loglevel)
@@ -2206,7 +2207,7 @@ contains
 
   subroutine print_parameters(model)
 
-    use glimmer_physcon, only: rhoi, rhoo, lhci, shci, trpt, grav
+    use glimmer_physcon, only: rhoi, rhoo, lhci, shci, trpt, grav, n_glen
     use glide_types
     use glimmer_log
     implicit none
@@ -2369,6 +2370,9 @@ contains
     call write_log(message)
 
     write(message,*) 'triple point of water (K)     : ', trpt
+    call write_log(message)
+
+    write(message,*) 'Glen flow law exponent        : ', n_glen
     call write_log(message)
 
     write(message,*) 'geothermal flux  (W/m^2)      : ', model%paramets%geot

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -1093,13 +1093,14 @@ contains
          'Native PCG solver, Chronopoulos-Gear       ', &
          'Trilinos interface                         '/)
 
-    character(len=*), dimension(-1:4), parameter :: ho_whichapprox = (/ &
+    character(len=*), dimension(-1:5), parameter :: ho_whichapprox = (/ &
          'SIA only (glissade_velo_sia)                     ', &
          'SIA only (glissade_velo_higher)                  ', &
          'SSA only (glissade_velo_higher)                  ', &
          'Blatter-Pattyn HO (glissade_velo_higher)         ', &
          'Depth-integrated L1L2 (glissade_velo_higher)     ', &
-         'Depth-integrated viscosity (glissade_velo_higher)' /)
+         'Depth-integrated viscosity (glissade_velo_higher)', &
+         'Hybrid SIA/SSA                                   ' /)
 
     character(len=*), dimension(0:4), parameter :: ho_whichprecond = (/ &
          'No preconditioner (native PCG)                ', &
@@ -1242,7 +1243,8 @@ contains
 
        if ( (model%options%which_ho_approx == HO_APPROX_SSA  .or.  &
              model%options%which_ho_approx == HO_APPROX_L1L2 .or.  &
-             model%options%which_ho_approx == HO_APPROX_DIVA)   &
+             model%options%which_ho_approx == HO_APPROX_DIVA .or.  &
+             model%options%which_ho_approx == HO_APPROX_HYBRID)    &
                                 .and.                            &
              (model%options%which_ho_sparse == HO_SPARSE_PCG_STANDARD .or.    &
               model%options%which_ho_sparse == HO_SPARSE_PCG_CHRONGEAR) ) then

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -883,11 +883,10 @@ contains
          'advective-diffusive balance ',&
          'temp from external file     ' /)
 
-    character(len=*), dimension(0:3), parameter :: flow_law = (/ &
-         'const 1e-16 Pa^-n a^-1      ', &
+    character(len=*), dimension(0:2), parameter :: flow_law = (/ &
+         'uniform factor flwa         ', &
          'Paterson and Budd (T = -5 C)', &
-         'Paterson and Budd           ', &
-         'read flwa/flwastag from file' /)
+         'Paterson and Budd           ' /)
 
     !TODO - Rename slip_coeff to which_btrc?
     character(len=*), dimension(0:5), parameter :: slip_coeff = (/ &
@@ -2034,9 +2033,9 @@ contains
     call GetValue(section,'pmp_offset',         model%temper%pmp_offset)
     call GetValue(section,'pmp_threshold',      model%temper%pmp_threshold)
     call GetValue(section,'geothermal',         model%paramets%geot)
-    !TODO - Change default_flwa to flwa_constant?  Would have to change config files.
     call GetValue(section,'flow_factor',        model%paramets%flow_enhancement_factor)
     call GetValue(section,'flow_factor_float',  model%paramets%flow_enhancement_factor_float)
+    !TODO - Change default_flwa to flwa_constant?  Would have to change config files.
     call GetValue(section,'default_flwa',       model%paramets%default_flwa)
     call GetValue(section,'efvs_constant',      model%paramets%efvs_constant)
     call GetValue(section,'effstrain_min',      model%paramets%effstrain_min)

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -104,7 +104,6 @@ module glide_types
   integer, parameter :: FLWA_CONST_FLWA = 0
   integer, parameter :: FLWA_PATERSON_BUDD_CONST_TEMP = 1
   integer, parameter :: FLWA_PATERSON_BUDD = 2
-  integer, parameter :: FLWA_INPUT = 3
 
   integer, parameter :: BTRC_ZERO = 0
   integer, parameter :: BTRC_CONSTANT = 1
@@ -470,7 +469,6 @@ module glide_types
     !> \item[1] \emph{Paterson and Budd} relationship, 
     !> with temperature set to $-5^{\circ}\mathrm{C}$ 
     !> \item[2] \emph{Paterson and Budd} relationship
-    !> \item[3] Read flwa/flwastag from file
     !> \end{description}
 
     integer :: whichbtrc = 0
@@ -2148,6 +2146,7 @@ module glide_types
   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
   !TODO - Move these parameters to types associated with a certain kind of physics
+  !TODO - Set default geot = 0, so that idealized tests by default have no mass loss
   type glide_paramets
     real(dp),dimension(5) :: bpar = (/ 0.2d0, 0.5d0, 0.0d0 ,1.0d-2, 1.0d0/)
     real(dp) :: btrac_const = 0.d0     ! m yr^{-1} Pa^{-1} (gets scaled during init)

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -313,6 +313,7 @@ module glide_types
   integer, parameter :: HO_APPROX_BP = 2
   integer, parameter :: HO_APPROX_L1L2 = 3
   integer, parameter :: HO_APPROX_DIVA = 4
+  integer, parameter :: HO_APPROX_HYBRID = 5
 
   integer, parameter :: HO_PRECOND_NONE = 0
   integer, parameter :: HO_PRECOND_DIAG = 1
@@ -776,7 +777,7 @@ module glide_types
 
     !> Flag that describes basal boundary condition for HO dyn core: 
     !> \begin{description}
-    !> \item[0] spatially uniform value (low value of 10 Pa/yr by default)
+    !> \item[0] spatially uniform value; low value of 10 Pa/(m/yr) by default
     !> \item[1] large value for frozen bed, lower value for bed at pressure melting point
     !> \item[2] treat beta value as a till yield stress (in Pa) using Picard iteration 
     !> \item[3] pseudo-plastic basal sliding law; can model linear, power-law or plastic behavior
@@ -893,6 +894,7 @@ module glide_types
     !> Flag that indicates which Stokes approximation to use with the glissade dycore.
     !> Not valid for other dycores 
     !> Compute Blatter-Pattyn HO momentum balance by default.
+    !> TODO: Change the default to DIVA
     !> Note: There are two SIA options:
     !>       Option -1 uses module glissade_velo_sia to compute local SIA velocities, similar to Glide
     !>       Option 0 uses module glissade_velo_higher to compute SIA velocities via an iterative solve
@@ -902,7 +904,8 @@ module glide_types
     !> \item[1]  Shallow-shelf approximation, horizontal-plane stresses only; uses glissade_velo_higher
     !> \item[2]  Blatter-Pattyn approximation with both vertical-shear and horizontal-plane stresses; uses glissade_velo_higher
     !> \item[3]  Vertically integrated 'L1L2' approximation with vertical-shear and horizontal-plane stresses; uses glissade_velo_higher
-    !> \item[4]  Depth-integrated viscosity approximation based on Goldberg (2011); uses glissade_velo_higher 
+    !> \item[4]  Depth-integrated viscosity approximation (DIVA) based on Goldberg (2011); uses glissade_velo_higher
+    !> \item[5]  Hybrid solver combining an SSA basal solve with a local vertical SIA solve
     !> \end{description}
 
     integer :: which_ho_precond = 2    

--- a/libglimmer/glimmer_paramets.F90
+++ b/libglimmer/glimmer_paramets.F90
@@ -33,7 +33,7 @@
 module glimmer_paramets
 
   use glimmer_global, only : dp
-  use glimmer_physcon, only : scyr, gn
+  use glimmer_physcon, only : scyr
 
   implicit none
   save
@@ -118,6 +118,7 @@ module glimmer_paramets
   real(dp), parameter :: grav_glam = 9.81d0           ! m s^{-2}
 
   ! GLAM scaling parameters; units are correct if thk0 has units of meters
+  integer, parameter :: gn = 3                              ! Glen flow exponent; fixed at 3 for purposes of setting vis0
   real(dp), parameter :: tau0 = rhoi_glam*grav_glam*thk0    ! stress scale in GLAM ( Pa )  
   real(dp), parameter :: evs0 = tau0 / (vel0/len0)          ! eff. visc. scale in GLAM ( Pa s )
   real(dp), parameter :: vis0 = tau0**(-gn) * (vel0/len0)   ! rate factor scale in GLAM ( Pa^-3 s^-1 )

--- a/libglimmer/glimmer_physcon.F90
+++ b/libglimmer/glimmer_physcon.F90
@@ -79,11 +79,17 @@ module glimmer_physcon
 !  real(dp) :: trpt = 273.16d0                     !< Triple point of water (K)
 #endif
 
+  ! The Glen flow-law exponent, n_glen, is used in Glissade.
+  ! It is not a parameter, because the default can be overridden in the config file.
+  ! TODO: Allow setting n_glen independently for each ice sheet instance?
+  ! Note: Earlier code used an integer parameter, gn = 3, for all flow-law calculations.
+  !       For backward compatiblity, gn = 3 is retained for Glide.
+  real(dp) :: n_glen = 3.0d0                     !< Exponent in Glen's flow law; user-configurable real(dp) in Glissade
+  integer, parameter :: gn = 3                   !< Exponent in Glen's flow law; fixed integer parameter in Glide
   real(dp),parameter :: celsius_to_kelvin = 273.15d0  !< Note: Not quite equal to trpt
   real(dp),parameter :: scyr = 31536000.d0       !< Number of seconds in a year of exactly 365 days
   real(dp),parameter :: rhom = 3300.0d0          !< The density of magma(?) (kg m<SUP>-3</SUP>) 
   real(dp),parameter :: rhos = 2600.0d0          !< The density of solid till (kg m$^{-3}$) 
-  integer, parameter :: gn = 3                   !< The power dependency of Glen's flow law.
   real(dp),parameter :: actenh = 139.0d3         !< Activation energy in Glen's flow law for \f$T^{*}\geq263\f$K. (J mol<SUP>-1</SUP>)
   real(dp),parameter :: actenl = 60.0d3          !< Activation energy in Glen's flow law for \f$T^{*}<263\f$K. (J mol<SUP>-1</SUP>)  
   real(dp),parameter :: arrmlh = 1.733d3         !< Constant of proportionality in Arrhenius relation

--- a/libglimmer/glimmer_scales.F90
+++ b/libglimmer/glimmer_scales.F90
@@ -45,7 +45,7 @@ contains
 
     ! set scale factors for I/O (can't have non-integer powers)
 
-    use glimmer_physcon, only : scyr, gn
+    use glimmer_physcon, only : scyr
     use glimmer_paramets, only : thk0, tim0, vel0, vis0, len0, acc0, tau0, evs0
     implicit none
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -456,7 +456,11 @@ contains
     ! handle relaxed/equilibrium topo
     ! Initialise isostasy first
 
-    call init_isostasy(model)
+    if (model%options%isostasy == ISOSTASY_COMPUTE) then
+
+       call init_isostasy(model)
+
+    endif
 
     select case(model%isostasy%whichrelaxed)
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1893,7 +1893,7 @@ contains
                                 model%temper%btemp_ground,                                    & ! deg C
                                 model%temper%btemp_float,                                     & ! deg C
                                 bmlt_ground_unscaled)                                           ! m/s
-                                     
+
     ! Update basal hydrology, if needed
     ! Note: glissade_calcbwat uses SI units
 
@@ -1971,6 +1971,7 @@ contains
     use glissade_bmlt_float, only: verbose_bmlt_float
     use glissade_calving, only: verbose_calving
     use glissade_grid_operators, only: glissade_vertical_interpolate
+    use glide_stop, only: glide_finalise
 
     implicit none
 
@@ -2159,21 +2160,25 @@ contains
                                model%geomderv%dusrfdew*thk0/len0, model%geomderv%dusrfdns*thk0/len0,           &
                                model%velocity%uvel * scyr * vel0, model%velocity%vvel * scyr * vel0,           &
                                model%numerics%dt_transport * tim0 / scyr,                                      &
+                               model%numerics%adaptive_cfl_threshold,                                          &
                                model%numerics%adv_cfl_dt,         model%numerics%diff_cfl_dt)
 
        ! Set the transport timestep.
        ! The timestep is model%numerics%dt by default, but optionally can be reduced for subcycling
 
+       !WHL - debug
+!      if (main_task) then
+!         print*, 'Checked advective CFL threshold'
+!         print*, 'model dt (yr) =', model%numerics%dt * tim0/scyr
+!         print*, 'adv_cfl_dt    =', model%numerics%adv_cfl_dt
+!      endif
+
+       advective_cfl = model%numerics%dt*(tim0/scyr) / model%numerics%adv_cfl_dt
+
        if (model%numerics%adaptive_cfl_threshold > 0.0d0) then
 
-          !WHL - debug
-!          if (main_task) then
-!             print*, 'Check advective CFL threshold'
-!             print*, 'model dt (yr) =', model%numerics%dt * tim0/scyr
-!             print*, 'adv_cfl_dt    =', model%numerics%adv_cfl_dt
-!          endif
+          ! subcycle the transport when advective_cfl exceeds the threshold
 
-          advective_cfl = model%numerics%dt*(tim0/scyr) / model%numerics%adv_cfl_dt
           if (advective_cfl > model%numerics%adaptive_cfl_threshold) then
 
              ! compute the number of subcycles
@@ -2186,14 +2191,29 @@ contains
                 print*, 'Ratio =', advective_cfl / model%numerics%adaptive_cfl_threshold
                 print*, 'nsubcyc =', nsubcyc
              endif
+
           else
              nsubcyc = 1
           endif
           dt_transport = model%numerics%dt * tim0 / real(nsubcyc,dp)   ! convert to s
 
        else  ! no adaptive subcycling
-          nsubcyc = model%numerics%subcyc
-          dt_transport = model%numerics%dt_transport * tim0  ! convert to s
+
+          advective_cfl = model%numerics%dt*(tim0/scyr) / model%numerics%adv_cfl_dt
+
+          ! If advective_cfl exceeds 1.0, then abort cleanly.  Otherwise, set dt_transport and proceed.
+          ! Note: Usually, it would be enough to write a fatal abort message.
+          !       The call to glide_finalise was added to allow CISM to finish cleanly when running
+          !        a suite of automated stability tests, e.g. with the stabilitySlab.py script.
+          if (advective_cfl > 1.0d0) then
+             if (main_task) print*, 'advective CFL violation; call glide_finalise and exit cleanly'
+             call glide_finalise(model, crash=.true.)
+             stop
+          else
+             nsubcyc = model%numerics%subcyc
+             dt_transport = model%numerics%dt_transport * tim0  ! convert to s
+          endif
+
        endif
 
        !-------------------------------------------------------------------------

--- a/libglissade/glissade_basal_traction.F90
+++ b/libglissade/glissade_basal_traction.F90
@@ -440,9 +440,12 @@ contains
        !       If this factor is not present in the input file, it is set to 1 everywhere.
 
        ! Compute beta
-       ! gn = Glen's n from physcon module
-       beta(:,:) = coulomb_c * basal_physics%effecpress_stag(:,:) * speed(:,:)**(1.0d0/gn - 1.0d0) * &
-            (speed(:,:) + basal_physics%effecpress_stag(:,:)**gn * big_lambda)**(-1.0d0/gn)
+       ! Note: Where this equation has powerlaw_m, we used to have Glen's flow exponent n,
+       !       following the notation of Leguy et al. (2014).
+       !       Changed to powerlaw_m to be consistent with the Schoof and Tsai laws.
+       m = basal_physics%powerlaw_m
+       beta(:,:) = coulomb_c * basal_physics%effecpress_stag(:,:) * speed(:,:)**(1.0d0/m - 1.0d0) * &
+            (speed(:,:) + basal_physics%effecpress_stag(:,:)**m * big_lambda)**(-1.0d0/m)
 
        ! If c_space_factor /= 1.0 everywhere, then multiply beta by c_space_factor
        if (maxval(abs(basal_physics%c_space_factor_stag(:,:) - 1.0d0)) > tiny(0.0d0)) then

--- a/libglissade/glissade_grid_operators.F90
+++ b/libglissade/glissade_grid_operators.F90
@@ -49,6 +49,7 @@ module glissade_grid_operators
     private
     public :: glissade_stagger, glissade_unstagger, glissade_stagger_real_mask, &
               glissade_gradient, glissade_gradient_at_edges, &
+              glissade_average_to_edges,            &
               glissade_surface_elevation_gradient,  &
               glissade_slope_angle,                 &
               glissade_laplacian_smoother,          &
@@ -705,6 +706,64 @@ contains
     endif
 
   end subroutine glissade_gradient_at_edges
+
+!****************************************************************************
+
+  subroutine glissade_average_to_edges(nx,           ny,           &
+                                       field,                      &
+                                       field_east,   field_north,  &
+                                       cell_mask)
+
+    !----------------------------------------------------------------
+    ! Given a scalar variable f on the unstaggered grid (dimension nx, ny),
+    ! average the field to east and north edges.
+    ! Note: The east fields have dimension (nx-1,ny) and the north fields (nx,ny-1).
+    !----------------------------------------------------------------
+
+    !----------------------------------------------------------------
+    ! Input-output arguments
+    !----------------------------------------------------------------
+
+    integer, intent(in) ::      &
+       nx, ny                   ! horizontal grid dimensions
+
+    real(dp), dimension(nx,ny), intent(in) ::       &
+       field                    ! scalar field, defined at cell centers
+
+    real(dp), dimension(nx-1,ny), intent(out) ::    &
+       field_east               ! field averaged to east edges
+
+    real(dp), dimension(nx,ny-1), intent(out) ::    &
+       field_north              ! field averaged to north edges
+
+    integer, dimension(nx,ny), intent(in) ::        &
+       cell_mask                ! average at edges only if cell_mask = 1 on either side
+
+    ! Local variables
+
+    integer :: i, j
+
+    field_east(:,:) = 0.0d0
+    field_north(:,:) = 0.0d0
+
+    do j = 1, ny
+       do i = 1, nx-1
+          if (cell_mask(i,j) == 1  .and. cell_mask(i+1,j) == 1) then
+             field_east(i,j) = 0.5d0*(field(i,j) + field(i+1,j))
+          endif
+       enddo
+    enddo
+
+    do j = 1, ny-1
+       do i = 1, nx
+          if (cell_mask(i,j) == 1  .and. cell_mask(i,j+1) == 1) then
+             field_north(i,j) = 0.5d0*(field(i,j) + field(i,j+1))
+          endif
+       enddo
+    enddo
+
+
+  end subroutine glissade_average_to_edges
 
 !****************************************************************************
 

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -1119,10 +1119,13 @@ module glissade_therm
 
              delta_e = (ucondflx(ew,ns) - lcondflx(ew,ns) + dissipcol(ew,ns)) * dttem
 
-             ! Note: For very small dttem (e.g., 1.0d-6 year or less), this error can be triggered
-             !       by roundoff error.  In that case, the user may need to increase the threshold.
-             ! July 2021: Increased from 1.0d-8 to 1.0d-7 to allow smaller dttem.
              if (abs((efinal-einit-delta_e)/dttem) > 1.0d-7) then
+             ! WHL: For stability tests with a very short time step (e.g., < 1.d-6 year),
+             !      the energy-conservation error can be triggered by machine roundoff.
+             !      For these tests, I uncommented the line below, which compares the
+             !      error to the total amount of energy.  The latter criterion is less likely
+             !      to give false positives, but might be more likely to give false negatives.
+!!             if (abs((efinal-einit-delta_e)/(efinal)) > 1.0d-8) then
 
                 if (verbose_column) then
                    print*, 'Ice thickness:', thck(ew,ns)

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -1122,9 +1122,10 @@ module glissade_therm
              if (abs((efinal-einit-delta_e)/dttem) > 1.0d-7) then
              ! WHL: For stability tests with a very short time step (e.g., < 1.d-6 year),
              !      the energy-conservation error can be triggered by machine roundoff.
-             !      For these tests, I uncommented the line below, which compares the
-             !      error to the total amount of energy.  The latter criterion is less likely
-             !      to give false positives, but might be more likely to give false negatives.
+             !      For the tests in Robinson et al. (2021), I replaced the line above
+             !      with the line below, which compares the error to the total energy.
+             !      The latter criterion is less likely to give false positives,
+             !       but might be more likely to give false negatives.
 !!             if (abs((efinal-einit-delta_e)/(efinal)) > 1.0d-8) then
 
                 if (verbose_column) then

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -1640,10 +1640,11 @@ module glissade_therm
     ! At each temperature point, compute the temperature part of the enthalpy.
     ! enth_T = enth for cold ice, enth_T < enth for temperate ice
 
-    enth_T(0) = rhoi*shci*temp(0)  !WHL - not sure enth_T(0) is needed
-    do up = 1, upn
+    do up = 1, upn-1
        enth_T(up) = (1.d0 - waterfrac(up)) * rhoi*shci*temp(up)
     enddo
+    enth_T(0) = rhoi*shci*temp(0)
+    enth_T(up) = rhoi*shci*temp(up)
 
 !WHL - debug
     if (verbose_column) then
@@ -2250,8 +2251,7 @@ module glissade_therm
     ! Compute the dissipation source term associated with strain heating,
     ! based on the shallow-ice approximation.
     
-    use glimmer_physcon, only : gn   ! Glen's n
-    use glimmer_physcon, only: rhoi, shci, grav
+    use glimmer_physcon, only: rhoi, shci, grav, n_glen
 
     integer, intent(in) :: ewn, nsn, upn   ! grid dimensions
 
@@ -2267,11 +2267,13 @@ module glissade_therm
     real(dp), dimension(:,:,:), intent(out) ::  &
          dissip       ! interior heat dissipation (deg/s)
     
-    integer, parameter :: p1 = gn + 1  
-
     integer :: ew, ns
     real(dp), dimension(upn-1) :: sia_dissip_fact  ! factor in SIA dissipation calculation
     real(dp) :: geom_fact         ! geometric factor
+
+    real(dp) :: p1                ! exponent = n_glen + 1
+
+    p1 = n_glen + 1.0d0
 
     ! Two methods of doing this calculation: 
     ! 1. find dissipation at u-pts and then average

--- a/libglissade/glissade_velo.F90
+++ b/libglissade/glissade_velo.F90
@@ -44,6 +44,8 @@ contains
       ! Glissade higher-order velocity driver
 
       use glimmer_log
+      use glimmer_paramets, only: vel0
+      use glimmer_physcon, only: scyr
       use glide_types
       use glissade_velo_higher, only: glissade_velo_higher_solve
       use glissade_velo_sia, only: glissade_velo_sia_solve
@@ -52,20 +54,118 @@ contains
 
       type(glide_global_type),intent(inout) :: model
 
-      integer :: i, j        
+      real(dp), dimension(:,:,:), allocatable :: &
+           uvel_sia, vvel_sia        ! temporary SIA velocity
+
+      integer :: i, j, k
+      integer :: ewn, nsn, upn
+      integer :: itest, jtest, rtest
+      integer :: whichbtrc_sav
+
+      logical, parameter :: verbose_velo = .false.
+
+      ewn = model%general%ewn
+      nsn = model%general%nsn
+      upn = model%general%upn
+
+      ! get coordinates of diagnostic point
+      rtest = -999
+      itest = 1
+      jtest = 1
+      if (this_rank == model%numerics%rdiag_local) then
+         rtest = model%numerics%rdiag_local
+         itest = model%numerics%idiag_local
+         jtest = model%numerics%jdiag_local
+      endif
 
       !-------------------------------------------------------------------
       ! Call the velocity solver.
       ! The standard glissade higher-order solver is glissade_velo_higher_solve.
-      ! There is an additional local shallow-ice solver, glissade_velo_sia_solve.
+      ! There is also a local shallow-ice solver, glissade_velo_sia_solve.
       !-------------------------------------------------------------------
       
       if (model%options%which_ho_approx == HO_APPROX_LOCAL_SIA) then
  
-         call glissade_velo_sia_solve (model,                                       &
-                                       model%general%ewn,      model%general%nsn,   &
-                                       model%general%upn)
-                       
+         call glissade_velo_sia_solve(model, ewn, nsn, upn)
+
+      elseif (model%options%which_ho_approx == HO_APPROX_HYBRID) then
+
+         !-------------------------------------------------------------------
+         ! compute the SIA part of the velocity, assuming no basal sliding
+         !-------------------------------------------------------------------
+
+         ! make sure basal sliding is turned off
+         whichbtrc_sav = model%options%whichbtrc
+         model%options%whichbtrc = BTRC_ZERO
+
+         call glissade_velo_sia_solve(model, ewn, nsn, upn)
+
+         ! restore the original value of whichbtrc, just in case
+         model%options%whichbtrc = whichbtrc_sav
+
+         ! save the result
+         allocate(uvel_sia(upn,ewn,nsn))
+         allocate(vvel_sia(upn,ewn,nsn))
+         uvel_sia = model%velocity%uvel
+         vvel_sia = model%velocity%vvel
+
+         if (verbose_velo .and. this_rank == rtest) then
+            i = itest
+            j = jtest
+            print*, ' '
+            print*, 'SIA part of uvel, vvel (m/yr): r, i, j =', rtest, itest, jtest
+            print*, ' '
+            do k = 1, upn
+               print*, k, model%velocity%uvel(k,i,j)*(vel0*scyr), &
+                          model%velocity%vvel(k,i,j)*(vel0*scyr)
+            enddo
+         endif
+
+         !-------------------------------------------------------------------
+         ! compute the basal velocity using the SSA solver
+         !-------------------------------------------------------------------
+
+         ! temporarily set the approximation to SSA
+         model%options%which_ho_approx = HO_APPROX_SSA
+
+         ! Compute mask for staggered grid. This is needed as an input to calcbeta
+         ! (which used to be called here but now is called from glissade_velo_higher_solve).
+         ! TODO - Remove the use of stagmask in the Glissade solver?
+
+         call glide_set_mask(model%numerics,                                     &
+                             model%geomderv%stagthck, model%geomderv%stagtopg,   &
+                             model%general%ewn-1,     model%general%nsn-1,       &
+                             model%climate%eus,       model%geometry%stagmask)
+
+         call t_startf('glissade_velo_higher_solver')
+         call glissade_velo_higher_solve(model, ewn, nsn, upn)
+         call t_stopf('glissade_velo_higher_solver')
+
+         if (verbose_velo .and. this_rank == rtest) then
+            i = itest
+            j = jtest
+            print*, ' '
+            print*, 'SSA part of uvel, vvel (m/yr): r, i, j =', rtest, itest, jtest
+            print*, ' '
+            do k = 1, upn
+               print*, k, model%velocity%uvel(k,i,j)*(vel0*scyr), &
+                          model%velocity%vvel(k,i,j)*(vel0*scyr)
+            enddo
+         endif
+
+         !-------------------------------------------------------------------
+         ! Add the result to the SIA velocity found above
+         !-------------------------------------------------------------------
+
+         model%velocity%uvel = model%velocity%uvel + uvel_sia
+         model%velocity%vvel = model%velocity%vvel + vvel_sia
+
+         ! restore the approximation option and clean up
+         model%options%which_ho_approx = HO_APPROX_HYBRID
+
+         deallocate(uvel_sia)
+         deallocate(vvel_sia)
+
       else   ! standard higher-order solve
              ! can be BP, L1L2, SSA or SIA, depending on model%options%which_ho_approx
 
@@ -86,12 +186,23 @@ contains
          !        in module glissade.F90.
 
          call t_startf('glissade_velo_higher_solver')
-         call glissade_velo_higher_solve(model,                                             &
-                                         model%general%ewn,      model%general%nsn,         &
-                                         model%general%upn)
+         call glissade_velo_higher_solve(model, ewn, nsn, upn)
          call t_stopf('glissade_velo_higher_solver')
 
       endif   ! which_ho_approx
+
+      ! optional diagnostics
+      if (verbose_velo .and. this_rank == rtest) then
+         i = itest
+         j = jtest
+         print*, ' '
+         print*, 'uvel, vvel (m/yr): r, i, j =', rtest, itest, jtest
+         print*, ' '
+         do k = 1, upn
+            print*, k, model%velocity%uvel(k,i,j)*(vel0*scyr), &
+                       model%velocity%vvel(k,i,j)*(vel0*scyr)
+         enddo
+      endif
 
     end subroutine glissade_velo_driver
 

--- a/libglissade/glissade_velo.F90
+++ b/libglissade/glissade_velo.F90
@@ -43,9 +43,6 @@ contains
 
       ! Glissade higher-order velocity driver
 
-      use glimmer_global, only : dp
-      use glimmer_physcon, only: gn, scyr
-      use glimmer_paramets, only: thk0, len0, vel0, vis0, tau0, evs0
       use glimmer_log
       use glide_types
       use glissade_velo_higher, only: glissade_velo_higher_solve

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -4013,7 +4013,6 @@
           if (verbose_velo .and. this_rank==rtest) then
              i = itest
              j = jtest
-             print*, ' '
              print*, 'rank, i, j, uvel_2d, vvel_2d (m/yr):', &
                       this_rank, i, j, uvel_2d(i,j), vvel_2d(i,j)               
           endif
@@ -4209,7 +4208,8 @@
        enddo
 
        call compute_3d_velocity_L1L2(nx,               ny,              &
-                                     nz,               sigma,           &
+                                     nz,                                &
+                                     sigma,            stagsigma,       &
                                      dx,               dy,              &
                                      itest,   jtest,   rtest,           &
                                      parallel,                          &
@@ -4222,9 +4222,7 @@
                                      usrf,                              &
                                      dusrf_dx,         dusrf_dy,        &
                                      flwa,             efvs,            &
-                                     whichefvs,        efvs_constant,   &
-                                     whichgradient_margin,              &
-                                     max_slope,                         &
+                                     whichefvs,                         &
                                      uvel,             vvel)
 
        call staggered_parallel_halo(uvel, parallel)
@@ -4310,7 +4308,7 @@
        print*, 'uvel, k=1 (m/yr):'
        do j = jtest+3, jtest-3, -1
           do i = itest-3, itest+3
-             write(6,'(f8.2)',advance='no') uvel(1,i,j)
+             write(6,'(f10.3)',advance='no') uvel(1,i,j)
           enddo
           print*, ' '
        enddo
@@ -4318,7 +4316,23 @@
        print*, 'vvel, k=1 (m/yr):'
        do j = jtest+3, jtest-3, -1
           do i = itest-3, itest+3
-             write(6,'(f8.2)',advance='no') vvel(1,i,j)
+             write(6,'(f10.3)',advance='no') vvel(1,i,j)
+          enddo
+          print*, ' '
+       enddo
+       print*, ' '
+       print*, 'uvel, k=nz (m/yr):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') uvel(nz,i,j)
+          enddo
+          print*, ' '
+       enddo
+       print*, ' '
+       print*, 'vvel, k=nz (m/yr):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') vvel(1,i,j)
           enddo
           print*, ' '
        enddo
@@ -6412,7 +6426,8 @@
 !****************************************************************************
 
   subroutine compute_3d_velocity_L1L2(nx,               ny,              &
-                                      nz,               sigma,           &
+                                      nz,                                &
+                                      sigma,            stagsigma,       &
                                       dx,               dy,              &
                                       itest,   jtest,   rtest,           &
                                       parallel,                          &
@@ -6424,15 +6439,13 @@
                                       usrf,                              &
                                       dusrf_dx,         dusrf_dy,        &
                                       flwa,             efvs,            &
-                                      whichefvs,        efvs_constant,   &
-                                      whichgradient_margin,              &
-                                      max_slope,                         &
+                                      whichefvs,                         &
                                       uvel,             vvel)
 
     !----------------------------------------------------------------
-    ! Given the basal velocity and the 3D profile of effective viscosity
-    !  and horizontal-plane stresses, construct the 3D stress and velocity
-    !  profiles for the L1L2 approximation.
+    ! Given the basal velocity and the 3D profile of effective viscosity and
+    !  horizontal-plane stresses, construct the 3D stress and velocity profiles
+    !  for the L1L2 approximation, following Perego et al. (J. Glaciol., 2012).
     !----------------------------------------------------------------
 
     !----------------------------------------------------------------
@@ -6453,7 +6466,10 @@
        parallel                    ! info for parallel communication
 
     real(dp), dimension(nz), intent(in) ::    &
-       sigma              ! sigma vertical coordinate
+       sigma                       ! sigma vertical coordinate at layer boundaries
+
+    real(dp), dimension(nz-1), intent(in) ::    &
+       stagsigma                   ! sigma vertical coordinate at layer midpoints
 
     integer, dimension(nx,ny), intent(in) ::  &
        ice_mask,        & ! = 1 for cells where ice is present (thck > thklim), else = 0
@@ -6487,18 +6503,6 @@
 
     integer, intent(in) :: &
        whichefvs          ! option for effective viscosity calculation
-
-    real(dp), intent(in) :: &
-       efvs_constant      ! constant value of effective viscosity (Pa yr)
-
-    integer, intent(in) ::  &
-       whichgradient_margin     ! option for computing gradient at ice margin
-                                ! 0 = include all neighbor cells in gradient calculation
-                                ! 1 = include ice-covered and/or land cells
-                                ! 2 = include ice-covered cells only
-
-    real(dp), intent(in) ::  &
-       max_slope          ! maximum slope allowed for surface gradient computations (unitless)
 
     real(dp), dimension(nz,nx-1,ny-1), intent(inout) ::  &
        uvel, vvel         ! velocity components (m/yr)
@@ -6542,93 +6546,29 @@
        stagtau_parallel_sq,     &! tau_parallel^2, interpolated to staggered grid
        stagflwa                  ! flwa, interpolated to staggered grid
 
-    real(dp), dimension(nx-1,ny-1) ::   &
-       vintfact                  ! vertical integration factor at vertices
-
     real(dp) ::   &
        depth,                   &! distance from upper surface to midpoint of a given layer
        eps_parallel,            &! parallel effective strain rate, evaluated at cell centers
        tau_eff_sq,              &! square of effective stress (Pa^2)
                                  ! = tau_parallel^2 + tau_perp^2 for L1L2
-       tau_xz_vertex,           &! tau_xz averaged from edges to vertices
-       tau_yz_vertex,           &! tau_yz averaged from edges to vertices
-       fact_east, fact_north,   &! factors in velocity integral
        fact                      ! factor in velocity integral
-
-    real(dp), dimension(nx-1,ny) ::  &
-       thck_east,               &! ice thickness averaged to east edges
-       flwa_east,               &! flow factor averaged to east edges
-       tau_parallel_sq_east,    &! tau_parallel^2, averaged to east edges
-       dusrf_dx_east,           &! x gradient of upper surface elevation at east edges (m/m)
-       dusrf_dy_east,           &! y gradient of upper surface elevation averaged to east edges (m/m)
-       dwork1_dx_east,          &! x gradient of work1 array at east edges
-       dwork2_dx_east,          &! x gradient of work2 array at east edges
-       dwork3_dx_east,          &! x gradient of work3 array at east edges
-       dwork2_dy_east,          &! y gradient of work2 array averaged to east edges
-       dwork3_dy_east,          &! y gradient of work3 array averaged to east edges
-       tau_xz_east,             &! tau_xz at east edges
-       tau_yz_east,             &! tau_yz at east edges
-       tau_xz_east_sia,         &! tau_xz_east with SIA stresses only
-       uedge                     ! u velocity component at east edge, relative to bed (m/yr)
-
-    real(dp), dimension(nx,ny-1) ::  &
-       thck_north,              &! ice thickness averaged to north edges
-       flwa_north,              &! flow factor averaged to north edges
-       tau_parallel_sq_north,   &! tau_parallel^2, averaged to north edges
-       dusrf_dy_north,          &! y gradient of upper surface elevation at north edges (m/m)
-       dusrf_dx_north,          &! x gradient of upper surface elevation averaged to north edges (m/m)
-       dwork1_dy_north,         &! y gradient of work1 array at north edges
-       dwork2_dy_north,         &! y gradient of work2 array at north edges
-       dwork3_dy_north,         &! y gradient of work3 array at north edges
-       dwork1_dx_north,         &! x gradient of work1 array averaged to north edges
-       dwork2_dx_north,         &! x gradient of work2 array averaged to north edges
-       tau_xz_north,            &! tau_xz at north edges
-       tau_yz_north,            &! tau_yz at north edges
-       tau_yz_north_sia,        &! tau_yz_north with SIA stresses only
-       vedge                     ! v velocity component at north edge, relative to bed (m/yr)
 
     integer :: i, j, k, n
 
     !-----------------------------------------------------------------------------------------------
-    !WHL: I tried three ways to compute the 3D velocity, given the basal velocity field:
-    ! (1) Compute velocity at vertices using     
-    !          u(z) = u_b + 2 * integral_b_to_z [A*tau_eff^(n-1)*tau_xz dz]
-    !          v(z) = v_b + 2 * integral_b_to_z [A*tau_eff^(n-1)*tau_yz dz]
-    ! (2) Compute integration factors at vertices, and then compute velocity at edges using
-    !          uedge(z) =  (vintfact(i,j) + vintfact(i,j-1))/2.d0 * dsdx_edge 
-    !          vedge(z) =  (vintfact(i,j) + vintfact(i-1,j))/2.d0 * dsdy_edge 
-    !     where vintfact = 2*A*tau_eff^(n-1)*(rho*g*|grad(s)|
-    !     Average uedge and vedge to vertices and add to u_b to get 3D uvel and vvel.
-    !     Apart from the averaging at the end, this algorithm is similar to that in Yelmo,
-    !      but Yelmo uses a C grid and skips the last step.
-    ! (3) Do all the intermediate computations at cell edges rather than vertices.
-    !     Average uedge and vedge to vertices at the end, and add to u_b to get 3D uvel and vvel.
+    ! Compute velocity at vertices following Perego et al. (2012).
     !
-    ! Methods 2 and 3 were developed while running slab tests for the paper by Robinson et al. (2021).
-    ! The goal was to make CISM more stable at fine resolution (<~ 200 m).
-    ! However, all three methods yield similar behavior.  Stability follows the SSA curve
-    !  (see Fig. 1 in Robinson et al.) at resolutions of ~400 m to 1 km, but then suddenly drops off.
-    !  All three methods have a 'stability cliff' and appear to be unconditionally unstable at high resolution.
-    ! That is, reducing the time step to a small value does not ensure stability.
-    ! Yelmo, on the other hand, follows the SIA stability limit at fine resolution.
-    ! The reason for the differences is unclear, but might be related to CISM's B-grid staggering
-    !  as compared to Yelmo's C-grid staggering.
-    ! When tau_xz and tau_yz are replaced with their SIA counterparts in vertical integrals,
-    !  the CISM algorithms become more stable, following the SIA curve.
+    ! The latest version was implemented in fall 2021 for the paper by Robinson et al. (TC, 2021).
+    ! An important change was to evaluate both the membrane stress and SIA stress terms at layer midpoints.
+    ! Previously, the membrane stress was evaluated at lower layer boundaries.
+    ! With the change, the stability curve is parallel to the SIA curve at fine resolution for the slab problem.
+    ! Before the change, the model did not converge on the solution for dx <~ 200 m.
     !-----------------------------------------------------------------------------------------------
 
-    logical, parameter :: edge_velocity = .false.  ! if false, use method 1 as discussed above
-!!    logical, parameter :: edge_velocity = .true.  ! if true, use method 2 or 3
-
-    logical, parameter :: all_edge = .false.      ! if false, use method 2 (Yelmo-style with some interpolation back and forth)
-!!    logical, parameter :: all_edge = .true.      ! if true, use method 3 (all possible computations on edges)
-
-    ! Note: Membrane stresses are included in tau_eff even if left out of the tau_xz and tau_yz terms
-    !       in the vertical velocity integral.
     logical, parameter :: &
-         include_membrane_stress_in_tau = .true.  ! if true, include membrane stresses in tau_xz and tau_yz
-                                                  ! if false, leave them out
+         include_membrane_stress_in_tau = .true.  ! if true, include membrane stresses in tau_xz and tau_yz;
 
+                                                  ! if false, include the SIA stress only
     integer :: &
          staggered_ilo, staggered_ihi, &  ! bounds of locally owned vertices on staggered grid
          staggered_jlo, staggered_jhi
@@ -6645,13 +6585,20 @@
     du_dy(:,:) = 0.d0
     dv_dx(:,:) = 0.d0
     dv_dy(:,:) = 0.d0
+    tau_xz(:,:,:) = 0.d0
+    tau_yz(:,:,:) = 0.d0
+    tau_xz_sia(:,:,:) = 0.d0
+    tau_yz_sia(:,:,:) = 0.d0
+
+    ! initialize uvel = vvel = 0 except at bed
+    uvel(1:nz-1,:,:) = 0.d0
+    vvel(1:nz-1,:,:) = 0.d0
 
     ! Compute viscosity integral and strain rates in elements.
     ! Loop over all cells that border locally owned vertices.
 
     do j = nhalo+1, ny-nhalo+1
        do i = nhalo+1, nx-nhalo+1
-       
           if (active_cell(i,j)) then
 
              ! Load x and y coordinates and basal velocity at cell vertices
@@ -6692,7 +6639,7 @@
              enddo
 
              ! Compute effective strain rate (squared) at cell centers
-             ! See Perego et al. eq. 17: 
+             ! See Perego et al. Eq. 17:
              !     eps_parallel^2 = eps_xx^2 + eps_yy^2 + eps_xx*eps_yy + eps_xy^2
 
              eps_parallel = sqrt(du_dx(i,j)**2 + dv_dy(i,j)**2 + du_dx(i,j)*dv_dy(i,j)  &
@@ -6704,28 +6651,26 @@
              enddo
 
              ! For each layer k, compute the integral of the effective viscosity from
-             ! the base of layer k to the upper surface.
- 
-             efvs_integral_z_to_s(1,i,j) = efvs(1,i,j) * (sigma(2) - sigma(1))*thck(i,j)
+             ! the midpoint of layer k to the upper surface.
 
+             efvs_integral_z_to_s(1,i,j) = efvs(1,i,j) * (stagsigma(1))*thck(i,j)
              do k = 2, nz-1
                 efvs_integral_z_to_s(k,i,j) = efvs_integral_z_to_s(k-1,i,j)  &
-                                            + efvs(k,i,j) * (sigma(k+1) - sigma(k))*thck(i,j)
+                                            + efvs(k-1,i,j) * (sigma(k) - stagsigma(k-1))*thck(i,j)  &
+                                            + efvs(k,i,j)   * (stagsigma(k) - sigma(k))*thck(i,j)
              enddo   ! k
 
           endif   ! active_cell
-
        enddo      ! i
     enddo         ! j
 
-    ! Halo update for tau_parallel, so it is valid in all halo cells
     call parallel_halo(tau_parallel, parallel)
 
     !--------------------------------------------------------------------------------
     ! For each active vertex, compute the vertical shear stresses tau_xz and tau_yz
     ! in each layer of the column.
     !
-    ! These stresses are given by (PGB eq. 27)
+    ! These stresses are given by Perego et al. Eq. 27:
     !
     !   tau_xz(z) = -rhoi*grav*ds_dx*(s-z) + 2*d/dx[efvs_int(z) * (2*du_dx + dv_dy)]
     !                                      + 2*d/dy[efvs_int(z) *   (du_dy + dv_dx)] 
@@ -6740,18 +6685,9 @@
     ! because strain rates are discontinuous at cell edges and vertices.  Instead, we use
     ! a standard centered finite difference method to evaluate d/dx and d/dy of the
     ! bracketed terms.
-    !--------------------------------------------------------------------------------
-
-    tau_xz(:,:,:) = 0.d0
-    tau_yz(:,:,:) = 0.d0
-    tau_xz_sia(:,:,:) = 0.d0
-    tau_yz_sia(:,:,:) = 0.d0
-
-    !--------------------------------------------------------------------------------
-    ! Given the vertical shear stresses tau_xz and tau_yz for each layer k,
-    !  compute the velocity components at each level.
     !
-    ! These are given by (PGB eq. 30)
+    ! Given the vertical shear stresses tau_xz and tau_yz for each layer k,
+    !  compute the velocity components at each level, following Perego et al. Eq. 30:
     ! 
     !    u(z) = u_b + 2 * integral_b_to_z [A*tau_eff^(n-1)*tau_xz dz]
     !    v(z) = v_b + 2 * integral_b_to_z [A*tau_eff^(n-1)*tau_yz dz]
@@ -6760,399 +6696,78 @@
     !
     !    tau_parallel^2 = (2 * efvs * eps_parallel)^2
     !    tau_perp ^2 = tau_xz^2 + tau_yz^2
-    !
     !--------------------------------------------------------------------------------
-
-    ! initialize uvel = vvel = 0 except at bed
-       
-    uvel(1:nz-1,:,:) = 0.d0
-    vvel(1:nz-1,:,:) = 0.d0
-
-    ! Compute surface elevation gradient on cell edges.
-    ! Setting gradient_margin_in = 0 takes the gradient over both neighboring cells,
-    !  including ice-free cells.
-    ! Setting gradient_margin_in = 1 computes a gradient if both neighbor cells are
-    !  ice-covered, or an ice-covered cell sits above ice-free land; else gradient = 0
-    ! Setting gradient_margin_in = 2 computes a gradient only if both neighbor cells
-    !  are ice-covered.
-    ! At a land margin, either 0 or 1 is appropriate, but 2 is inaccurate.
-    ! At a shelf margin, either 1 or 2 is appropriate, but 0 is inaccurate.
-    ! So HO_GRADIENT_MARGIN_HYBRID = 1 is the safest value.
-
-    if (edge_velocity) then   ! compute thickness and surface gradients at cell edges
-
-       uedge(:,:) = 0.d0
-       vedge(:,:) = 0.d0
-
-       call glissade_gradient_at_edges(nx,               ny,                &
-                                       dx,               dy,                &
-                                       usrf,                                &
-                                       dusrf_dx_east,    dusrf_dy_north,    &
-                                       ice_mask,                            &
-                                       gradient_margin_in = whichgradient_margin, &
-                                       usrf = usrf,                         &
-                                       land_mask = land_mask,               &
-                                       max_slope = max_slope)
-
-       call glissade_average_to_edges(nx,                ny,                &
-                                      thck,                                 &
-                                      thck_east,         thck_north,        &
-                                      ice_mask)
-    endif
 
     do k = nz-1, 1, -1   ! loop over velocity levels above the bed
 
-       ! Compute work arrays (work1, work2, work3) at cell centers.
+       ! Average tau_parallel and flwa to vertices
+       ! With stagger_margin_in = 1, only cells with ice are included in the average.
+
+       call glissade_stagger(nx,                   ny,                         &
+                             tau_parallel(k,:,:),  stagtau_parallel_sq(:,:),   &
+                             ice_mask,             stagger_margin_in = 1)
+       stagtau_parallel_sq(:,:) = stagtau_parallel_sq(:,:)**2
+
+       call glissade_stagger(nx,          ny,              &
+                             flwa(k,:,:), stagflwa(:,:),   &
+                             ice_mask,    stagger_margin_in = 1)
+
+       ! Compute work arrays at cell centers.
        ! These are needed to find tau_xz and tau_yz.
 
        work1(:,:) = efvs_integral_z_to_s(k,:,:) * (2.d0*du_dx(:,:) + dv_dy(:,:))
        work2(:,:) = efvs_integral_z_to_s(k,:,:) *      (du_dy(:,:) + dv_dx(:,:))
        work3(:,:) = efvs_integral_z_to_s(k,:,:) * (2.d0*dv_dy(:,:) + du_dx(:,:))
 
-       ! Halo update for work arrays, so values are valid in all halo cells
        call parallel_halo(work1, parallel)
        call parallel_halo(work2, parallel)
        call parallel_halo(work3, parallel)
 
-       if (all_edge) then   ! average tau_parallel and flwa to edges
-
-          call glissade_average_to_edges(nx,                   ny,                    &
-                                         tau_parallel(k,:,:),                         &
-                                         tau_parallel_sq_east, tau_parallel_sq_north, &
-                                         ice_mask)
-          tau_parallel_sq_east(:,:)  = tau_parallel_sq_east(:,:)**2
-          tau_parallel_sq_north(:,:) = tau_parallel_sq_north(:,:)**2
-
-          call glissade_average_to_edges(nx,                ny,                &
-                                         flwa(k,:,:),                          &
-                                         flwa_east,         flwa_north,        &
-                                         ice_mask)
-
-       else   ! average tau_parallel and flwa to vertices
-              ! With stagger_margin_in = 1, only cells with ice are included in the average.
-
-          call glissade_stagger(nx,                   ny,                         &
-                                tau_parallel(k,:,:),  stagtau_parallel_sq(:,:),   &
-                                ice_mask,             stagger_margin_in = 1)
-          stagtau_parallel_sq(:,:) = stagtau_parallel_sq(:,:)**2
-
-          call glissade_stagger(nx,          ny,              &
-                                flwa(k,:,:), stagflwa(:,:),   &
-                                ice_mask,    stagger_margin_in = 1)
+       ! Compute horizontal gradients of the work arrays.
+       ! We need dwork1_dx, dwork2_dx, dwork2_dy and dwork3_dx at vertices.
+       ! The calls to glissade_centered_gradient compute a couple of extraneous derivatives,
+       !  but these calls are simpler than inlining the gradient code.
+       ! With gradient_margin_in = 1, only ice-covered cells are included in the gradient.
+       ! This is the appropriate setting, since efvs and strain rates have no meaning in ice-free cells.
        
-       endif   ! all_edge
+       call glissade_gradient(nx,               ny,         &
+                              dx,               dy,         &
+                              work1,                        &
+                              dwork1_dx,        dwork1_dy,  &
+                              ice_mask,                     &
+                              gradient_margin_in = 1)
 
-       if (edge_velocity) then   ! new algorithm based on Yelmo
+       call glissade_gradient(nx,               ny,         &
+                              dx,               dy,         &
+                              work2,                        &
+                              dwork2_dx,        dwork2_dy,  &
+                              ice_mask,                     &
+                              gradient_margin_in = 1)
 
-          vintfact(:,:) = 0.0d0
-          tau_xz_east(:,:) = 0.0d0
-          tau_yz_east(:,:) = 0.0d0
-          tau_xz_north(:,:) = 0.0d0
-          tau_yz_north(:,:) = 0.0d0
-          tau_xz_east_sia(:,:) = 0.0d0
-          tau_yz_north_sia(:,:) = 0.0d0
+       call glissade_gradient(nx,               ny,         &
+                              dx,               dy,         &
+                              work3,                        &
+                              dwork3_dx,        dwork3_dy,  &
+                              ice_mask,                     &
+                              gradient_margin_in = 1)
 
-          dwork1_dx_east   = 0.0d0
-          dwork1_dy_north  = 0.0d0
-          dwork2_dx_east   = 0.0d0
-          dwork2_dy_north  = 0.0d0
-          dwork3_dx_east   = 0.0d0
-          dwork3_dy_north  = 0.0d0
-
-          dwork1_dx_north  = 0.0d0
-          dwork2_dx_north  = 0.0d0
-          dwork2_dy_east   = 0.0d0
-          dwork3_dy_east   = 0.0d0
-
-          ! Compute gradients of horizontal stresses at edges
-          ! (at east edges for d/dx, and at north edges for d/dy).
-          ! Note: This subroutine assumes dimensions of (nx,ny) for the input array,
-          !       (nx-1,ny) for east edge gradients, and (nx,ny-1) for north edge gradients.
-          ! Note: Do not pass max_slope to the gradient routines;
-          !       this is appropriate only when computing elevation gradients.
-
-          call glissade_gradient_at_edges(nx,               ny,                &
-                                          dx,               dy,                &
-                                          work1,                               &
-                                          dwork1_dx_east,   dwork1_dy_north,   &
-                                          ice_mask,                            &
-                                          gradient_margin_in = whichgradient_margin, &
-                                          usrf = usrf,                         &
-                                          land_mask = land_mask)
-
-          call glissade_gradient_at_edges(nx,               ny,                &
-                                          dx,               dy,                &
-                                          work2,                               &
-                                          dwork2_dx_east,   dwork2_dy_north,   &
-                                          ice_mask,                            &
-                                          gradient_margin_in = whichgradient_margin, &
-                                          usrf = usrf,                         &
-                                          land_mask = land_mask)
-
-          call glissade_gradient_at_edges(nx,               ny,                &
-                                          dx,               dy,                &
-                                          work3,                               &
-                                          dwork3_dx_east,   dwork3_dy_north,   &
-                                          ice_mask,                            &
-                                          gradient_margin_in = whichgradient_margin, &
-                                          usrf = usrf,                         &
-                                          land_mask = land_mask)
-
-          ! Interpolate dwork2_dy and dwork3_dy from north to east edges.
-          ! The north arrays have dimensions (nx,ny-1) and are valid for all edges in their domain.
-          ! The interpolated east arrays are valid for edges(1:nx-1,2:ny-1).
-
-          do j = 2, ny-1
-             do i = 1, nx-1
-                dwork2_dy_east(i,j) = &
-                     0.25d0 * (dwork2_dy_north(i,j)   + dwork2_dy_north(i+1,j)   +  &
-                               dwork2_dy_north(i,j-1) + dwork2_dy_north(i+1,j-1))
-                dwork3_dy_east(i,j) = &
-                     0.25d0 * (dwork3_dy_north(i,j)   + dwork3_dy_north(i+1,j)   +  &
-                               dwork3_dy_north(i,j-1) + dwork3_dy_north(i+1,j-1))
-                dusrf_dy_east(i,j) = &
-                     0.25d0 * (dusrf_dy_north(i,j)    + dusrf_dy_north(i+1,j) +  &
-                               dusrf_dy_north(i,j-1)  + dusrf_dy_north(i+1,j-1))
-             enddo
-          enddo
-
-          ! Interpolate dwork1_dx and dwork2_dx from east to north edges.
-          ! The east arrays have dimensions (nx-1,ny) and are valid for all edges in their domain.
-          ! The interpolated north arrays are valid for edges (2:nx-1,1:ny-1).
-
-          do j = 1, ny-1
-             do i = 2, nx-1
-                dwork1_dx_north(i,j) = &
-                     0.25d0 * (dwork1_dx_east(i-1,j+1) + dwork1_dx_east(i,j+1) +  &
-                               dwork1_dx_east(i-1,j)   + dwork1_dx_east(i,j))
-                dwork2_dx_north(i,j) = &
-                     0.25d0 * (dwork2_dx_east(i-1,j+1) + dwork2_dx_east(i,j+1) +  &
-                               dwork2_dx_east(i-1,j)   + dwork2_dx_east(i,j))
-                dusrf_dx_north(i,j) = &
-                     0.25d0 * (dusrf_dx_east(i-1,j+1)  + dusrf_dx_east(i,j+1) +  &
-                               dusrf_dx_east(i-1,j)    + dusrf_dx_east(i,j))
-             enddo
-          enddo
-
-          ! Compute shear stresses tau_xz (at east edges) and tau_yz (at north edges)
-          ! Note: Results are valid only where dwork2_dy_east and dwork2_dx_north are valid:
-          !       east edges (1:nx-1,2:ny-1) and north edges (2:nx-1,1:ny-1).
-          !       This includes all edges of locally owned cells and one row of halo cells.
-
-          ! loop over east edges
-          do j = 1, ny
-             do i = 1, nx-1
-                if (ice_mask(i,j) == 1 .and. ice_mask(i+1,j) == 1) then
-                   depth = 0.5d0*(sigma(k) + sigma(k+1)) * thck_east(i,j)
-                   tau_xz_east_sia(i,j) = -rhoi*grav*depth*dusrf_dx_east(i,j)
-                   tau_xz_east(i,j)     =  tau_xz_east_sia(i,j) &
-                                         + 2.d0*dwork1_dx_east(i,j) + dwork2_dy_east(i,j)
-                   tau_yz_east(i,j)     =  -rhoi*grav*depth*dusrf_dy_east(i,j)  &
-                                         + dwork2_dx_east(i,j) + 2.d0*dwork3_dy_east(i,j)
-                endif
-             enddo
-          enddo
-
-          ! loop over north edges
-          do j = 1, ny-1
-             do i = 1, nx
-                if (ice_mask(i,j) == 1 .and. ice_mask(i,j+1) == 1) then
-                   depth = 0.5d0*(sigma(k) + sigma(k+1)) * thck_north(i,j)
-                   tau_yz_north_sia(i,j) = -rhoi*grav*depth*dusrf_dy_north(i,j)
-                   tau_yz_north(i,j)     =  tau_yz_north_sia(i,j) &
-                                          + dwork2_dx_north(i,j) + 2.d0*dwork3_dy_north(i,j)
-                   tau_xz_north(i,j)     = -rhoi*grav*depth*dusrf_dx_north(i,j) &
-                                          + 2.d0*dwork1_dx_north(i,j) + dwork2_dy_north(i,j)
-                endif
-             enddo
-          enddo
-
-          if (all_edge) then
-
-             ! loop over east edges (1:nx-1,2:ny-1) and north edges (2:nx-1,1:ny-1).
-             do j = 2, ny-1
-                do i = 1, nx-1
-                   tau_eff_sq = tau_parallel_sq_east(i,j)   &
-                        + tau_xz_east(i,j)**2 + tau_yz_east(i,j)**2
-                   fact_east = 2.d0 * flwa_east(i,j) * tau_eff_sq**((n_glen-1.d0)/2.d0)  &
-                        * (sigma(k+1) - sigma(k))*thck_east(i,j)
-                   if (include_membrane_stress_in_tau) then
-                      uedge(i,j) = uedge(i,j) + fact_east * tau_xz_east(i,j)
-                   else
-                      uedge(i,j) = uedge(i,j) + fact_east * tau_xz_east_sia(i,j)
-                   endif
-                enddo
-             enddo
-
-             do j = 1, ny-1
-                do i = 2, nx-1
-                   tau_eff_sq = tau_parallel_sq_north(i,j)   &
-                        + tau_xz_north(i,j)**2 + tau_yz_north(i,j)**2
-                   fact_north = 2.d0 * flwa_north(i,j) * tau_eff_sq**((n_glen-1.d0)/2.d0)  &
-                        * (sigma(k+1) - sigma(k))*thck_north(i,j)
-                   if (include_membrane_stress_in_tau) then
-                      vedge(i,j) = vedge(i,j) + fact_north * tau_yz_north(i,j)
-                   else
-                      vedge(i,j) = vedge(i,j) + fact_north * tau_yz_north_sia(i,j)
-                   endif
-                enddo
-             enddo
-
-          else   ! average some quantities to vertices
-
-             ! Average tau_xz and tau_yz from edges to vertices.
-             ! Compute tau_eff_sq and a multiplicative factor at vertices.
-             ! Results are valid for vertices (2:nx-2, 2:ny-2): all vertices of locally owned cells.
-
-             do j = 2, ny-2
-             do i = 2, nx-2
-                if (active_vertex(i,j)) then
-                   tau_xz_vertex = 0.5d0*(tau_xz_east(i,j) + tau_xz_east(i,j+1))
-                   tau_yz_vertex = 0.5d0*(tau_yz_north(i,j) + tau_yz_north(i+1,j))
-                   tau_eff_sq = stagtau_parallel_sq(i,j)   &
-                        + tau_xz_vertex**2 + tau_yz_vertex**2
-                   vintfact(i,j) = 2.d0 * stagflwa(i,j) * tau_eff_sq**((n_glen-1.d0)/2.d0)  &
-                                 * (sigma(k+1) - sigma(k))*stagthck(i,j)
-                endif
-             enddo
-             enddo
-
-             ! Halo update for vintfact so uedge/vedge can be found at all locally owned vertices
-             call staggered_parallel_halo(vintfact, parallel)
-
-             ! Remove the membrane stresses from the velocity computation if desired.
-             ! Note: This should not be done until after including the full stresses in tau_eff_sq.
-
-             if (.not. include_membrane_stress_in_tau) then
-                tau_xz_east  = tau_xz_east_sia
-                tau_yz_north = tau_yz_north_sia
-             endif
-
-             ! Compute u at east edges, and v at north edges, for this level k.
-             ! Note: uedge and vedge do not include the basal speed (which is computed on vertices only)
-
-             do j = 2, ny-1
-             do i = 1, nx-1
-                if (active_vertex(i,j) .and. active_vertex(i,j-1)) then
-                   uedge(i,j) = uedge(i,j) + (vintfact(i,j) + vintfact(i,j-1))/2.d0 * tau_xz_east(i,j)
-                endif
-             enddo
-             enddo
-
-             do j = 1, ny-1
-             do i = 2, nx-1
-                if (active_vertex(i,j) .and. active_vertex(i-1,j)) then
-                   vedge(i,j) = vedge(i,j) + (vintfact(i,j) + vintfact(i-1,j))/2.d0 * tau_yz_north(i,j)
-                endif
-             enddo
-             enddo
-
-          endif   ! all_edge
-
-                !TODO - incorporate efvs logic (code pasted from below)
-!                if (whichefvs == HO_EFVS_NONLINEAR) then
-!                   fact = 2.d0 * stagflwa(i,j) * tau_eff_sq**((n_glen-1.d0)/2.d0) &
-!                        * (sigma(k+1) - sigma(k))*stagthck(i,j)
-!                else   ! HO_EFVS_CONSTANT, HO_EFVS_FLOWFACT
-!                   if (efvs(k,i,j) > 0.0d0) then
-!                      fact = (sigma(k+1) - sigma(k))*stagthck(i,j) / efvs(k,i,j)
-!                   else
-!                      fact = 0.0d0
-!                   endif
-!                endif
-
-          ! For locally owned vertices, average edge velocities to vertices and add to bed velocity.
-          ! (Halo update is done at a higher level after returning)
-          ! Note: Currently do not support Dirichlet BC with depth-varying velocity
-
-          do j = staggered_jlo, staggered_jhi
-             do i = staggered_ilo, staggered_ihi
-
-                if (umask_dirichlet(i,j) == 1) then
-                   uvel(k,i,j) = uvel(nz,i,j)
-                else
-                   uvel(k,i,j) = uvel(nz,i,j) + (uedge(i,j) + uedge(i,j+1)) / 2.d0
-                endif
-
-                if (vmask_dirichlet(i,j) == 1) then
-                   vvel(k,i,j) = vvel(nz,i,j)
-                else
-                   vvel(k,i,j) = vvel(nz,i,j) + (vedge(i,j) + vedge(i+1,j)) / 2.d0
-                endif
-
-             enddo   ! i
-          enddo   ! j
-
-          if (verbose_L1L2 .and. this_rank==rtest) then
-             i = itest
-             j = jtest
-             depth = 0.5d0*(sigma(k) + sigma(k+1)) * thck_east(i,j)  ! based on thck at east edge
-             print*, 'k, edgethck, depth, fact, tau_xz, tau_yz:', &
-                  k, thck_east(i,j), depth, vintfact(i,j), tau_xz_east(i,j), tau_yz_north(i,j)
-             print*, '   dw1_dx, dw2_dx, dw2_dy, dw3_dy:', &
-                  dwork1_dx_east(i,j), dwork2_dy_east(i,j), dwork2_dx_north(i,j), dwork3_dy_north(i,j)
-             print*, '   uedge(i,j:j+1):', uedge(i,j), uedge(i,j+1)
-             print*, '   vedge(i:i+1,j):', vedge(i,j), vedge(i+1,j)
-             print*, '   uvel(k), vvel(k):', uvel(k,i,j), vvel(k,i,j)
-             print*, ' '
-          endif
-
-       else   ! compute velocity at vertices (method 1)
-
-          ! Compute horizontal gradients of the work arrays above.
-          ! We need dwork1_dx, dwork2_dx, dwork2_dy and dwork3_dx at vertices.
-          ! The calls to glissade_centered_gradient compute a couple of extraneous derivatives,
-          !  but these calls are simpler than inlining the gradient code.
-          ! Setting gradient_margin_in = HO_GRADIENT_MARGIN_MARINE uses only ice-covered cells to
-          !  compute the gradient.  This is the appropriate flag for these
-          !  calls, because efvs and strain rates have no meaning in ice-free cells.
-
-          ! With gradient_margin_in = 1, only ice-covered cells are included in the gradient.
-          ! This is the appropriate setting, since efvs and strain rates have no meaning in ice-free cells.
-
-          call glissade_gradient(nx,               ny,         &
-                                 dx,               dy,         &
-                                 work1,                        &
-                                 dwork1_dx,        dwork1_dy,  &
-                                 ice_mask,                     &
-                                 gradient_margin_in = 1)
-
-          call glissade_gradient(nx,               ny,         &
-                                 dx,               dy,         &
-                                 work2,                        &
-                                 dwork2_dx,        dwork2_dy,  &
-                                 ice_mask,                     &
-                                 gradient_margin_in = 1)
-
-          call glissade_gradient(nx,               ny,         &
-                                 dx,               dy,         &
-                                 work3,                        &
-                                 dwork3_dx,        dwork3_dy,  &
-                                 ice_mask,                     &
-                                 gradient_margin_in = 1)
-
-          ! loop over locally owned active vertices
-          do j = staggered_jlo, staggered_jhi
+       ! loop over locally owned active vertices
+       do j = staggered_jlo, staggered_jhi
           do i = staggered_ilo, staggered_ihi
-
              if (active_vertex(i,j)) then
 
                 ! Evaluate tau_xz and tau_yz for this layer
                 ! Compute two versions of these stresses: with all terms including membrane stresses,
                 !  and with SIA terms only.  Optionally, the SIA-only versions can be used in velocity integrals.
 
-                depth = 0.5d0*(sigma(k) + sigma(k+1)) * stagthck(i,j)   ! depth at layer midpoint
-
+                depth = stagsigma(k) * stagthck(i,j)   ! depth at layer midpoint
                 tau_xz_sia(k,i,j) = -rhoi*grav*depth*dusrf_dx(i,j)
                 tau_yz_sia(k,i,j) = -rhoi*grav*depth*dusrf_dy(i,j)
 
-                tau_xz(k,i,j) = tau_xz_sia(k,i,j) &
-                               + 2.d0*dwork1_dx(i,j) + dwork2_dy(i,j)
-                tau_yz(k,i,j) = tau_yz_sia(k,i,j) &
-                               + dwork2_dx(i,j) + 2.d0*dwork3_dy(i,j)
+                tau_xz(k,i,j) = tau_xz_sia(k,i,j) + 2.d0*dwork1_dx(i,j) + dwork2_dy(i,j)
+                tau_yz(k,i,j) = tau_yz_sia(k,i,j) + dwork2_dx(i,j) + 2.d0*dwork3_dy(i,j)
 
-                tau_eff_sq = stagtau_parallel_sq(i,j)   &
-                           + tau_xz(k,i,j)**2 + tau_yz(k,i,j)**2
+                tau_eff_sq = stagtau_parallel_sq(i,j) + tau_xz(k,i,j)**2 + tau_yz(k,i,j)**2
 
                 ! Note: The first formula below is correct for whichefvs = 2 (efvs computed from effective strain rate),
                 !        but not for whichefvs = 0 (constant efvs) or whichefvs = 1 (multiple of flow factor).
@@ -7164,7 +6779,6 @@
                 !  =>   1/efvs = 2 * A * tau_e(n-1)
                 !
                 ! Thus, for options 0 and 1, we can replace 2 * A * tau_e^(n-1) below with 1/efvs.
-                !TODO - Copy this logic to the edge-based calculation
 
                 if (whichefvs == HO_EFVS_NONLINEAR) then
                    fact = 2.d0 * stagflwa(i,j) * tau_eff_sq**((n_glen-1.d0)/2.d0) &
@@ -7177,15 +6791,15 @@
                    endif
                 endif
 
-                ! reset velocity to prescribed basal value if Dirichlet condition applies
-                ! else compute velocity at this level 
+                ! Reset velocity to prescribed basal value if Dirichlet condition applies,
+                ! else compute velocity at this level
 
                 if (umask_dirichlet(i,j) == 1) then
                    uvel(k,i,j) = uvel(nz,i,j)
                 else
                    if (include_membrane_stress_in_tau) then
                       uvel(k,i,j) = uvel(k+1,i,j) + fact * tau_xz(k,i,j)
-                   else
+                   else   ! SIA stress term only
                       uvel(k,i,j) = uvel(k+1,i,j) + fact * tau_xz_sia(k,i,j)
                    endif
                 endif
@@ -7195,27 +6809,27 @@
                 else
                    if (include_membrane_stress_in_tau) then
                       vvel(k,i,j) = vvel(k+1,i,j) + fact * tau_yz(k,i,j)
-                   else
+                   else   ! SIA stress term only
                       vvel(k,i,j) = vvel(k+1,i,j) + fact * tau_yz_sia(k,i,j)
                    endif
                 endif
 
                 if (verbose_L1L2 .and. this_rank==rtest .and. i==itest .and. j==jtest) then
-                   depth = 0.5d0*(sigma(k) + sigma(k+1)) * stagthck(i,j)
-                   print*, 'k, edgethck, depth, fact, tau_xz, tau_yz:', &
-                        k, stagthck(i,j), depth, fact, tau_xz(k,i,j), tau_yz(k,i,j)
-                   print*, '   dw1_dx, dw2_dx, dw2_dy, dw3_dy:', &
-                        dwork1_dx(i,j), dwork2_dx(i,j), dwork2_dy(i,j), dwork3_dy(i,j)
-                   print*, '   uvel(k), vvel(k):', uvel(k,i,j), vvel(k,i,j)
+                   depth = stagsigma(k) * stagthck(i,j)
                    print*, ' '
+                   print*, 'k, depth, fact:', &
+                        k, depth, fact
+                   print*, 'tau_xz(i,j): SIA term, membrane term, total:', &
+                        tau_xz_sia(k,i,j), tau_xz(k,i,j) - tau_xz_sia(k,i,j), tau_xz(k,i,j)
+                   print*, 'tau_yz(i,j): SIA term, membrane term, total:', &
+                        tau_yz_sia(k,i,j), tau_yz(k,i,j) - tau_yz_sia(k,i,j), tau_yz(k,i,j)
+                   print*, 'uvel(k), vvel(k):', uvel(k,i,j), vvel(k,i,j)
                 endif
 
              endif
 
           enddo   ! i
-          enddo   ! j
-
-       endif      ! edge_velocity
+       enddo      ! j
 
     enddo         ! k
 

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -200,8 +200,8 @@
 !    logical :: verbose = .true.  
     logical :: verbose_init = .false.   
 !    logical :: verbose_init = .true.   
-!    logical :: verbose_solver = .false.
-    logical :: verbose_solver = .true.
+    logical :: verbose_solver = .false.
+!    logical :: verbose_solver = .true.
     logical :: verbose_Jac = .false.
 !    logical :: verbose_Jac = .true.
     logical :: verbose_residual = .false.

--- a/libglissade/glissade_velo_sia.F90
+++ b/libglissade/glissade_velo_sia.F90
@@ -55,7 +55,7 @@
   module glissade_velo_sia
 
     use glimmer_global, only: dp
-    use glimmer_physcon, only: gn, rhoi, grav, scyr
+    use glimmer_physcon, only: n_glen, rhoi, grav, scyr
     use glimmer_paramets, only: thk0, len0, vel0, vis0, tau0
 !    use glimmer_log, only: write_log
 
@@ -881,16 +881,15 @@
           
           if (stagthck(i,j) > thklim) then
 
-             siafact = 2.d0 * (rhoi*grav)**gn * stagthck(i,j)**(gn+1)             &
-                             * (dusrf_dx(i,j)**2 + dusrf_dy(i,j)**2) ** ((gn-1)/2)
-
+             siafact = 2.d0 * (rhoi*grav)**n_glen * stagthck(i,j)**(n_glen+1)             &
+                             * (dusrf_dx(i,j)**2 + dusrf_dy(i,j)**2) ** ((n_glen-1)/2)
              vintfact(nz,i,j) = 0.d0
 
              do k = nz-1, 1, -1
 
-                vintfact(k,i,j) = vintfact(k+1,i,j) -                             &
-                                  siafact * stagflwa(k,i,j)                       &
-                                          * ((sigma(k) + sigma(k+1))/2.d0) ** gn  &
+                vintfact(k,i,j) = vintfact(k+1,i,j) -                                 &
+                                  siafact * stagflwa(k,i,j)                           &
+                                          * ((sigma(k) + sigma(k+1))/2.d0) ** n_glen  &
                                           * (sigma(k+1) - sigma(k))
 
              enddo   ! k

--- a/tests/MISMIP/mismip.code/README.mismip
+++ b/tests/MISMIP/mismip.code/README.mismip
@@ -1,6 +1,7 @@
 Instructions for setting up and running the MISMIP experiments with CISM.
 
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 Note: These instructions assume that you have access to the NCAR HPC Cheyenne,
 with an LIWG HPC account. If you do not have an account and would like one,

--- a/tests/MISMIP3d/mismip3d.code/README.mismip3d
+++ b/tests/MISMIP3d/mismip3d.code/README.mismip3d
@@ -1,6 +1,7 @@
 Instructions for setting up and running the MISMIP3d experiments with CISM.
 
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 Note: part of the instruction assumes that you have access to the NCAR HPC
  Cheyenne and have access to the LIWG HPC spending account.

--- a/tests/MISOMIP/mismip+/README.mismip+
+++ b/tests/MISOMIP/mismip+/README.mismip+
@@ -1,6 +1,7 @@
 Instructions for setting up and running the MISMIP+ experiments with CISM.
 
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 See this paper for details on MISMIP+:
 

--- a/tests/ismip-hom/README.md
+++ b/tests/ismip-hom/README.md
@@ -56,7 +56,7 @@ that is actually used to perform the model run.  If you wish to adjust any model
 settings, you should adjust them in this file.  Most users will not have any
 reason to modify settings.
 
- 2. __Run Glimmer/CISM by invoking the `runISMIP_HOM.py` script:__
+ 2. __Run CISM by invoking the `runISMIP_HOM.py` script:__
 
 ```sh
 ./runISMIP_HOM.py

--- a/tests/ismip-hom/plotISMIP_HOM.py
+++ b/tests/ismip-hom/plotISMIP_HOM.py
@@ -214,8 +214,8 @@ def read(filename,experiment):
         print('inputfile=',filename)
         data = list()
         for line in inputfile:
-            # This if statement was necessary with the update to python3 to avoid the code
-            # to crash because it would read empty lines in the text files. 
+            # This if statement is necessary with the update to python3 to avoid a code
+            # crash because it would read empty lines in the text files.
             if line == "\n":
                continue
             else:
@@ -398,7 +398,8 @@ def main():
 
                     # Figure out u,v since all experiments needs at least one of them (avoids duplicate code in each case below
                     #   Want to use last time level.  Most experiments should only have a single time level, but F may have many in the file.
-                    #   Apparently some older versions of netCDF4 give an error when using the -1 dimension if the size is 1, hence this bit of seemingly unnecessary logic...
+                    #   Apparently some older versions of netCDF4 give an error when using the -1 dimension if the size is 1,
+                    #   hence this bit of seemingly unnecessary logic...
                     if netCDFfile.variables['uvel_extend'][:].shape[0] == 1:
                         t = 0
                     else:
@@ -505,25 +506,25 @@ def main():
                         tick.label1.set_fontsize('xx-small')
                 axes.set_title('%d km' % size, size='medium')
 
-                # Get the Glimmer output data
-                glimmerData = read(out_file.replace('.out.nc','.txt'),experiment)
+                # Get the CISM output data
+                cismData = read(out_file.replace('.out.nc','.txt'),experiment)
 
-                # The Glimmer data is on a staggered grid;
+                # The CISM data is on a staggered grid;
                 # Interpolate to obtain the value at x=0 and x=1
                 # using periodic boundary conditions
-                #v = (glimmerData[0][1] + glimmerData[-1][1])/2
-                #glimmerData = [(0.0,v)]+glimmerData+[(1.0,v)]
+                #v = (cismData[0][1] + cismData[-1][1])/2
+                #cismData = [(0.0,v)]+ cismData+[(1.0,v)]
 
-                # Plot the Glimmer data
-                axes.plot([row[0] for row in glimmerData],
-                          [row[1] for row in glimmerData],color='black')
+                # Plot the CISM data
+                axes.plot([row[0] for row in cismData],
+                          [row[1] for row in cismData],color='black')
 
                 # Get the data from other models for comparison
                 firstOrder = 0
                 fullStokes = 1
                 count = [0,0]
-                sumV  = [[0.0 for v in glimmerData],[0.0 for v in glimmerData]]
-                sumV2 = [[0.0 for v in glimmerData],[0.0 for v in glimmerData]]
+                sumV  = [[0.0 for v in cismData],[0.0 for v in cismData]]
+                sumV2 = [[0.0 for v in cismData],[0.0 for v in cismData]]
                 for (path,directories,filenames) in os.walk('ismip_all'):
                     for filename in filenames:
                         modelName = filename[0:4]
@@ -551,8 +552,8 @@ def main():
 
                         #axes.plot([row[0] for row in data], [row[1] for row in data] )   ## OPTIONAL: print out every individual model in its native x-coordinates.
 
-                        # Interpolate onto the x values from the Glimmer model run
-                        for (i,target) in enumerate([row[0] for row in glimmerData]):
+                        # Interpolate onto the x values from the CISM model run
+                        for (i,target) in enumerate([row[0] for row in cismData]):
                             below = -99999.0
                             above =  99999.0
                             for (j,x) in enumerate([row[0] for row in data]):
@@ -592,13 +593,13 @@ def main():
                             continue
                         mean = list()
                         standardDeviation = list()
-                        for i in range(len(glimmerData)):
+                        for i in range(len(cismData)):
                             mean.append(sumV[index][i]/count[index])
                             standardDeviation.append(sqrt(sumV2[index][i]/count[index]-mean[-1]**2))
 
                         # Plot the mean using a dotted line
                         color = (index,0,1-index) # blue for first order (index=0); red for full Stokes (index=1)
-                        x = [row[0] for row in glimmerData]
+                        x = [row[0] for row in cismData]
                         axes.plot(x,mean,':',color=color)
 
                         # Plot a filled polygon showing the mean plus and minus one standard deviation
@@ -609,20 +610,20 @@ def main():
                         axes.fill(x,y,facecolor=color,edgecolor=color,alpha=0.25)
 
                         if index == firstOrder:
-                            # Calculate some statistics comparing the Glimmer data with the other models
-                            pcterror = [100.0*abs(glimmer-others)/others for (glimmer,others) in zip([row[1] for row in glimmerData],mean)]
-                            abserror = [abs(glimmer-others)        for (glimmer,others) in zip([row[1] for row in glimmerData],mean)]
+                            # Calculate some statistics comparing the CISM data with the other models
+                            pcterror = [100.0*abs(cism-others)/others for (cism,others) in zip([row[1] for row in cismData],mean)]
+                            abserror = [abs(cism-others)        for (cism,others) in zip([row[1] for row in cismData],mean)]
                             maximum = max(pcterror)
-                            position = glimmerData[pcterror.index(maximum)][0]
+                            position = cismData[pcterror.index(maximum)][0]
                             total   = sum([e for e in pcterror])
                             compare = sum([(s/m) for (s,m) in zip(standardDeviation,mean)])
-                            n = len(glimmerData)
+                            n = len(cismData)
                             #print '\t'.join([str(size)+' km',str(total/n),str(compare/n),str(position)])
                             print( 'Size='+str(size)+' km' )
                             print( '  Mean percent error along flowline of CISM relative to mean of first-order models='+str(total/float(n))+'%')
                             print( '  Mean COD (stdev/mean) along flowline of mean of first-order models (excluding CISM)='+str(compare/float(n)*100.0)+'%')
                             print( '  Max. CISM percent error='+str(maximum)+'% at x-position '+str(position))
-                            print( '  Max. CISM absolute error='+str(max(abserror))+' m/yr at x-position '+str(glimmerData[abserror.index(max(abserror))][0]))
+                            print( '  Max. CISM absolute error='+str(max(abserror))+' m/yr at x-position '+str(cismData[abserror.index(max(abserror))][0]))
 
             except:
                 print( "Error in analyzing/plotting experiment ",experiment," at size ",size," km")
@@ -682,18 +683,18 @@ def main():
             # Plot CISM output
             axes2.plot(xprime, zprime, color='black')
 
-            # create glimmerData so we can re-use the code from above
-            glimmerData = list()
+            # create cismData so we can re-use the code from above
+            cismData = list()
             for i in range(len(xprime)):
-                glimmerData.append(tuple([xprime[i], zprime[i]]))
+                cismData.append(tuple([xprime[i], zprime[i]]))
 
             # Now plot the other models - yucky code copied from above
             # Get the data from other models for comparison
             firstOrder = 0
             fullStokes = 1
             count = [0,0]
-            sumV  = [[0.0 for v in glimmerData],[0.0 for v in glimmerData]]
-            sumV2 = [[0.0 for v in glimmerData],[0.0 for v in glimmerData]]
+            sumV  = [[0.0 for v in cismData],[0.0 for v in cismData]]
+            sumV2 = [[0.0 for v in cismData],[0.0 for v in cismData]]
             for (path,directories,filenames) in os.walk('ismip_all'):
                 for filename in filenames:
                     modelName = filename[0:4]
@@ -721,8 +722,8 @@ def main():
 
                     #axes2.plot([row[0] for row in data], [row[1] for row in data] )   ## OPTIONAL: print out every individual model in its native x-coordinates.
 
-                    # Interpolate onto the x values from the Glimmer model run
-                    for (i,target) in enumerate([row[0] for row in glimmerData]):
+                    # Interpolate onto the x values from the cism model run
+                    for (i,target) in enumerate([row[0] for row in cismData]):
                         below = -99999.0
                         above =  99999.0
                         for (j,x) in enumerate([row[0] for row in data]):
@@ -760,13 +761,13 @@ def main():
                                 continue
                             mean = list()
                             standardDeviation = list()
-                            for i in range(len(glimmerData)):
+                            for i in range(len(cismData)):
                                 mean.append(sumV[index][i]/count[index])
                                 standardDeviation.append(sqrt(sumV2[index][i]/count[index]-mean[-1]**2))
 
                             # Plot the mean using a dotted line
                             color = (index,0,1-index) # blue for first order (index=0); red for full Stokes (index=1)
-                            x = [row[0] for row in glimmerData]
+                            x = [row[0] for row in cismData]
                             axes2.plot(x,mean,':',color=color)
 
                             # Plot a filled polygon showing the mean plus and minus one standard deviation

--- a/tests/new/README.md
+++ b/tests/new/README.md
@@ -1,11 +1,12 @@
-Hw to create a new CISM test
+How to create a new CISM test
 =============================
 
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 This directory contains a new test template called `runTest.py` which
-should be used to create a new test in CISM. This template is based off of the
-`tests/higher-order/dome` test, and you should start by playing around with that test
+should be used to create a new test in CISM. This template is based on the
+`tests/dome` test, and you should start by playing around with that test
 so that you understand how the options work, and how the tests are run. If you
 maintain the structure of this test template, your new test will work with the
 `tests/regression/build_and_test.py` structure (BATS). 

--- a/tests/ross/README.md
+++ b/tests/ross/README.md
@@ -1,7 +1,8 @@
 Ross Ice Shelf Experiment
 =========================
 
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 This experiment was designed to model the Ross Ice Shelf off Antarctica.  For
 information about the experiment and its results see:

--- a/tests/ross/plotRoss.py
+++ b/tests/ross/plotRoss.py
@@ -144,7 +144,7 @@ def main():
 
     # Read the RIGGS data
     riggs_file = open(os.path.join('data','riggs_clean.dat'))
-    latitude,longitude,riggs_velocity,glimmer_velocity = list(),list(),list(),list()
+    latitude,longitude,riggs_velocity,cism_velocity = list(),list(),list(),list()
     lat0,lon0,vel0 = list(),list(),list()
     for line in riggs_file:
         tokens = [float(data) for data in line.split()]
@@ -152,7 +152,7 @@ def main():
         lat = -(tokens[3] + tokens[4]/60 + tokens[5]/60**2)
         lon = -(tokens[6] + tokens[7]/60 + tokens[8]/60**2)*tokens[9]
         if y[1] < lat < y[-2] and x[1] < lon < x[-2]:
-            # Interpolate the Glimmer data onto this point
+            # Interpolate the CISM data onto this point
             for i in range(nx):
                 if lon < x[i+1]: break
             for j in range(ny):
@@ -168,9 +168,9 @@ def main():
                 latitude.append(lat)
                 longitude.append(lon)
                 riggs_velocity.append(tokens[10])
-                glimmer_velocity.append(v)
+                cism_velocity.append(v)
             else:
-                print( 'Glimmer velocity is zero at (%g, %g); RIGGS velocity is %g' % (lon,lat,tokens[10]))
+                print( 'CISM velocity is zero at (%g, %g); RIGGS velocity is %g' % (lon,lat,tokens[10]))
                 lat0.append(lat)
                 lon0.append(lon)
                 vel0.append(tokens[10])
@@ -182,26 +182,26 @@ def main():
     # Present the output
     # ------------------
     sigma = 30
-    X2 = sum([((v1-v2)/sigma)**2 for v1,v2 in zip(riggs_velocity,glimmer_velocity)])
+    X2 = sum([((v1-v2)/sigma)**2 for v1,v2 in zip(riggs_velocity,cism_velocity)])
     print('\n')
     print( 'Chi-squared for',len(riggs_velocity),'points is', X2)
-    print( 'The maximum velocity from Glimmer/CISM is', numpy.max(velnorm))
+    print( 'The maximum velocity from CISM is', numpy.max(velnorm))
     print( 'The maximum velocity from the RIGGS data is', max(riggs_velocity))
 
     # Create a scatter plot
     pyplot.figure(1)
     pyplot.clf()
     pyplot.plot([0,1800],[0,1800],color='red',linewidth=2,alpha=0.5)
-    pyplot.scatter(glimmer_velocity,riggs_velocity,color='blue')
+    pyplot.scatter(cism_velocity,riggs_velocity,color='blue')
     pyplot.axis('equal')
     pyplot.axis([0,1800,0,1800])
     pyplot.xticks(numpy.linspace(0.0, 1800.0, num=10, endpoint=True))
     pyplot.yticks(numpy.linspace(0.0, 1800.0, num=10, endpoint=True))
     pyplot.ylabel('Measured velocity from RIGGS (meters/year)')
-    pyplot.xlabel('Model velocity from Glimmer/CISM (meters/year)')
+    pyplot.xlabel('Model velocity from CISM (meters/year)')
     pyplot.title('Ross Ice Shelf Experiment')
 
-    # Create a color plot of Glimmer and RIGGS velocities
+    # Create a color plot of CISM and RIGGS velocities
     pyplot.figure(2)
     pyplot.clf()
     plot_discarded_points = False
@@ -234,15 +234,15 @@ def main():
     pyplot.title('Ross Ice Shelf Experiment - Velocity (meters/year)')
     print('\n')
     print( 'FIGURE 2:')
-    print( 'If Glimmer/CISM perfectly predicted the velocities measured by the Ross')
+    print( 'If CISM perfectly predicted the velocities measured by the Ross')
     print( 'Ice Shelf Geophysical and Glaciological Survey (RIGGS), the colors in')
     print( 'the circles (which represent the RIGGS velocities) would be the same as')
     print( 'the color of the background (which represents the velocities calculated')
-    print( 'by Glimmer/CISM).')
+    print( 'by CISM).')
     print('\n')
 
 
-    # Create a contour plot of Glimmer to compare to paper Figure 3.
+    # Create a contour plot of CISM to compare to paper Figure 3.
     pyplot.figure(3, facecolor='w', figsize=(12, 4), dpi=72)
     pyplot.clf()
     pyplot.subplot(1,2,1)

--- a/tests/shelf/README.md
+++ b/tests/shelf/README.md
@@ -2,7 +2,8 @@
 Shelf
 =====
 
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 This directory contains Python scripts for running idealized ice shelf
 experiments.
@@ -65,8 +66,8 @@ order core, while still present in the code, is no longer supported).
 
 The script performs the following three steps:
 
-1. Create a netCDF input file for Glimmer.
-2. Run Glimmer, creating a netCDF output file.
+1. Create a netCDF input file for CISM.
+2. Run CISM, creating a netCDF output file.
 
 The netCDF files are written into the `output` subdirectory, which is controlled
 by the `-o/--output-dir` option.
@@ -132,8 +133,8 @@ center of the domain.
 
 The script performs the following three steps:
 
-1. Create a netCDF input file for Glimmer.
-2. Run Glimmer, creating a netCDF output file.
+1. Create a netCDF input file for CISM.
+2. Run CISM, creating a netCDF output file.
 
 The netCDF files are written into the `output` subdirectory, which is controlled
 by the `-o/--output-dir` option.

--- a/tests/slab/README.md
+++ b/tests/slab/README.md
@@ -1,18 +1,88 @@
 Slab test case
 ==============
 
-WARNING: THIS TEST CASE IS IN DEVELOPMENT AND HAS NOT BEEN SCIENTIFICALLY VALIDATED.
-USE AT YOUR OWN RISK!
-
-
 This directory contains python scripts for running an experiment involving a
-uniform and infinite ice sheet ("slab") on an inclined plane.
+uniform, infinite ice sheet ("slab") on an inclined plane.
 
-The test case is described in sections 5.1-2 of:
-    J.K. Dukoqicz, 2012. Reformulating the full-Stokes ice sheet model for a
-    more efficient computational solution. The Cryosphere, 6, 21-34.
-    www.the-cryosphere.net/6/21/2012/
+The test case is described in sections 5.1-5.2 of:
+    Dukowicz, J. K., 2012, Reformulating the full-Stokes ice sheet model for a
+    more efficient computational solution. The Cryosphere, 6, 21-34,
+    doi:10.5194/tc-6-21-2012.
 
-Blatter-Pattyn First-order solution is described in J.K. Dukowicz, manuscript
-in preparation.
+Some results from this test case are described in Sect. 3.4 of:
+    Robinson, A., D. Goldberg, and W. H. Lipscomb, A comparison of the performance
+    of depth-integrated ice-dynamics solvers. Submitted to The Cryosphere, Aug. 2021.
+
+The test case consists of an ice slab of uniform thickness moving down an
+inclined plane by a combination of sliding and shearing.
+Analytic Stokes and first-order velocity solutions exist for all values of Glen's n >= 1.
+The solutions for n = 1 are derived in Dukowicz (2012), and solutions for n > 1
+are derived in an unpublished manuscript by Dukowicz (2013).
+
+The original scripts, runSlab.py and plotSlab.py, were written by Matt Hoffman
+with support for Glens' n = 1.  They came with warnings that the test is not supported.
+The test is now supported, and the scripts include some new features:
+
+* The user may specify any n >= 1 (not necessarily an integer).
+  The tests assume which_ho_efvs = 2 (nonlinear viscosity) with flow_law = 0 (constant A).
+* Physics parameters are no longer hard-coded.  The user can enter the ice thickness,
+  beta, viscosity coefficient (mu_n), and slope angle (theta) on the command line.
+* The user can specify time parameters dt (the dynamic time step) and nt (number of steps).
+  The previous version did not support transient runs.
+* The user can specify a small thickness perturbation dh, which is added to the initial
+  uniform thickness via random sampling from a Gaussian distribution.
+  The perturbation will grow or decay, depending on the solver stability for given dx and dt.
+
+The run script is executed by a command like the following:
+
+> python runSlab.py -n 4 -a DIVA -theta 0.0375 -thk 1000. -mu 1.e5 -beta 1000.
+
+In this case, the user runs on 4 processors with the DIVA solver, a slope angle of 0.0375 degrees,
+Glen's n = 1 (the default), slab thickness H = 1000 m, sliding coefficient beta = 1000 Pa (m/yr)^{-1},
+and viscosity coefficient 1.e5 Pa yr.
+These parameters correspond to the thick shearing test case described by Robinson et al. (2021).
+
+To see the full set of command-line options, type 'python runSlab.py -h'.
+
+Notes on effective viscosity:
+   * For n = 1, the viscosity coefficient mu_1 has a default value of 1.e6 Pa yr in the relation
+     mu = mu_1 * eps((1-n)/n), where eps is the effective strain rate.
+   * For n > 1, the user can specify a coefficient mu_n; otherwise the run script computes mu_n
+     such that the basal and surface speeds are nearly the same as for an n = 1 case with the
+     mu_1 = 1.e6 Pa yr and the same values of thickness, beta, and theta.
+   * There is a subtle difference between the Dukowicz and CISM definitions of the
+     effective strain rate; the Dukowicz value is twice as large. Later, it might be helpful
+     to make the Dukowicz convention consistent with CISM.)
+
+The plotting script, plotSlab.py, is run by typing 'python plotSlab.py'.  It creates two plots.
+The first plot shows the vertical velocity profile in nondimensional units and in units of m/yr.
+There is excellent agreement between higher-order CISM solutions and the analytic solution
+for small values of the slope angle theta.  For steep slopes, the answers diverge as expected.
+
+For the second plot, the extent of the y-axis is wrong. This remains to be fixed.
+
+This directory also includes a new script, stabilitySlab.py, to carry out the stability tests
+described in Robinson et al. (2021).
+
+For a given set of physics parameters and stress-balance approximation (DIVA, L1L2, etc.),
+the script launches multiple CISM runs at a range of grid resolutions.
+At each grid resolution, the script determines the maximum stable time step.
+A run is deemed stable when the standard deviation of an initial small thickness perturbation
+is reduced over the course of 100 time steps.  A run is unstable if the standard deviation
+increases or if the model aborts (usually with a CFL violation).
+
+To run the stability script, type a command like the following:
+
+> python stabilitySlab.py -n 4 -a DIVA -theta 0.0375 -thk 1000. -mu 1.e5 -beta 1000.  \
+  -dh 0.1 -nt 100 -nr 12 -rmin 10. -rmax 40000.
+
+Here, the first few commands correspond to the thick shearing test case and are passed repeatedly
+to the run script.  The remaining commands specify that each run will be initialized
+with a Gaussian perturbation of amplitude 0.1 m and run for 100 timesteps.
+The maximum stable timestep will be determined at 12 resolutions ranging from 10m to 40 km.
+This test takes several minutes to complete on a Macbook Pro with 4 cores.
+
+To see the full set of commmand line options, type 'python stabilitySlab.py -h'.
+
+For questions, please contact Willian Lipscomb (lipscomb@ucar.edu) or Gunter Leguy (gunterl@ucar.edu).
 

--- a/tests/slab/README.md
+++ b/tests/slab/README.md
@@ -1,6 +1,9 @@
 Slab test case
 ==============
 
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
+
 This directory contains python scripts for running an experiment involving a
 uniform, infinite ice sheet ("slab") on an inclined plane.
 
@@ -9,9 +12,10 @@ The test case is described in sections 5.1-5.2 of:
     more efficient computational solution. The Cryosphere, 6, 21-34,
     doi:10.5194/tc-6-21-2012.
 
-Some results from this test case are described in Sect. 3.4 of:
-    Robinson, A., D. Goldberg, and W. H. Lipscomb, A comparison of the performance
-    of depth-integrated ice-dynamics solvers. Submitted to The Cryosphere, Aug. 2021.
+Some CISM results from this test case are described in Sect. 3.4 of:
+    Robinson, A., D. Goldberg, and W. H. Lipscomb, 2022, A comparison of the
+    stability and performance of depth-integrated ice-dynamics solvers.
+    The Cryosphere, 16, 689-709, doi:10.5194/tc-16-689-2022.
 
 The test case consists of an ice slab of uniform thickness moving down an
 inclined plane by a combination of sliding and shearing.
@@ -20,7 +24,7 @@ The solutions for n = 1 are derived in Dukowicz (2012), and solutions for n > 1
 are derived in an unpublished manuscript by Dukowicz (2013).
 
 The original scripts, runSlab.py and plotSlab.py, were written by Matt Hoffman
-with support for Glen's n = 1.  They came with warnings that the test is not supported.
+with support for n = 1.  They came with warnings that the test is not supported.
 The test is now supported, and the scripts include some new features:
 
 * The user may specify any n >= 1 (not necessarily an integer).
@@ -54,7 +58,7 @@ Notes on effective viscosity:
      effective strain rate; the Dukowicz value is twice as large. Later, it might be helpful
      to make the Dukowicz convention consistent with CISM.
 
-The plotting script, plotSlab.py, is run by typing 'python plotSlab.py'.  It creates two plots.
+Run the plotting script, plotSlab.py, by typing 'python plotSlab.py'.  Two plots should appear.
 The first plot shows the vertical velocity profile in nondimensional units and in units of m/yr.
 There is excellent agreement between higher-order CISM solutions and the analytic solution
 for small values of the slope angle theta.  For steep slopes, the answers diverge as expected.
@@ -84,4 +88,3 @@ This test takes several minutes to complete on a Macbook Pro with 4 cores.
 To see the full set of commmand line options, type 'python stabilitySlab.py -h'.
 
 For questions, please contact William Lipscomb (lipscomb@ucar.edu) or Gunter Leguy (gunterl@ucar.edu).
-

--- a/tests/slab/README.md
+++ b/tests/slab/README.md
@@ -20,7 +20,7 @@ The solutions for n = 1 are derived in Dukowicz (2012), and solutions for n > 1
 are derived in an unpublished manuscript by Dukowicz (2013).
 
 The original scripts, runSlab.py and plotSlab.py, were written by Matt Hoffman
-with support for Glens' n = 1.  They came with warnings that the test is not supported.
+with support for Glen's n = 1.  They came with warnings that the test is not supported.
 The test is now supported, and the scripts include some new features:
 
 * The user may specify any n >= 1 (not necessarily an integer).
@@ -35,9 +35,9 @@ The test is now supported, and the scripts include some new features:
 
 The run script is executed by a command like the following:
 
-> python runSlab.py -n 4 -a DIVA -theta 0.0375 -thk 1000. -mu 1.e5 -beta 1000.
+> python runSlab.py -n 4 -a DIVA -theta 0.0573 -thk 1000. -mu 1.e5 -beta 1000.
 
-In this case, the user runs on 4 processors with the DIVA solver, a slope angle of 0.0375 degrees,
+In this case, the user runs on 4 processors with the DIVA solver, a slope angle of 0.0573 degrees,
 Glen's n = 1 (the default), slab thickness H = 1000 m, sliding coefficient beta = 1000 Pa (m/yr)^{-1},
 and viscosity coefficient 1.e5 Pa yr.
 These parameters correspond to the thick shearing test case described by Robinson et al. (2021).
@@ -52,7 +52,7 @@ Notes on effective viscosity:
      mu_1 = 1.e6 Pa yr and the same values of thickness, beta, and theta.
    * There is a subtle difference between the Dukowicz and CISM definitions of the
      effective strain rate; the Dukowicz value is twice as large. Later, it might be helpful
-     to make the Dukowicz convention consistent with CISM.)
+     to make the Dukowicz convention consistent with CISM.
 
 The plotting script, plotSlab.py, is run by typing 'python plotSlab.py'.  It creates two plots.
 The first plot shows the vertical velocity profile in nondimensional units and in units of m/yr.
@@ -63,9 +63,8 @@ For the second plot, the extent of the y-axis is wrong. This remains to be fixed
 
 This directory also includes a new script, stabilitySlab.py, to carry out the stability tests
 described in Robinson et al. (2021).
-
 For a given set of physics parameters and stress-balance approximation (DIVA, L1L2, etc.),
-the script launches multiple CISM runs at a range of grid resolutions.
+this script launches multiple CISM runs at a range of grid resolutions.
 At each grid resolution, the script determines the maximum stable time step.
 A run is deemed stable when the standard deviation of an initial small thickness perturbation
 is reduced over the course of 100 time steps.  A run is unstable if the standard deviation
@@ -84,5 +83,5 @@ This test takes several minutes to complete on a Macbook Pro with 4 cores.
 
 To see the full set of commmand line options, type 'python stabilitySlab.py -h'.
 
-For questions, please contact Willian Lipscomb (lipscomb@ucar.edu) or Gunter Leguy (gunterl@ucar.edu).
+For questions, please contact William Lipscomb (lipscomb@ucar.edu) or Gunter Leguy (gunterl@ucar.edu).
 

--- a/tests/slab/plotSlab.py
+++ b/tests/slab/plotSlab.py
@@ -31,7 +31,7 @@ from math import tan, pi, sin, cos, atan
 # Get hard-coded parameters from the run script.
 from runSlab import rhoi, grav
 
-import ConfigParser
+import configparser
 
 import argparse
 parser = argparse.ArgumentParser(description=__doc__,
@@ -168,13 +168,13 @@ def main():
     # Get gn and default_flwa from the config file
 
     try:
-        config_parser = ConfigParser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_parser.read( configpath )
 
         gn = float(config_parser.get('parameters','n_glen'))
         flwa = float(config_parser.get('parameters', 'default_flwa'))
 
-    except ConfigParser.Error as error:
+    except configparser.Error as error:
         print("Error parsing " + args.config )
         print("   "),
         print(error)

--- a/tests/slab/plotSlab.py
+++ b/tests/slab/plotSlab.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-
 """
 This script plots the results of an experiment with an ice "slab" on an
 inclined plane. Test case is described in sections 5.1-2 of:
-    J.K. Dukoqicz, 2012. Reformulating the full-Stokes ice sheet model for a
+    J.K. Dukowicz, 2012. Reformulating the full-Stokes ice sheet model for a
     more efficient computational solution. The Cryosphere, 6, 21-34.
     www.the-cryosphere.net/6/21/2012/
 
@@ -12,13 +11,12 @@ Blatter-Pattyn First-order solution is described in J.K. Dukowicz, manuscript
 in preparation.
 """
 #FIXME: Manuscript likely not in prep anymore -- JHK, 08/07/2015
+#       Not published as of July 2021 -- WHL
 
 # Written by Matt Hoffman, Dec. 16, 2013
 # Reconfigured by Joseph H Kennedy at ORNL on August 7, 2015 to work with the regression testing
 #     NOTE: Did not adjust inner workings except where needed.
-
-
-#NOTE: this script is assuming n=3, but more general solutions are available.
+# Revised by William Lipscomb in 2021 to support more options, including general values of Glen's n.
 
 import os
 import sys
@@ -28,8 +26,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from netCDF import *
-from math import tan, pi, sin, cos
-from runSlab import n, rhoi, grav, theta, beta, efvs, thickness  # Get the values used to run the experiment
+from math import tan, pi, sin, cos, atan
+
+# Get hard-coded parameters from the run script.
+from runSlab import rhoi, grav
+
+import ConfigParser
 
 import argparse
 parser = argparse.ArgumentParser(description=__doc__,
@@ -46,16 +48,15 @@ parser.add_argument('-f', '--output-file',
         help="The tests output file you would like to plot. If a path is" \
         +"passed via this option, the -o/--output-dir option will be ignored.")
 
+parser.add_argument('-c','--config-file',
+        help="The configure file used to set up the test case and run CISM")
+
 
 # ===========================================================
 # Define some variables and functions used in the main script
 # ===========================================================
 
-# Calculate scales from Ducowicz unpub. man.
-eta = beta * thickness * efvs**-n * (rhoi * grav * thickness)**(n-1) 
-velscale = (rhoi * grav * thickness / efvs)**n * thickness
-thetar = theta * pi/180.0  # theta in radians
-
+#WHL args.output-file with a hyphen?
 def get_in_file():
     if args.output_file:
         out_d, out_f = os.path.split(args.output_file)
@@ -76,7 +77,7 @@ def get_in_file():
             newest = max(matching, key=os.path.getmtime)
             print("\nWARNING: MULTIPLE *.out.nc FILES DETECTED!")
             print(  "==========================================")
-            print(  "Ploting the most recently modified file in the output directory:")
+            print(  "Plotting the most recently modified file in the output directory:")
             print(  "    "+newest)
             print(  "To plot another file, specify it with the -f/--outfile option.\n")
             
@@ -94,6 +95,25 @@ def get_in_file():
      
     return filein
 
+def split_file_name(file_name):
+    """
+    Get the root name, size, and number of processors from an out.nc filename.
+    #WHL - Adapted from plotISMIP_HOM.py
+    """
+    root = ''
+    size = ''
+    proc = ''
+
+    file_details = file_name.replace('.out.nc','') .split('.')
+#    print(file_details)
+#    print('len = ' + str(len(file_details)))
+
+    if len(file_details) > 2:
+        proc = '.'+file_details[2]
+    size = '.'+file_details[1]
+    root = file_details[0]
+
+    return (root, size, proc)
 
 # =========================
 # Actual script starts here
@@ -103,10 +123,7 @@ def main():
     Plot the slab test results.
     """
 
-    print("WARNING: THIS TEST CASE IS IN DEVELOPMENT. USE AT YOUR OWN RISK!")
-
-
-    filein = get_in_file()    
+    filein = get_in_file()
 
     # Get needed variables from the output file
     x1 = filein.variables['x1'][:]
@@ -120,28 +137,96 @@ def main():
     # use integer floor division operator to get an index close to the center 
     xp = len(x0)//2
     yp = len(y0)//2
-    #yp = 15
-    #xp = 15
     # =====================================================================
+
     print('Using x index of '+str(xp)+'='+str(x0[xp]))
     print('Using y index of '+str(yp)+'='+str(y0[yp]))
 
     thk = filein.variables['thk'][:]
     if netCDF_module == 'Scientific.IO.NetCDF':
-       thk = thk * filein.variables['thk'].scale_factor
+        thk = thk * filein.variables['thk'].scale_factor
     topg = filein.variables['topg'][:]
     if netCDF_module == 'Scientific.IO.NetCDF':
-       topg = topg * filein.variables['topg'].scale_factor
+        topg = topg * filein.variables['topg'].scale_factor
     uvel = filein.variables['uvel'][:]
     if netCDF_module == 'Scientific.IO.NetCDF':
-       uvel = uvel * filein.variables['uvel'].scale_factor
+        uvel = uvel * filein.variables['uvel'].scale_factor
+    beta_2d = filein.variables['beta'][:]
+    if netCDF_module == 'Scientific.IO.NetCDF':
+        beta_2d = beta_2d * filein.variables['beta'].scale_factor
 
+    # Get the name of the config file
+    # If not entered on the command line, then construct from the output filename
+
+    if not args.config_file:
+        root, size, proc = split_file_name(args.output_file)
+        args.config_file = root + size + proc + '.config'
+
+    configpath = os.path.join(args.output_dir, args.config_file)
+    print('configpath = ' + configpath)
+
+    # Get gn and default_flwa from the config file
+
+    try:
+        config_parser = ConfigParser.SafeConfigParser()
+        config_parser.read( configpath )
+
+        gn = float(config_parser.get('parameters','n_glen'))
+        flwa = float(config_parser.get('parameters', 'default_flwa'))
+
+    except ConfigParser.Error as error:
+        print("Error parsing " + args.config )
+        print("   "),
+        print(error)
+        sys.exit(1)
+
+    # Derive the viscosity constant mu_n from flwa
+    # This expression is derived in the comments on flwa in runSlab.py.
+    mu_n = 1.0 / (2.0**((1.0+gn)/(2.0*gn)) * flwa**(1.0/gn))
+
+    # Get the ice thickness from the output file.
+    # If thickness = constant (i.e., the optional perturbation dh = 0), it does not matter where we sample.
+    # Note: In general, this thickness will differ from the baseline 'thk' that is used in runSlab.py
+    #        to create the input file.
+    #       This is because the baseline value is measured perpendicular to the sloped bed,
+    #        whereas the CISM value is in the vertical direction, which is not perpendicular to the bed.
+    thickness = thk[0,yp,xp]
+
+    # Get beta from the output file.
+    # Since beta = constant, it does not matter where we sample.
+    beta = beta_2d[0,yp,xp]
+
+    # Derive theta from the output file as atan(slope(topg))
+    # Since the slope is constant, it does not matter where we sample.
+    slope = (topg[0,yp,xp] - topg[0,yp,xp+1]) / (x0[xp+1] - x0[xp])
+    thetar = atan(slope)
+    theta = thetar * 180.0/pi
+
+    # Compute the dimensionless parameter eta and the velocity scale,
+    # which appear in the scaled velocity solution.
+    eta = (beta * thickness / mu_n**gn) * (rhoi * grav * thickness)**(gn-1)
+    velscale = (rhoi * grav * thickness / mu_n)**gn * thickness
+
+    print('gn   = ' + str(gn))
+    print('rhoi = ' + str(rhoi))
+    print('grav = ' + str(grav))
+    print('thck = ' + str(thickness))
+    print('mu_n = ' + str(mu_n))
+    print('flwa = ' + str(flwa))
+    print('beta = ' + str(beta))
+    print('eta  = '  + str(eta))
+    print('theta= ' + str(theta))
+    print('velscale = ' + str(velscale))
 
     # === Plot the results at the given location ===
     # Note we are not plotting like in Fig 3 of paper.
     # That figure plotted a profile against zprime.
     # It seemed more accurate to plot a profile against z to avoid interpolating model results (analytic solution can be calculated anywhere).
-    # Also, the analytic solution calculates the bed-parallel u velocity, but CISM calculates u as parallel to the geoid, so we need to transform the analytic solution to the CISM coordinate system.
+    # Also, the analytic solution calculates the bed-parallel u velocity, but CISM calculates u as parallel to the geoid,
+    #  so we need to transform the analytic solution to the CISM coordinate system.
+
+    #WHL - I think the analytic solution is actually for u(z'), which is not bed-parallel.
+    #      The bed-parallel solution would be u'(z'), with w'(z') = 0.
 
     fig = plt.figure(1, facecolor='w', figsize=(12, 6))
 
@@ -151,24 +236,23 @@ def main():
     x = (x0-x0[xp]) / thickness
     # calculate rotated zprime coordinates for this column (we assume the solution truly is spatially uniform)
     zprime = x[xp] * sin(thetar) + z * cos(thetar)
-    #print 'zprime', zprime
 
     # Calculate analytic solution for x-component of velocity (eq. 39 in paper) for the CISM-column
-    #uvelStokesAnalyticScaled =  sin(theta * pi/180.0) * cos(theta * pi/180.0) * (0.5 * zprime**2 - zprime - 1.0/eta)
-    uvelStokesAnalyticScaled = (-1)**n * 2**((1.0-n)/2.0) * sin(thetar)**n * cos(thetar) / (n+1) \
-                    * ( (zprime - 1.0)**(n+1) - (-1.0)**(n+1) ) + sin(thetar) * cos(thetar) / eta
+    uvelStokesAnalyticScaled = sin(thetar) * cos(thetar) / eta   \
+        - 2**((1.0-gn)/2.0) * sin(thetar)**gn * cos(thetar) / (gn+1) * ( (1.0 - zprime)**(gn+1) - 1.0 )
 
-    # Calculate the BP FO solution for x-component of velocity (Ducowicz, in prep. paper, Eq.30, n=3)
-    #uvelFOAnalyticScaled = (tan(theta * pi/180.0))**3 / (8.0 * (1.0 + 3.0 * (sin(theta * pi/180.0)**2))**2) \
-    uvelFOAnalyticScaled = (-1)**n * 2**((1.0-n)/2.0) * tan(thetar)**n /  \
-                           ( (n + 1) * (1.0 + 3.0 * sin(thetar)**2)**((n+1.0)/2.0) )  \
-                           * ( (zprime - 1.0)**(n+1) - (-1.0)**(n+1) ) + tan(thetar) / eta
+    # Calculate the BP FO solution for x-component of velocity (Dukowicz, in prep. paper, Eq.30, n=3)
+    uvelFOAnalyticScaled = + tan(thetar) / eta  \
+                           -  2**((1.0-gn)/2.0) * tan(thetar)**gn /  \
+                           ( (gn + 1) * (1.0 + 3.0 * sin(thetar)**2)**((gn+1.0)/2.0) )  \
+                           * ( (1.0 - zprime)**(gn+1) - 1.0 )
 
     ### 1. Plot as nondimensional variables
     # Plot analytic solution 
     fig.add_subplot(1,2,1)
     plt.plot(uvelStokesAnalyticScaled, z, '-kx', label='Analytic Stokes')
     plt.plot(uvelFOAnalyticScaled, z, '-ko', label='Analytic FO')
+
     # Plot model results
     plt.plot(uvel[0,:,yp,xp] / velscale, z, '--ro', label='CISM') 
     plt.ylim((-0.05, 1.05))
@@ -191,7 +275,16 @@ def main():
     plt.title('Velocity profile at x=' + str(x0[xp]) + ' m, y=' + str(y0[yp]) + ' m\n(Unscaled coordinates)')
 
     #################
+#    print('y0_min:')
+#    print(y0.min())
+#    print('y0_max:')
+#    print(y0.max())
+
     # Now plot maps to show if the velocities vary over the domain (they should not)
+    # For some reason, the y-axis has a greater extent than the range (y0.min, y0.max).
+    #TODO - Fix the y-axis extent.  Currently, the extent is too large for small values of ny.
+    #TODO - Plot the thickness relative to the initial thickness.
+
     fig = plt.figure(2, facecolor='w', figsize=(12, 6))
     fig.add_subplot(1,2,1)
     uvelDiff = uvel[0,0,:,:] - uvel[0,0,yp,xp]
@@ -224,13 +317,10 @@ def main():
     #plt.plot(level, tan(thetar)**3 / (8.0 * (1.0 + 3.0 * sin(thetar)**2)**2) * (1.0 - (level-1.0)**4 ) + tan(thetar)/eta, 'b--' , label='nonlinear fo')
     #plt.ylim((0.0, 0.04)); plt.xlabel("z'"); plt.ylabel('u'); plt.legend()
 
-
     plt.draw()
     plt.show()
 
     filein.close()
-
-    print("WARNING: THIS TEST CASE IS IN DEVELOPMENT. USE AT YOUR OWN RISK!")
 
 # Run only if this is being run as a script.
 if __name__=='__main__':
@@ -240,4 +330,3 @@ if __name__=='__main__':
     
     # run the script
     sys.exit(main())
-

--- a/tests/slab/runSlab.py
+++ b/tests/slab/runSlab.py
@@ -62,7 +62,7 @@ parser.add_argument('-s','--setup-only', action='store_true',
 #      Rather, mu_n is computed below, unless mu_n > 0 is specified in the command line.
 #      For n = 1, the default is mu_1 = 1.0e6 Pa yr.
 parser.add_argument('-a','--approx', default='DIVA',
-        help="Stokes approximation (SIALOC, SIA, SSA, BP, L1L2, DIVA)")
+        help="Stokes approximation (SIALOC, SIA, SSA, BP, L1L2, DIVA, HYBRID)")
 parser.add_argument('-beta','--beta', default=2000.0,
         help="Friction parameter beta (Pa (m/yr)^{-1})")
 parser.add_argument('-dh','--delta_thck', default=0.0,
@@ -324,6 +324,8 @@ def main():
         approx = 3
     elif (args.approx == 'DIVA'):
         approx = 4
+    elif (args.approx == 'HYBRID'):
+        approx = 5
     config_parser.set('ho_options', 'which_ho_approx', str(approx))
 
     config_parser.set('CF input', 'name', file_name)

--- a/tests/slab/runSlab.py
+++ b/tests/slab/runSlab.py
@@ -12,14 +12,18 @@ Run an experiment with an ice "slab".
 #    more efficient computational solution. The Cryosphere, 6, 21-34,
 #    https://doi.org/10.5194/tc-6-21-2012.
 # Reconfigured by Joseph H Kennedy at ORNL on April 27, 2015 to work with the regression testing.
+#
 # Revised by William Lipscomb in 2021 to support more options.
+# CISM results are described in this paper:
+#    Robinson, A., D. Goldberg, and W. H. Lipscomb, 2022, A comparison of the
+#    stability and performance of depth-integrated ice-dynamics solvers.
+#    The Cryosphere, 16, 689-709, doi:10.5194/tc-16-689-2022.
 
 import os
 import sys
 import errno
 import subprocess
-import configparser 
-
+import configparser
 import numpy as np
 import netCDF
 
@@ -172,7 +176,7 @@ def main():
         file_name = config_parser.get('CF input', 'name')
         root, ext = os.path.splitext(file_name)
 
-    except ConfigParser.Error as error:
+    except configparser.Error as error:
         print("Error parsing " + args.config )
         print("   "), 
         print(error)
@@ -358,8 +362,8 @@ def main():
     nc_file.createVariable('time','f',('time',))[:] = [0]
     nc_file.createVariable('x1','f',('x1',))[:] = x
     nc_file.createVariable('y1','f',('y1',))[:] = y
-    nc_file.createVariable('x0','f',('x0',))[:] = dx/2 + x[:-1] # staggered grid
-    nc_file.createVariable('y0','f',('y0',))[:] = dy/2 + y[:-1]
+    nc_file.createVariable('x0','f',('x0',))[:] = dx//2 + x[:-1] # staggered grid
+    nc_file.createVariable('y0','f',('y0',))[:] = dy//2 + y[:-1]
 
     # Calculate values for the required variables.
     thk  = np.zeros([1,ny,nx],dtype='float32')
@@ -406,7 +410,7 @@ def main():
 ##            dthk = dh * sin((float(i) - 0.5)*pi)
 
             thk[0,:,i] = thk[0,:,i] + dthk
-            print(i, dthk, thk[0,ny/2,i])
+            print(i, dthk, thk[0,ny//2,i])
             thk_in = thk   # for comparing later to final thk
 
 

--- a/tests/slab/slab.config
+++ b/tests/slab/slab.config
@@ -1,30 +1,34 @@
 [grid]
-upn = 50
+upn = 20
 ewn = 30
-nsn = 20
+nsn = 5
 dew = 50
 dns = 50
 
 [time]
 tstart = 0.
 tend = 0.
-dt = 1.
+dt = 0.01
+dt_diag = 0.01
+idiag = 15
+jdiag = 5
 
 [options]
-dycore = 2              # 1 = glam, 2 = glissade
-flow_law = 0            # 0 = constant
+dycore = 2              # 2 = glissade
+flow_law = 0            # 0 = constant flwa (default = 1.e-16 Pa-n yr-1)
 evolution = 3           # 3 = remapping
-temperature = 1         # 1 = prognostic, 3 = enthalpy
+temperature = 1         # 1 = prognostic
+basal_mass_balance = 0  # 0 = basal mbal not in continuity eqn
 
 [ho_options]
 which_ho_babc = 5       # 5 = externally-supplied beta(required by test case)
-which_ho_efvs = 0       # 0 = constant (required by test case - makes n effectively 1)
-which_ho_sparse = 3     # 1 = SLAP GMRES, 3 = glissade parallel PCG, 4 = Trilinos for linear solver
+which_ho_sparse = 3     # 1 = SLAP GMRES, 3 = glissade parallel PCG
 which_ho_nonlinear = 0  # 0 = Picard, 1 = accelerated Picard
+which_ho_approx = 4     # 2 = BP, 3 = L1L2, 4 = DIVA
 
 [parameters]
 ice_limit = 1.          # min thickness (m) for dynamics
-periodic_offset_ew = 487.379544349
+geothermal = 0.
 
 [CF default]
 comment = created with slab.py

--- a/tests/slab/slab.config
+++ b/tests/slab/slab.config
@@ -42,4 +42,3 @@ time = 1
 variables = thk usurf uvel vvel velnorm topg beta
 frequency = 1
 name = slab.out.nc
-

--- a/tests/slab/stabilitySlab.py
+++ b/tests/slab/stabilitySlab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """
@@ -8,8 +8,9 @@ A run is deemed to be stable if the standard deviation of a small thickness pert
 decreases during a transient run (100 timesteps by default).
  
 Used to obtain the CISM stability results described in:
-Robinson, A., D. Goldberg, and W. H. Lipscomb, A comparison of the performance
-of depth-integrated ice-dynamics solvers, to be submitted.
+    Robinson, A., D. Goldberg, and W. H. Lipscomb, 2022, A comparison of the
+    stability and performance of depth-integrated ice-dynamics solvers.
+    The Cryosphere, 16, 689-709, doi:10.5194/tc-16-689-2022.
 """
 
 # Authors
@@ -20,7 +21,6 @@ import os
 import sys
 import errno
 import subprocess
-import ConfigParser
 
 import numpy as np
 import netCDF
@@ -296,7 +296,7 @@ def main():
                 filein = netCDF.NetCDFFile(outpath,'r')
                 thk = filein.variables['thk'][:]
 
-                j = ny/2
+                j = ny//2
                 thk_in = thk[0,j,:]
                 thk_out = thk[1,j,:]
 

--- a/tests/slab/stabilitySlab.py
+++ b/tests/slab/stabilitySlab.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+"""
+This script runs a series of CISM experiments at different resolutions.
+At each resolution, it determines the maximum stable time step.
+A run is deemed to be stable if the standard deviation of a small thickness perturbation
+decreases during a transient run (100 timesteps by default).
+ 
+Used to obtain the CISM stability results described in:
+Robinson, A., D. Goldberg, and W. H. Lipscomb, A comparison of the performance
+of depth-integrated ice-dynamics solvers, to be submitted.
+"""
+
+# Authors
+# -------
+# Created by William Lipscomb, July 2021
+
+import os
+import sys
+import errno
+import subprocess
+import ConfigParser
+
+import numpy as np
+import netCDF
+from math import sqrt, log10
+
+# Parse the command line options                                                                                                                   
+# ------------------------------                                                                                                                   
+import argparse
+parser = argparse.ArgumentParser(description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+# small helper function so argparse will understand unsigned integers                                                                              
+def unsigned_int(x):
+    x = int(x)
+    if x < 1:
+        raise argparse.ArgumentTypeError("This argument is an unsigned int type! Should be an integer greater than zero.")
+    return x
+
+# The following command line arguments determine the set of resolutions to run the slab test.
+# At each resolution, we aim to find the maximum stable time step.
+# Note: If args.n_resolution > 1, then args.resolution (see below) is ignored.
+
+parser.add_argument('-nr','--n_resolution', default=1,
+        help="number of resolutions")
+parser.add_argument('-rmin','--min_resolution', default=10.0,
+        help="minimum resolution (m)")
+parser.add_argument('-rmax','--max_resolution', default=40000.0,
+        help="minimum resolution (m)")
+
+# The following command line arguments are the same as in runSlab.py.
+# Not sure how to avoid code repetition.
+
+parser.add_argument('-c','--config', default='./slab.config', 
+        help="The configure file used to setup the test case and run CISM")
+parser.add_argument('-e','--executable', default='./cism_driver', 
+        help="The CISM driver")
+parser.add_argument('-m', '--modifier', metavar='MOD', default='',
+        help="Add a modifier to file names. FILE.EX will become FILE.MOD.EX")
+parser.add_argument('-n','--parallel', metavar='N', type=unsigned_int, default=0, 
+        help="Run in parallel using N processors.")
+parser.add_argument('-o', '--output_dir',default='./output',
+        help="Write all created files here.")
+parser.add_argument('-a','--approx', default='BP',
+        help="Stokes approximation (SIA, SSA, BP, L1L2, DIVA)")
+parser.add_argument('-beta','--beta', default=2000.0,
+        help="Friction parameter beta (Pa (m/yr)^{-1})")
+parser.add_argument('-dh','--delta_thck', default=0.0,
+        help="Thickness perturbation (m)")
+parser.add_argument('-dt','--tstep', default=0.01,
+        help="Time step (yr)")
+parser.add_argument('-gn','--glen_exponent', default=1,
+        help="Exponent in Glen flow law")
+parser.add_argument('-l','--levels', default=10,
+        help="Number of vertical levels")
+parser.add_argument('-mu','--mu_n', default=0.0,
+        help="Viscosity parameter mu_n (Pa yr^{1/n})")
+parser.add_argument('-nt','--n_tsteps', default=0,
+        help="Number of timesteps")
+parser.add_argument('-nx','--nx_grid', default=50,
+       help="Number of grid cells in x direction")
+parser.add_argument('-ny','--ny_grid', default=5,
+        help="Number of grid cells in y direction")
+parser.add_argument('-r','--resolution', default=100.0,
+        help="Grid resolution (m)")
+parser.add_argument('-theta','--theta', default=5.0,
+        help="Slope angle (deg)")
+parser.add_argument('-thk','--thickness', default=1000.0,
+        help="Ice thickness")
+
+                        ############
+                        # Functions #
+                        ############
+
+def reading_file(inputFile):
+
+    #Check whether a netCDF file exists, and return a list of times in the file
+
+    ReadVarFile = True 
+    try:
+        filein = netCDF.NetCDFFile(inputFile,'r')
+        time = filein.variables['time'][:]
+        filein.close()
+        print('Was able to read file ' + inputFile)
+        print(time)
+    except:
+        ReadVarFile = False
+        time = [0.]
+        print('Was not able to read file' + inputFile)
+
+    return time, ReadVarFile
+
+
+def check_output_file(outputFile, time_end):
+
+    # Check that the output file exists with the expected final time slice
+
+    # Path to experiment
+    path_to_slab_output = './output/'
+
+    # File to check
+    filename = path_to_slab_output + outputFile
+
+    # Read the output file
+    print('Reading file ' + str(filename))
+    time_var, VarRead = reading_file(filename)
+
+#    print(time_var)
+
+    # Checking that the last time entry is the same as we expect from time_end
+    # Allow for a small roundoff difference.
+    if abs(time_var[-1] - time_end) < 1.0e-7:
+        check_time_var = True
+    else:
+        check_time_var = False
+
+    print('time_end = ' + str(time_end))
+    print('last time in file = ' + str(time_var[-1]))
+
+    # Creating the status of both checks 
+    check_passed = check_time_var and VarRead
+
+    if check_passed:
+        print('Found output file with expected file time slice')
+    else:
+        if (not VarRead):
+            print('Output file cannot be read')
+        else:
+            if not check_time_var:
+                print('Output file is missing time slices')
+    
+    return check_passed
+
+
+def main():
+
+    print('In main')
+
+    """
+    For each of several values of the horizontal grid resolution, determine the maximum
+    stable time step for a given configuration of the slab test.
+    """
+
+    resolution = []
+
+    # Based on the input arguments, make a list of resolutions at which to run the test.
+    # The formula and the default values of rmin and rmax give resolutions agreeing with
+    #  those used by Alex Robinson for Yelmo, for the case nres = 12:
+    #  resolution = [10., 21., 45., 96., 204., 434., 922., 1960., 4170., 8850., 18800., 40000.]
+
+    print('Computing resolutions')
+    print(args.n_resolution)
+    if int(args.n_resolution) > 1:
+        nres = int(args.n_resolution)
+        resolution = [0. for n in range(nres)]
+        rmin = float(args.min_resolution)
+        rmax = float(args.max_resolution)
+        for n in range(nres):
+            res = 10.0**(log10(rmin) + (log10(rmax) - log10(rmin))*float(n)/float(nres-1))
+            # Round to 3 significant figures (works for log10(res) < 5)
+            if log10(res) > 4.:
+                resolution[n] = round(res, -2)
+            elif log10(res) > 3.:
+                resolution[n] = round(res, -1)
+            else:
+                resolution[n] = round(res)
+    else:
+        nres = 1
+        resolution.append(float(args.resolution))
+
+    print('nres = ' + str(nres))
+    print(resolution)
+
+    # Create an array to store max time step for each resolution
+    rows, cols = (nres, 2)
+    res_tstep = [[0. for i in range(cols)] for j in range(rows)]
+    for n in range(nres):
+        res_tstep[n][0] = resolution[n]
+
+    for n in range(nres):
+
+        print('output_dir: ' + args.output_dir)
+
+        # Construct the command for calling the main runSlab script
+        run_command = 'python runSlab.py'
+        run_command = run_command + ' -c '  + args.config
+        run_command = run_command + ' -e '  + args.executable
+        if args.parallel > 0:
+            run_command = run_command + ' -n '  + str(args.parallel)
+        run_command = run_command + ' -o '  + args.output_dir
+        run_command = run_command + ' -a '  + args.approx
+        run_command = run_command + ' -beta ' + str(args.beta)
+        run_command = run_command + ' -dh ' + str(args.delta_thck)
+        run_command = run_command + ' -gn ' + str(args.glen_exponent)
+        run_command = run_command + ' -l '  + str(args.levels)
+        run_command = run_command + ' -mu ' + str(args.mu_n)
+        run_command = run_command + ' -nt ' + str(args.n_tsteps)
+        run_command = run_command + ' -nx ' + str(args.nx_grid)
+        run_command = run_command + ' -ny ' + str(args.ny_grid)
+        run_command = run_command + ' -theta '+ str(args.theta)
+        run_command = run_command + ' -thk '+ str(args.thickness)
+
+        tend = float(args.n_tsteps) * args.tstep
+
+        res = resolution[n]
+        run_command = run_command + ' -r '  + str(res)
+         
+        # Choose the time step.
+        # Start by choosing a very small timestep that can be assumed stable
+        #  and a large step that can be assumed unstable.
+        # Note: SIA-type solvers at 10m resolution can require dt <~ 1.e-6 yr.
+
+        tstep_lo = 1.0e-7
+        tstep_hi = 1.0e+5
+        tstep_log_precision = 1.0e-4
+        print('Initial tstep_lo = ' + str(tstep_lo))
+        print('Initial tstep_hi = ' + str(tstep_hi))
+        print('Log precision = ' + str(tstep_log_precision))
+
+        while (log10(tstep_hi) - log10(tstep_lo)) > tstep_log_precision:
+
+            # Compute the time step as the geometric mean of the tstep_lo and tstep_hi.
+            # tstep_lo is the largest time step known to be stable.
+            # tstep_hi is the smallest time step known to be unstable.
+
+            tstep = sqrt(tstep_lo*tstep_hi)
+    
+            run_command_full = run_command + ' -dt ' + str(tstep)
+
+            print("\nRunning CISM slab test...")
+            print('resolution = ' + str(res))
+            print('tstep = ' + str(tstep))
+            print('run_command = ' + run_command_full)
+
+            process = subprocess.check_call(run_command_full, shell=True)
+
+            print("\nFinished running the CISM slab test")
+
+            # Determine the name of the output file.
+            # Must agree with naming conventions in runSlab.py
+
+            file_name = args.config
+            root, ext = os.path.splitext(file_name)
+
+            res=str(int(res)).zfill(5)  # 00100 for 100m, 01000 for 1000m, etc.
+
+            if args.parallel > 0:
+                mod = args.modifier + '.' + res + '.p' + str(args.parallel).zfill(3)
+            else:
+                mod = args.modifier + '.' + res
+
+            outputFile = root + mod + '.out.nc'
+
+            # Check whether the output file exists with the desired final time slice.
+
+            time_end = float(args.n_tsteps) * tstep
+
+            print('outputFile = ' + str(outputFile))
+            print('n_tsteps = ' + str(float(args.n_tsteps)))
+            print('tstep = ' + str(tstep))
+            print('time_end = ' + str(time_end))
+
+            check_passed = check_output_file(outputFile, time_end)
+
+            if check_passed:
+
+                print('Compute stdev of initial and final thickness for j = ny/2')
+                nx = int(args.nx_grid)
+                ny = int(args.ny_grid)
+
+                # Read initial and final thickness from output file
+                outpath = os.path.join(args.output_dir, outputFile)
+                print('outpath = ' + outpath)
+                filein = netCDF.NetCDFFile(outpath,'r')
+                thk = filein.variables['thk'][:]
+
+                j = ny/2
+                thk_in = thk[0,j,:]
+                thk_out = thk[1,j,:]
+
+                # Compute <H>
+                Hav_in = 0.0
+                Hav_out = 0.0
+                for i in range(nx):
+                    Hav_in = Hav_in + thk_in[i]
+                    Hav_out = Hav_out + thk_out[i]
+                Hav_in = Hav_in / nx
+                Hav_out = Hav_out / nx
+
+                # Compute <H^2>
+                H2av_in = 0.0
+                H2av_out = 0.0
+                for i in range(nx):
+                    H2av_in = H2av_in + thk_in[i]**2
+                    H2av_out = H2av_out + thk_out[i]**2
+                H2av_in = H2av_in / nx
+                H2av_out = H2av_out / nx
+
+                print('H2av_out =' + str(H2av_out))
+                print('Hav_out^2 =' + str(Hav_out**2))
+
+                # Compute stdev = sqrt(<H^2> - <H>^2)
+                var_in  = H2av_in  - Hav_in**2
+                var_out = H2av_out - Hav_out**2
+
+                if var_in > 0.:
+                    stdev_in = sqrt(H2av_in - Hav_in**2)
+                else:
+                    stdev_in = 0.
+
+                if var_out > 0.:
+                    stdev_out = sqrt(H2av_out - Hav_out**2)
+                else:
+                    stdev_out = 0.
+
+                if stdev_in > 0.:
+                    ratio = stdev_out/stdev_in
+                else:
+                    ratio = 0.
+
+                print('stdev_in  = ' + str(stdev_in))
+                print('stdev_out = ' + str(stdev_out))
+                print('ratio = ' + str(ratio))
+
+                # Determine whether the run was stable.
+                # A run is defined to be stable if the final standard deviation of thickness
+                #  is less than the initial standard deviation
+
+                if ratio < 1.:
+                    tstep_lo = max(tstep_lo, tstep)
+                    print('Stable, new tstep_lo =' + str(tstep_lo))
+                else:
+                    tstep_hi = min(tstep_hi, tstep)
+                    print('Unstable, new tstep_hi =' + str(tstep_hi))
+
+            else:   # check_passed = F; not stable
+                tstep_hi = min(tstep_hi, tstep)
+                print('Unstable, new tstep_hi =' + str(tstep_hi))
+
+            print('Latest tstep_lo = ' + str(tstep_lo))
+            print('Latest tstep_hi = ' + str(tstep_hi))
+
+            # Add to the array containing the max stable timestep at each resolution.
+            # Take the max stable timestep to be the average of tstep_lo and tstep_hi.
+            res_tstep[n][1] = 0.5 * (tstep_lo + tstep_hi)
+
+            print('New res_tstep, res #' + str(n))
+            print(res_tstep)
+
+    # Print a table containing the max timestep for each resolution
+    for n in range(nres):
+        float_res = res_tstep[n][0]
+        float_dt  = res_tstep[n][1]
+        formatted_float_res = "{:8.1f}".format(float_res)
+        formatted_float_dt =  "{:.3e}".format(float_dt)  # exponential notation with 3 decimal places
+        print(formatted_float_res + '    ' + formatted_float_dt)
+
+# Run only if this is being run as a script.                                                                                                       
+if __name__=='__main__':
+
+    # get the command line arguments                                                                                                               
+    args = parser.parse_args()
+
+    # run the script
+    sys.exit(main())

--- a/tests/stream/README.md
+++ b/tests/stream/README.md
@@ -1,7 +1,8 @@
 ======
 stream
 ======
-Note: For setting up the experiments on an NCAR computing environment, follow the steps in the README.NCAR_HPC file in the tests directory.
+Note: For setting up the experiments in an NCAR computing environment,
+follow the steps in the README.NCAR_HPC file in the tests directory.
 
 This directory contains Python scripts for running idealized ice stream
 experiments.

--- a/tests/stream/runStream.py
+++ b/tests/stream/runStream.py
@@ -231,7 +231,7 @@ def main():
     dy = 2.0 * streamHalfWidth / float(nStream)
     dx = dy  # always want this
     
-    # Figure out the number of cells we need to add to get as close t0 the 
+    # Figure out the number of cells we need to add to get as close to the
     # desired width of the strong region as possible (note: may want to use 
     # ceil() instead of round() here)
     nStrongStrip = int(round(strongWidth / dy + eps))  


### PR DESCRIPTION
This PR includes code updates to support the slab test in directory ..tests/slab. The test case was proposed by Dukowicz (2012, doi:10.5194/tc-6-21-2012). CISM applications are described in Robinson et al. (2022, doi:10.5194/tc-16-689-2022). The test consists of a uniform, infinitely long ice sheet (a 'slab') moving down an inclined plane by a combination of sliding and shearing. Analytic solutions exist and can be compared to the CISM solution. The test is useful for comparing different Stokes approximations (B-P, DIVA, L1L2, SSA, SIA, etc.) in different physical situations (e.g., different values of ice thickness, bed slopes, Glen's 'n', viscosity, and basal friction) at different resolutions and time steps. Robinson et al. (2022) used the test to evaluate the stability of different solvers at a wide range of resolutions.

The slab directory contains python scripts to run the test and plot results. Matt Hoffman wrote the original version, which had limited functionality. With this set of commits, the test is fully supported.

These commits includes the following code mods and upgrades:
* python3 compatibility for the slab test
*  a new script 'stabilitySlab.py' that runs the stability tests described in Robinson et al. (2022)
* changes to make the L1L2 solver more accurate and robust
* a hybrid solver option that SIA and SSA solutions
* made Glen's 'n' a config parameter (called n_glen) instead of a hardwired constant; it is now real(dp) instead of integer

One known limitation: The plotting script produces two plots. The first shows velocity profiles and works fine, but the second has an issue with displaying results along the y-axis.
