### PR TITLE
Katetc/hma glaciers4, Replace Lipscomb/hma_glaciers4 PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,25 @@ P75R
 P75S
 Stnd
 mismip+Ice0
+
+#Ignore compiled topography files
+bin_to_cube/bin_to_cube
+bin_to_cube/bin_to_cube.o
+bin_to_cube/shr_kind_mod.mod
+bin_to_cube/shr_kind_mod.o
+cube_to_target/cube_to_target
+cube_to_target/cube_to_target.o
+cube_to_target/reconstruct.mod
+cube_to_target/reconstruct.o
+cube_to_target/remap.mod
+cube_to_target/remap.o
+cube_to_target/ridge_ana.mod
+cube_to_target/ridge_ana.o
+cube_to_target/rot.o
+cube_to_target/rotation.mod
+cube_to_target/shared_vars.mod
+cube_to_target/shared_vars.o
+cube_to_target/shr_kind_mod.mod
+cube_to_target/shr_kind_mod.o
+cube_to_target/smooth_topo_cube.o
+cube_to_target/smooth_topo_cube_sph.mod

--- a/builds/derecho-intel/derecho-intel-cmake
+++ b/builds/derecho-intel/derecho-intel-cmake
@@ -6,14 +6,7 @@
 
 source /etc/profile.d/z00_modules.csh
 
-module purge
-module load ncarenv/23.09
-module load intel/2023.2.1
-module load ncarcompilers/1.0.0
-module load cray-mpich/8.1.27
-module load mkl/2023.2.0
-module load netcdf/4.9.2
-module load cmake/3.26.3
+source derecho-intel-modules
 
 # remove old build data:
 rm -f ./CMakeCache.txt

--- a/builds/derecho-intel/derecho-intel-cmake.sh
+++ b/builds/derecho-intel/derecho-intel-cmake.sh
@@ -17,18 +17,9 @@ fi
 
 source /etc/profile.d/z00_modules.sh
 
+source derecho-intel-modules
+
 echo CISM: "${cism_top}"
-
-
-module purge
-module load ncarenv/23.09
-module load intel/2023.2.1
-module load cray-mpich/8.1.27
-module load mkl/2023.2.0
-module load netcdf/4.9.2
-module load ncarcompilers/1.0.0
-module load cmake/3.26.3
-
 
 # remove old build data:
 rm -f ./CMakeCache.txt

--- a/builds/derecho-intel/derecho-intel-modules
+++ b/builds/derecho-intel/derecho-intel-modules
@@ -1,0 +1,8 @@
+module purge
+module load ncarenv/23.09
+module load intel/2023.2.1
+module load ncarcompilers/1.0.0
+module load cray-mpich/8.1.27
+module load mkl/2023.2.0
+module load netcdf/4.9.2
+module load cmake/3.26.3

--- a/cism_driver/cism_front_end.F90
+++ b/cism_driver/cism_front_end.F90
@@ -137,7 +137,11 @@ subroutine cism_init_dycore(model)
   call eismint_surftemp(model%eismint_climate,model,time)
 
   ! read forcing time slice if needed - this will overwrite values from IC file if there is a conflict.
+  ! Note: The first 'model' is passed to the argument 'data', which is filled by calling glide_read.
   call glide_read_forcing(model, model)
+
+  ! Optionally, read all the time slices at once from selected forcing files.
+  call glide_read_forcing_once(model, model)
 
   call spinup_lithot(model)
 
@@ -283,16 +287,16 @@ subroutine cism_run_dycore(model)
     do while(time + time_eps < model%numerics%tend)
 
       !!! SFP moved block of code for applying time dependent forcing read in from netCDF here,
-      !!! as opposed to at the end of the time step (commented it out in it's original location for now)
+      !!! as opposed to at the end of the time step (commented it out in its original location for now)
       !!! This is a short-term fix. See additional discussion as part of issue #19 (in cism-piscees github repo).
 
       ! Forcing from a 'forcing' data file - will read time slice if needed
-      ! Note: Forcing is read from the appropriate time slice after every dynamic time step.
-      !       This is not strictly necessary if there are multiple time steps per forcing time slice.
-      !       We would need additional logic if we wanted to read a new time slice only when needed
-      !        to replace the current data.  TODO: Add this logic?
       call t_startf('read_forcing')
       call glide_read_forcing(model, model)
+
+      ! If any forcing data have been read once into Fortran arrays at initialization,
+      !  simply copy the data based on the current forcing time.
+      call glide_retrieve_forcing(model, model)
       call t_stopf('read_forcing')
 
       ! Increment time step

--- a/cism_driver/cism_front_end.F90
+++ b/cism_driver/cism_front_end.F90
@@ -229,8 +229,10 @@ subroutine cism_init_dycore(model)
 
 
   ! --- Output the initial state -------------
+  ! Note: For a standard restart, the initial state is not output, because this state
+  !       should already have been written to the output file when the previous run ended.
 
-  if (model%options%is_restart == RESTART_FALSE .or. model%options%forcewrite_restart) then
+  if (model%options%is_restart == NO_RESTART .or. model%options%is_restart == HYBRID_RESTART) then
      call t_startf('initial_io_writeall')
      call glide_io_writeall(model, model, time=time)          ! MJH The optional time argument needs to be supplied 
                                                               !     since we have not yet set model%numerics%time

--- a/libglide/glide.F90
+++ b/libglide/glide.F90
@@ -463,7 +463,8 @@ contains
        l_evolve_ice = .true.
     end if
 
-    if (model%options%is_restart == RESTART_TRUE) then
+    if (model%options%is_restart == STANDARD_RESTART .or. &
+        model%options%is_restart == HYBRID_RESTART) then
        ! On a restart, just assign the basal velocity from uvel/vvel (which are restart variables)
        ! to ubas/vbas which are used by the temperature solver to calculate basal heating.
        ! During time stepping ubas/vbas are calculated by slipvelo during thickness evolution or below on a cold start.

--- a/libglide/glide.F90
+++ b/libglide/glide.F90
@@ -218,6 +218,11 @@ contains
     ! read first time slice
     call glide_io_readall(model,model)
 
+    ! Compute grid cell areas
+    ! Note: cell_area is used for diagnostics only. It is set to dew*dns by default but can be corrected below.
+    !       For the purposes of CISM dynamics, all grid cells are rectangles of dimension dew*dns.
+    model%geometry%cell_area = model%numerics%dew*model%numerics%dns
+
     ! Compute area scale factors for stereographic map projection.
     ! This should be done after reading the input file, in case the input file contains mapping info.
     ! Note: Not yet enabled for other map projections.
@@ -230,6 +235,14 @@ contains
                                       model%general%nsn,       &
                                       model%numerics%dew*len0, &
                                       model%numerics%dns*len0)
+
+       ! Given the stereographic area correction factors, correct the diagnostic grid cell areas.
+       ! Note: area_factor is actually a length correction factor k; must divide by k^2 to adjust areas.
+       ! TODO: Change the name of area_factor
+       where (model%projection%stere%area_factor > 0.0d0)
+          model%geometry%cell_area = &
+               model%geometry%cell_area / model%projection%stere%area_factor**2
+       endwhere
 
     endif
 
@@ -291,9 +304,6 @@ contains
 !    print*, ' '
 !    print*, 'Created Glide variables'
 !    print*, 'max, min bheatflx (W/m2)=', maxval(model%temper%bheatflx), minval(model%temper%bheatflx)
-
-    ! Compute the cell areas of the grid
-    model%geometry%cell_area = model%numerics%dew*model%numerics%dns
 
     ! If a 2D bheatflx field is present in the input file, it will have been written 
     !  to model%temper%bheatflx.  For the case model%options%gthf = 0, we want to use

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1138,8 +1138,6 @@ contains
        write(message,'(a35,i14)') 'Diagnostic glacier index (CISM)', ng
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       call write_log(' ')
-
        write(message,'(a35,f14.6)') 'Glacier area (km^2)                ', &
             model%glacier%area(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
@@ -1158,10 +1156,6 @@ contains
 
        write(message,'(a35,f14.6)') 'mu_star (mm/yr w.e./deg C)         ', &
             model%glacier%mu_star(ng)
-       call write_log(trim(message), type = GM_DIAGNOSTIC)
-
-       write(message,'(a35,f14.6)') 'powerlaw_c (Pa (m/yr)^{-1/3})      ', &
-            model%glacier%powerlaw_c(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        call write_log(' ')

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1162,8 +1162,8 @@ contains
             model%glacier%alpha_snow(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'beta_artm_aux (deg C)              ', &
-            model%glacier%beta_artm_aux(ng)
+       write(message,'(a35,f14.6)') 'beta_artm (deg C)                  ', &
+            model%glacier%beta_artm(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        call write_log(' ')

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -376,7 +376,7 @@ contains
           if (ice_mask(i,j) == 1) then
              if (floating_mask(i,j) == 0) then  ! grounded ice
                 if (model%geometry%topg(i,j) - model%climate%eus < 0.0d0) then  ! grounded below sea level
-                   thck_floating = (-rhoo/rhoi) * (model%geometry%topg(i,j) - model%climate%eus)  ! thickness of ice that is exactly floating
+                   thck_floating = (-rhoo/rhoi) * (model%geometry%topg(i,j) - model%climate%eus)  ! exactly floating
                    thck_above_flotation = model%geometry%thck(i,j) - thck_floating
                    tot_mass_above_flotation = tot_mass_above_flotation    &
                                             + thck_above_flotation * cell_area(i,j)
@@ -599,16 +599,35 @@ contains
                                    tot_volume*1.0d-9         ! convert to km^3
     call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-    write(message,'(a25,e24.16)') 'Total ice mass (kg)      ',   &
-                                   tot_mass                  ! kg
-    call write_log(trim(message), type = GM_DIAGNOSTIC)
+    if (model%options%dm_dt_diag == DM_DT_DIAG_KG_S) then
 
-    write(message,'(a25,e24.16)') 'Mass above flotation (kg)',   &
-                                   tot_mass_above_flotation  ! kg
-    call write_log(trim(message), type = GM_DIAGNOSTIC)
+       write(message,'(a25,e24.16)') 'Total ice mass (kg)      ',   &
+                                      tot_mass                  ! kg
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-    write(message,'(a25,e24.16)') 'Total ice energy (J)     ', tot_energy
-    call write_log(trim(message), type = GM_DIAGNOSTIC)
+       write(message,'(a25,e24.16)') 'Mass above flotation (kg)',   &
+                                      tot_mass_above_flotation  ! kg
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a25,e24.16)') 'Total ice energy (J)     ',   &
+                                      tot_energy                ! J
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+    elseif (model%options%dm_dt_diag == DM_DT_DIAG_GT_Y) then
+
+       write(message,'(a25,e24.16)') 'Total ice mass (Gt)      ',   &
+                                      tot_mass * 1.0d-12        ! Gt
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a25,e24.16)') 'Mass above flotation (Gt)',   &
+                      tot_mass_above_flotation * 1.0d-12        ! Gt
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a25,e24.16)') 'Total ice energy (GJ)     ',  &
+                                    tot_energy * 1.0d-9         ! GJ
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+    endif  ! dm_dt_diag
 
     if (model%options%whichdycore == DYCORE_GLISSADE) then
 
@@ -654,7 +673,7 @@ contains
           write(message,'(a25,e24.16)') 'Total gr line flux (Gt/y)', tot_gl_flux * factor
           call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       endif
+       endif   ! dm_dt_diag
 
 !       write(message,'(a25,e24.16)') 'Mean accum/ablat (m/yr)  ', mean_acab
 !       call write_log(trim(message), type = GM_DIAGNOSTIC)

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1162,6 +1162,10 @@ contains
             model%glacier%snow_factor(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
+       write(message,'(a35,f14.6)') 'artm_aux_corr (deg C)              ', &
+            model%glacier%artm_aux_corr(ng)
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
        call write_log(' ')
 
     endif  ! enable_glaciers and main_task

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1158,12 +1158,12 @@ contains
             model%glacier%mu_star(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'snow_factor                        ', &
-            model%glacier%snow_factor(ng)
+       write(message,'(a35,f14.6)') 'alpha_snow                         ', &
+            model%glacier%alpha_snow(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'artm_aux_corr (deg C)              ', &
-            model%glacier%artm_aux_corr(ng)
+       write(message,'(a35,f14.6)') 'beta_artm_aux (deg C)              ', &
+            model%glacier%beta_artm_aux(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        call write_log(' ')

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1158,6 +1158,10 @@ contains
             model%glacier%mu_star(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
+       write(message,'(a35,f14.6)') 'snow_factor                        ', &
+            model%glacier%snow_factor(ng)
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
        call write_log(' ')
 
     endif  ! enable_glaciers and main_task

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -147,6 +147,12 @@ contains
 
     endif  ! main_task
 
+    ! Broadcast from main task to all processors
+    !TODO - Uncomment and make sure this does not cause problems
+!    call broadcast(model%numerics%idiag_local)
+!    call broadcast(model%numerics%jdiag_local)
+!    call broadcast(model%numerics%rdiag_local)
+
   end subroutine glide_init_diag
 
 !--------------------------------------------------------------------------

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1111,6 +1111,11 @@ contains
           endif
        enddo
 
+       ! Copy selected scalars into the derived type
+       model%glacier%total_area = tot_glc_area
+       model%glacier%total_volume = tot_glc_volume
+       model%glacier%nglacier_active = count_area
+
        ! Write some total glacier diagnostics
 
        write(message,'(a25)') 'Glacier diagnostics: '

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -234,8 +234,8 @@ contains
          lithtemp_diag                       ! lithosphere column diagnostics
 
     real(dp) :: &
-         tot_glc_area, tot_glc_area_target, &   ! total glacier area and target (km^2)
-         tot_glc_volume, tot_glc_volume_target  ! total glacier volume and target (km^3)
+         tot_glc_area_init, tot_glc_area, &   ! total glacier area, initial and current (km^2)
+         tot_glc_volume_init, tot_glc_volume  ! total glacier volume, initial and current (km^3)
 
     integer :: &
          i, j, k, ng,                       &
@@ -1087,15 +1087,15 @@ contains
 
        ! Compute some global glacier sums
        tot_glc_area = 0.0d0
-       tot_glc_area_target = 0.0d0
+       tot_glc_area_init = 0.0d0
        tot_glc_volume = 0.0d0
-       tot_glc_volume_target = 0.0d0
+       tot_glc_volume_init = 0.0d0
 
        do ng = 1, model%glacier%nglacier
           tot_glc_area = tot_glc_area + model%glacier%area(ng)
-          tot_glc_area_target = tot_glc_area_target + model%glacier%area_target(ng)
+          tot_glc_area_init = tot_glc_area_init + model%glacier%area_init(ng)
           tot_glc_volume = tot_glc_volume + model%glacier%volume(ng)
-          tot_glc_volume_target = tot_glc_volume_target + model%glacier%volume_target(ng)
+          tot_glc_volume_init = tot_glc_volume_init + model%glacier%volume_init(ng)
        enddo
 
        ! Write some total glacier diagnostics
@@ -1113,16 +1113,16 @@ contains
             tot_glc_area / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Total glacier area target (km^2)   ', &
-            tot_glc_area_target / 1.0d6
+       write(message,'(a35,f14.6)') 'Total glacier area_init (km^2)     ', &
+            tot_glc_area_init / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'Total glacier volume (km^3)        ', &
             tot_glc_volume / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Total glacier volume target (km^3) ', &
-            tot_glc_volume_target / 1.0d9
+       write(message,'(a35,f14.6)') 'Total glacier volume_init (km^3)   ', &
+            tot_glc_volume_init / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        call write_log(' ')
@@ -1142,16 +1142,16 @@ contains
             model%glacier%area(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Glacier area target (km^2)         ', &
-            model%glacier%area_target(ng) / 1.0d6
+       write(message,'(a35,f14.6)') 'Glacier area init(km^2)            ', &
+            model%glacier%area_init(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'Glacier volume (km^3)              ', &
             model%glacier%volume(ng) / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Glacier volume target (km^3)       ', &
-            model%glacier%volume_target(ng) / 1.0d9
+       write(message,'(a35,f14.6)') 'Glacier volume init (km^3)         ', &
+            model%glacier%volume_init(ng) / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'mu_star (mm/yr w.e./deg C)         ', &

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -234,8 +234,11 @@ contains
          lithtemp_diag                       ! lithosphere column diagnostics
 
     real(dp) :: &
-         tot_glc_area_init, tot_glc_area, &   ! total glacier area, initial and current (km^2)
-         tot_glc_volume_init, tot_glc_volume  ! total glacier volume, initial and current (km^3)
+         tot_glc_area_init, tot_glc_area, &  ! total glacier area, initial and current (km^2)
+         tot_glc_volume_init, tot_glc_volume ! total glacier volume, initial and current (km^3)
+
+    integer :: &
+         count_area, count_volume            ! number of glaciers with nonzero area and volume
 
     integer :: &
          i, j, k, ng,                       &
@@ -1090,12 +1093,20 @@ contains
        tot_glc_area_init = 0.0d0
        tot_glc_volume = 0.0d0
        tot_glc_volume_init = 0.0d0
+       count_area = 0
+       count_volume = 0
 
        do ng = 1, model%glacier%nglacier
           tot_glc_area = tot_glc_area + model%glacier%area(ng)
           tot_glc_area_init = tot_glc_area_init + model%glacier%area_init(ng)
           tot_glc_volume = tot_glc_volume + model%glacier%volume(ng)
           tot_glc_volume_init = tot_glc_volume_init + model%glacier%volume_init(ng)
+          if (model%glacier%area(ng) > eps) then
+             count_area = count_area + 1
+          endif
+          if (model%glacier%volume(ng) > eps) then
+             count_volume = count_volume + 1
+          endif
        enddo
 
        ! Write some total glacier diagnostics
@@ -1107,6 +1118,14 @@ contains
 
        write(message,'(a35,i14)')   'Number of glaciers                 ', &
             model%glacier%nglacier
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a35,i14)')   'Glaciers with nonzero area         ', &
+            count_area
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a35,i14)')   'Glaciers with nonzero volume       ', &
+            count_volume
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'Total glacier area (km^2)          ', &

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -1165,7 +1165,7 @@ contains
        write(message,'(a35,i14)') 'Diagnostic glacier index (CISM)    ', ng
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Glacier area_init(km^2)            ', &
+       write(message,'(a35,f14.6)') 'Glacier area_init (km^2)           ', &
             model%glacier%area_init(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 

--- a/libglide/glide_diagnostics.F90
+++ b/libglide/glide_diagnostics.F90
@@ -234,8 +234,10 @@ contains
          lithtemp_diag                       ! lithosphere column diagnostics
 
     real(dp) :: &
-         tot_glc_area_init, tot_glc_area, &  ! total glacier area, initial and current (km^2)
-         tot_glc_volume_init, tot_glc_volume ! total glacier volume, initial and current (km^3)
+         tot_glc_area_init, tot_glc_area,     & ! total glacier area, initial and current (km^2)
+         tot_glc_volume_init, tot_glc_volume, & ! total glacier volume, initial and current (km^3)
+         tot_glc_area_init_extent,            & ! glacier area summed over the initial extent (km^2)
+         tot_glc_volume_init_extent             ! glacier volume summed over the initial extent (km^2)
 
     integer :: &
          count_area, count_volume            ! number of glaciers with nonzero area and volume
@@ -1082,17 +1084,23 @@ contains
 
        ! Compute some global glacier sums
        tot_glc_area = 0.0d0
-       tot_glc_area_init = 0.0d0
        tot_glc_volume = 0.0d0
+       tot_glc_area_init = 0.0d0
        tot_glc_volume_init = 0.0d0
+       tot_glc_area_init_extent = 0.0d0
+       tot_glc_volume_init_extent = 0.0d0
        count_area = 0
        count_volume = 0
 
        do ng = 1, model%glacier%nglacier
           tot_glc_area = tot_glc_area + model%glacier%area(ng)
-          tot_glc_area_init = tot_glc_area_init + model%glacier%area_init(ng)
           tot_glc_volume = tot_glc_volume + model%glacier%volume(ng)
+          tot_glc_area_init = tot_glc_area_init + model%glacier%area_init(ng)
           tot_glc_volume_init = tot_glc_volume_init + model%glacier%volume_init(ng)
+          tot_glc_area_init_extent = tot_glc_area_init_extent &
+               + model%glacier%area_init_extent(ng)
+          tot_glc_volume_init_extent = tot_glc_volume_init_extent &
+               + model%glacier%volume_init_extent(ng)
           if (model%glacier%area(ng) > eps) then
              count_area = count_area + 1
           endif
@@ -1120,20 +1128,28 @@ contains
             count_volume
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
+       write(message,'(a35,f14.6)') 'Total glacier area_init (km^2)     ', &
+            tot_glc_area_init / 1.0d6
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
        write(message,'(a35,f14.6)') 'Total glacier area (km^2)          ', &
             tot_glc_area / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Total glacier area_init (km^2)     ', &
-            tot_glc_area_init / 1.0d6
+       write(message,'(a35,f14.6)') 'Total area_init_extent (km^2)      ', &
+            tot_glc_area_init_extent / 1.0d6
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a35,f14.6)') 'Total glacier volume_init (km^3)   ', &
+            tot_glc_volume_init / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'Total glacier volume (km^3)        ', &
             tot_glc_volume / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Total glacier volume_init (km^3)   ', &
-            tot_glc_volume_init / 1.0d9
+       write(message,'(a35,f14.6)') 'Total volume_init_extent (km^3)    ', &
+            tot_glc_volume_init_extent / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        call write_log(' ')
@@ -1142,27 +1158,35 @@ contains
 
        ng = model%glacier%ngdiag
 
-       write(message,'(a35,i14)') 'Diagnostic glacier index (RGI) ', &
+       write(message,'(a35,i14)') 'Diagnostic glacier index (RGI)     ', &
             model%glacier%cism_to_rgi_glacier_id(ng)
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,i14)') 'Diagnostic glacier index (CISM)', ng
+       write(message,'(a35,i14)') 'Diagnostic glacier index (CISM)    ', ng
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a35,f14.6)') 'Glacier area_init(km^2)            ', &
+            model%glacier%area_init(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'Glacier area (km^2)                ', &
             model%glacier%area(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Glacier area init(km^2)            ', &
-            model%glacier%area_init(ng) / 1.0d6
+       write(message,'(a35,f14.6)') 'Glacier area_init_extent (km^2)    ', &
+            model%glacier%area_init_extent(ng) / 1.0d6
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'Glacier volume (km^3)              ', &
             model%glacier%volume(ng) / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
-       write(message,'(a35,f14.6)') 'Glacier volume init (km^3)         ', &
+       write(message,'(a35,f14.6)') 'Glacier volume_init (km^3)         ', &
             model%glacier%volume_init(ng) / 1.0d9
+       call write_log(trim(message), type = GM_DIAGNOSTIC)
+
+       write(message,'(a35,f14.6)') 'Glacier volume_init_extent (km^3)  ', &
+            model%glacier%volume_init_extent(ng) / 1.0d9
        call write_log(trim(message), type = GM_DIAGNOSTIC)
 
        write(message,'(a35,f14.6)') 'mu_star (mm/yr w.e./deg C)         ', &

--- a/libglide/glide_lithot.F90
+++ b/libglide/glide_lithot.F90
@@ -82,7 +82,7 @@ contains
     !TODO - Make sure the sign is correct for the geothermal flux.
     !NOTE: CISM convention is that geot is positive down, so geot < 0 for upward geothermal flux
 
-    if (model%options%is_restart == RESTART_FALSE) then
+    if (model%options%is_restart == NO_RESTART) then
        ! set initial temp distribution to thermal gradient
        factor = model%paramets%geot / model%lithot%con_r
        do k=1,model%lithot%nlayer
@@ -112,7 +112,7 @@ contains
 
     integer t
 
-    if (model%options%is_restart == RESTART_FALSE .and. model%lithot%numt > 0) then
+    if (model%options%is_restart == NO_RESTART .and. model%lithot%numt > 0) then
        call write_log('Spinning up GTHF calculations',type=GM_INFO)
        call not_parallel(__FILE__,__LINE__)
        do t=1,model%lithot%numt

--- a/libglide/glide_nc_custom.F90
+++ b/libglide/glide_nc_custom.F90
@@ -208,6 +208,20 @@ contains
        call nc_errorhandle(__FILE__,__LINE__,status)
     end if
 
+    !TODO - Uncomment to add an ocean level dimension
+    ! ocean level dimension
+!    status = parallel_inq_varid(NCO%id,'zocn',varid)
+!    status= parallel_put_var(NCO%id,varid,model%ocean_data%zocn)
+!    call nc_errorhandle(__FILE__,__LINE__,status)
+
+    ! glacier dimension
+
+    if (model%options%enable_glaciers) then
+       status = parallel_inq_varid(NCO%id,'glacierid',varid)
+       status= parallel_put_var(NCO%id,varid,model%glacier%glacierid)
+       call nc_errorhandle(__FILE__,__LINE__,status)
+    end if
+
     ! clean up
     deallocate(x0_global, y0_global)
     deallocate(x1_global, y1_global)

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3175,7 +3175,7 @@ contains
     call GetValue(section,'set_snow_factor',    model%glacier%set_snow_factor)
     call GetValue(section,'set_powerlaw_c',     model%glacier%set_powerlaw_c)
     call GetValue(section,'snow_calc',          model%glacier%snow_calc)
-    call GetValue(section,'tmlt_const',         model%glacier%tmlt_const)
+    call GetValue(section,'tmlt',               model%glacier%tmlt)
     call GetValue(section,'snow_threshold_min', model%glacier%snow_threshold_min)
     call GetValue(section,'snow_threshold_max', model%glacier%snow_threshold_max)
     call GetValue(section,'diagnostic_minthck', model%glacier%diagnostic_minthck)
@@ -3279,7 +3279,7 @@ contains
           call write_log(message)
        endif
 
-       write(message,*) 'glc tmlt_const (deg C)    :  ', model%glacier%tmlt_const
+       write(message,*) 'glc tmlt (deg C)          :  ', model%glacier%tmlt
        call write_log(message)
        write(message,*) 'glc diagnostic minthck (m):  ', model%glacier%diagnostic_minthck
        call write_log(message)
@@ -3765,7 +3765,7 @@ contains
        ! some fields needed for glacier inversion
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_snow_factor')
-       call glide_add_to_restart_variable_list('glacier_tmlt')
+       call glide_add_to_restart_variable_list('glacier_artm_aux_corr')
        call glide_add_to_restart_variable_list('glacier_smb_obs')
        !TODO - would not need to write glacier_smb_obs if in a forcing file?
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -1600,9 +1600,6 @@ contains
        if (model%climate%nlev_smb < 2) then
           call write_log('Error, must have nlev_smb >= 2 for this input function', GM_FATAL)
        endif
-    elseif (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_LAPSE) then
-       write(message,*) 'artm lapse rate (deg/m) : ', model%climate%t_lapse
-       call write_log(message)
     endif
 
     if (model%options%enable_acab_anomaly) then
@@ -2881,6 +2878,12 @@ contains
        call write_log(message)
     endif
 
+    ! lapse rate
+    if (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_LAPSE) then
+       write(message,*) 'artm lapse rate (deg/m) : ', model%climate%t_lapse
+       call write_log(message)
+    endif
+
     if (model%basal_melt%bmlt_anomaly_timescale > 0.0d0) then
        write(message,*) 'bmlt_anomaly_timescale (yr): ', model%basal_melt%bmlt_anomaly_timescale
        call write_log(message)
@@ -3681,14 +3684,20 @@ contains
        call glide_add_to_restart_variable_list('cism_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
-       ! Save the arrays used to find the SMB and basal friction
-       !TODO: Not sure that area_target and volume_target are needed.
-       !      These could be computed based on cism_glacier_id_init and thck_obs.
-       call glide_add_to_restart_variable_list('glacier_area_target')
+       ! Save some arrays used to find the SMB and basal friction
+       if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
+          call glide_add_to_restart_variable_list('usrf_obs')
+          call glide_add_to_restart_variable_list('powerlaw_c')
+       elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
+          call glide_add_to_restart_variable_list('powerlaw_c')
+       endif
+       !TODO: Are area_target and volume_target needed?
+       !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_target')
-       ! Not sure that mu_star is needed (if computed based on SMB = 0 over init area)
-       call glide_add_to_restart_variable_list('glacier_mu_star')
-       call glide_add_to_restart_variable_list('glacier_powerlaw_c')
+       call glide_add_to_restart_variable_list('glacier_area_target')
+       ! mu_star is needed only if relaxing toward the desired value;
+       !  not needed if computed based on SMB = 0 over the target area
+!!       call glide_add_to_restart_variable_list('glacier_mu_star')
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -80,19 +80,19 @@ contains
        call handle_time(section, model)
     end if
 
-    ! read options parameters
+    ! read options
     call GetSection(config,section,'options')
     if (associated(section)) then
        call handle_options(section, model)
     end if
 
-    !read options for higher-order computation
+    ! read options for higher-order computation
     call GetSection(config,section,'ho_options')
     if (associated(section)) then
         call handle_ho_options(section, model)
     end if
 
-     !read options for computation using an external dycore -- Doug Ranken 04/20/12
+    ! read options for computation using an external dycore -- Doug Ranken 04/20/12
     call GetSection(config,section,'external_dycore_options')
     if (associated(section)) then
         call handle_dycore_options(section, model)
@@ -123,12 +123,13 @@ contains
        end if
     endif
 
-    ! Till options are not currently supported
-    ! read till parameters
-!!    call GetSection(config,section,'till_options')
-!!    if (associated(section)) then
-!!       call handle_till_options(section, model)
-!!    end if
+    ! read glacier info
+    if (model%options%enable_glaciers) then
+       call GetSection(config,section,'glaciers')
+       if (associated(section)) then
+          call handle_glaciers(section, model)
+       end if
+    endif
 
     ! Construct the list of necessary restart variables based on the config options 
     ! selected by the user in the config file.
@@ -157,7 +158,7 @@ contains
     call print_parameters(model)
     call print_gthf(model)
     call print_isostasy(model)
-!!    call print_till_options(model)  ! disabled for now
+    call print_glaciers(model)
 
   end subroutine glide_printconfig
 
@@ -765,9 +766,6 @@ contains
     call GetValue(section,'restart_extend_velo',model%options%restart_extend_velo)
     call GetValue(section,'forcewrite_restart',model%options%forcewrite_restart)
 
-    ! These are not currently supported
-    !call GetValue(section,'basal_proc',model%options%which_bproc)
-
   end subroutine handle_options
 
 !--------------------------------------------------------------------------------
@@ -819,8 +817,6 @@ contains
     call GetValue(section, 'force_retreat',               model%options%force_retreat)
     call GetValue(section, 'which_ho_ice_age',            model%options%which_ho_ice_age)
     call GetValue(section, 'enable_glaciers',             model%options%enable_glaciers)
-    call GetValue(section, 'glacier_mu_star',             model%options%glacier_mu_star)
-    call GetValue(section, 'glacier_powerlaw_c',          model%options%glacier_powerlaw_c)
     call GetValue(section, 'glissade_maxiter',            model%options%glissade_maxiter)
     call GetValue(section, 'linear_solve_ncheck',         model%options%linear_solve_ncheck)
     call GetValue(section, 'linear_maxiters',             model%options%linear_maxiters)
@@ -915,14 +911,6 @@ contains
          'local water balance      ', &
          'local + steady-state flux', &
          'Constant value (= 10 m)  ' /)
-
-      ! basal proc model is disabled for now.
-!!    character(len=*), dimension(0:2), parameter :: which_bproc = (/ &
-!!         'Basal proc mod disabled '  , &
-!!         'Basal proc, high res.   '   , &
-!!         'Basal proc, fast calc.  ' /)
-    character(len=*), dimension(0:0), parameter :: which_bproc = (/ &
-         'Basal process model disabled ' /)
 
     character(len=*), dimension(0:1), parameter :: b_mbal = (/ &
          'not in continuity eqn', &
@@ -1201,17 +1189,6 @@ contains
     character(len=*), dimension(0:1), parameter :: ho_whichice_age = (/ &
          'ice age computation off', &
          'ice age computation on ' /)
-
-    character(len=*), dimension(0:2), parameter :: which_glacier_mu_star = (/ &
-         'spatially uniform glacier parameter mu_star', &
-         'glacier-specific mu_star found by inversion', &
-         'glacier-specific mu_star read from file    ' /)
-
-    character(len=*), dimension(0:2), parameter :: which_glacier_powerlaw_c = (/ &
-         'spatially uniform glacier parameter Cp', &
-         'glacier-specific Cp found by inversion', &
-         'glacier-specific Cp read from file    ' /)
-
 
     call write_log('Dycore options')
     call write_log('-------------')
@@ -1676,13 +1653,6 @@ contains
        call write_log('Will write to output files on restart')
     endif
 
-!!     This option is not currently supported
-!!    if (model%options%which_bproc < 0 .or. model%options%which_bproc >= size(which_bproc)) then
-!!       call write_log('Error, basal_proc out of range',GM_FATAL)
-!!    end if
-!!    write(message,*) 'basal_proc              : ',model%options%which_bproc,which_bproc(model%options%which_bproc)
-!!    call write_log(message)
-
     !HO options
 
     if (model%options%whichdycore /= DYCORE_GLIDE) then   ! glissade higher-order
@@ -2094,24 +2064,6 @@ contains
           if (model%options%which_ho_ice_age < 0 .or. model%options%which_ho_ice_age >= size(ho_whichice_age)) then
              call write_log('Error, ice_age option out of range for glissade dycore', GM_FATAL)
           end if
-
-          if (model%options%enable_glaciers) then
-             call write_log('Glacier tracking and tuning is enabled')
-             write(message,*) 'glacier_mu_star         : ', model%options%glacier_mu_star, &
-                  which_glacier_mu_star(model%options%glacier_mu_star)
-             call write_log(message)
-             if (model%options%glacier_mu_star < 0 .or. &
-                  model%options%glacier_mu_star >= size(which_glacier_mu_star)) then
-                call write_log('Error, glacier_mu_star option out of range', GM_FATAL)
-             end if
-             write(message,*) 'glacier_powerlaw_c      : ', model%options%glacier_powerlaw_c, &
-                  which_glacier_powerlaw_c(model%options%glacier_powerlaw_c)
-             call write_log(message)
-             if (model%options%glacier_powerlaw_c < 0 .or. &
-                  model%options%glacier_powerlaw_c >= size(which_glacier_powerlaw_c)) then
-                call write_log('Error, glacier_powerlaw_c option out of range', GM_FATAL)
-             end if
-          endif
 
           write(message,*) 'glissade_maxiter        : ',model%options%glissade_maxiter
           call write_log(message)
@@ -3182,72 +3134,77 @@ contains
 
 !--------------------------------------------------------------------------------
 
-! These options are disabled for now.
+  subroutine handle_glaciers(section, model)
 
-!!  subroutine handle_till_options(section,model)
-!!    !Till options
-!!    use glimmer_config
-!!    use glide_types
-!!    implicit none
-!!    type(ConfigSection), pointer :: section
-!!    type(glide_global_type) :: model
+    use glimmer_config
+    use glide_types
+    implicit none
 
-!!    if (model%options%which_bproc==1) then
-!!        call GetValue(section, 'fric',  model%basalproc%fric)
-!!        call GetValue(section, 'etillo',  model%basalproc%etillo)
-!!        call GetValue(section, 'No',  model%basalproc%No)
-!!        call GetValue(section, 'Comp',  model%basalproc%Comp)
-!!        call GetValue(section, 'Cv',  model%basalproc%Cv)
-!!        call GetValue(section, 'Kh',  model%basalproc%Kh)
-!!    else if (model%options%which_bproc==2) then
-!!        call GetValue(section, 'aconst',  model%basalproc%aconst)
-!!        call GetValue(section, 'bconst',  model%basalproc%bconst)
-!!    end if
-!!    if (model%options%which_bproc > 0) then
-!!        call GetValue(section, 'Zs',  model%basalproc%Zs)
-!!        call GetValue(section, 'tnodes',  model%basalproc%tnodes)
-!!        call GetValue(section, 'till_hot', model%basalproc%till_hot)
-!!    end if  
-!!  end subroutine handle_till_options    
+    type(ConfigSection), pointer :: section
+    type(glide_global_type)  :: model
 
-!!  subroutine print_till_options(model)
-!!    use glide_types
-!!    use glimmer_log
-!!    implicit none
-!!    type(glide_global_type)  :: model
-!!    character(len=100) :: message
+    call GetValue(section,'set_mu_star',    model%glacier%set_mu_star)
+    call GetValue(section,'set_powerlaw_c', model%glacier%set_powerlaw_c)
+    call GetValue(section,'minthck',        model%glacier%minthck)
+    call GetValue(section,'tmlt',           model%glacier%tmlt)
 
-!!    if (model%options%which_bproc > 0) then 
-!!        call write_log('Till options')
-!!        call write_log('----------')
-!!        if (model%options%which_bproc==1) then
-!!            write(message,*) 'Internal friction           : ',model%basalproc%fric
-!!            call write_log(message)
-!!            write(message,*) 'Reference void ratio        : ',model%basalproc%etillo
-!!            call write_log(message)
-!!            write(message,*) 'Reference effective Stress  : ',model%basalproc%No
-!!            call write_log(message)
-!!            write(message,*) 'Compressibility             : ',model%basalproc%Comp
-!!            call write_log(message)
-!!            write(message,*) 'Diffusivity                 : ',model%basalproc%Cv
-!!            call write_log(message)
-!!            write(message,*) 'Hyd. conductivity           : ',model%basalproc%Kh
-!!            call write_log(message)
-!!        end if
-!!        if (model%options%which_bproc==2) then
-!!            write(message,*) 'aconst  : ',model%basalproc%aconst
-!!            call write_log(message)
-!!            write(message,*) 'bconst  : ',model%basalproc%aconst
-!!            call write_log(message)
-!!        end if
-!!        write(message,*) 'Solid till thickness : ',model%basalproc%Zs
-!!        call write_log(message)
-!!        write(message,*) 'Till nodes number : ',model%basalproc%tnodes
-!!        call write_log(message)
-!!        write(message,*) 'till_hot  :',model%basalproc%till_hot
-!!        call write_log(message)
-!!    end if
-!!  end subroutine print_till_options
+  end subroutine handle_glaciers
+
+!--------------------------------------------------------------------------------
+
+  subroutine print_glaciers(model)
+
+    use glide_types
+    use glimmer_log
+
+    implicit none
+    type(glide_global_type)  :: model
+    character(len=100) :: message
+
+    ! glacier inversion options
+
+    character(len=*), dimension(0:2), parameter :: glacier_set_mu_star = (/ &
+         'spatially uniform glacier parameter mu_star', &
+         'glacier-specific mu_star found by inversion', &
+         'glacier-specific mu_star read from file    ' /)
+
+    character(len=*), dimension(0:2), parameter :: glacier_set_powerlaw_c = (/ &
+         'spatially uniform glacier parameter Cp', &
+         'glacier-specific Cp found by inversion', &
+         'glacier-specific Cp read from file    ' /)
+
+    if (model%options%enable_glaciers) then
+
+       call write_log(' ')
+       call write_log('Glaciers')
+       call write_log('--------')
+
+       call write_log('Glacier tracking and tuning is enabled')
+
+       write(message,*) 'set_mu_star              : ', model%glacier%set_mu_star, &
+            glacier_set_mu_star(model%glacier%set_mu_star)
+       call write_log(message)
+       if (model%glacier%set_mu_star < 0 .or. &
+            model%glacier%set_mu_star >= size(glacier_set_mu_star)) then
+          call write_log('Error, glacier_set_mu_star option out of range', GM_FATAL)
+       end if
+
+       write(message,*) 'set_powerlaw_c           : ', model%glacier%set_powerlaw_c, &
+            glacier_set_powerlaw_c(model%glacier%set_powerlaw_c)
+       call write_log(message)
+       if (model%glacier%set_powerlaw_c < 0 .or. &
+            model%glacier%set_powerlaw_c >= size(glacier_set_powerlaw_c)) then
+          call write_log('Error, glacier_set_powerlaw_c option out of range', GM_FATAL)
+       end if
+
+       write(message,*) 'glacier minthck (m)      :  ', model%glacier%minthck
+       call write_log(message)
+       write(message,*) 'glacier Tmlt (deg C)     :  ', model%glacier%tmlt
+       call write_log(message)
+
+    endif   ! enable_glaciers
+
+  end subroutine print_glaciers
 
 !--------------------------------------------------------------------------------
 
@@ -3715,15 +3672,10 @@ contains
        ! Save the arrays used to find the SMB and basal friction
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_powerlaw_c')
-       if (model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
+       if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('glacier_volume_target')
        endif
     endif
-
-    ! basal processes module - requires tauf for a restart
-!!    if (options%which_bproc /= BAS_PROC_DISABLED ) then
-!!        call glide_add_to_restart_variable_list('tauf', model_id)
-!!    endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.
 

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -761,9 +761,7 @@ contains
     call GetValue(section,'periodic_ew',model%options%periodic_ew)
     call GetValue(section,'sigma',model%options%which_sigma)
     call GetValue(section,'ioparams',model%funits%ncfile)
-
-    !Note: Previously, the terms 'hotstart' and 'restart' were both supported in the config file.
-    !      Going forward, only 'restart' is supported.
+    call GetValue(section,'forcewrite_final', model%options%forcewrite_final)
     call GetValue(section,'restart',model%options%is_restart)
     call GetValue(section,'restart_extend_velo',model%options%restart_extend_velo)
 
@@ -1651,6 +1649,10 @@ contains
        call write_log('Periodic EW lateral boundary condition')
        call write_log('  Slightly cheated with how temperature is implemented.',GM_WARNING)
     end if
+
+    if (model%options%forcewrite_final) then
+       call write_log('Force write to output files when the run completes')
+    endif
 
     if (model%options%is_restart == STANDARD_RESTART) then
        call write_log('Restarting model from a previous run')

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3691,9 +3691,10 @@ contains
        call glide_add_to_restart_variable_list('cism_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
-       ! Save some arrays used to find SMB and basal friction parameters
-       call glide_add_to_restart_variable_list('glacier_smb_obs')
        call glide_add_to_restart_variable_list('glacier_mu_star')
+       if (model%glacier%set_powerlaw_c == GLACIER_MU_STAR_INVERSION) then
+          call glide_add_to_restart_variable_list('glacier_smb_obs')
+       endif
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('usrf_obs')
           call glide_add_to_restart_variable_list('powerlaw_c')

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3177,15 +3177,14 @@ contains
     call GetValue(section,'snow_calc',               model%glacier%snow_calc)
     call GetValue(section,'scale_area',              model%glacier%scale_area)
     call GetValue(section,'tmlt',                    model%glacier%tmlt)
-    call GetValue(section,'dt_aux',                  model%glacier%dt_aux)
     call GetValue(section,'mu_star_const',           model%glacier%mu_star_const)
     call GetValue(section,'mu_star_min',             model%glacier%mu_star_min)
     call GetValue(section,'mu_star_max',             model%glacier%mu_star_max)
     call GetValue(section,'alpha_snow_const',        model%glacier%alpha_snow_const)
     call GetValue(section,'alpha_snow_min',          model%glacier%alpha_snow_min)
     call GetValue(section,'alpha_snow_max',          model%glacier%alpha_snow_max)
-    call GetValue(section,'beta_artm_aux_max',       model%glacier%beta_artm_aux_max)
-    call GetValue(section,'beta_artm_aux_increment', model%glacier%beta_artm_aux_increment)
+    call GetValue(section,'beta_artm_max',           model%glacier%beta_artm_max)
+    call GetValue(section,'beta_artm_increment',     model%glacier%beta_artm_increment)
     call GetValue(section,'snow_threshold_min',      model%glacier%snow_threshold_min)
     call GetValue(section,'snow_threshold_max',      model%glacier%snow_threshold_max)
     call GetValue(section,'precip_lapse',            model%glacier%precip_lapse)
@@ -3271,7 +3270,7 @@ contains
 
        if (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION .and. &
            model%glacier%set_alpha_snow == GLACIER_ALPHA_SNOW_INVERSION) then
-          write(message,*) 'glc dt_aux (deg C)            :  ', model%glacier%dt_aux
+!!          write(message,*) 'glc baseline date         :  ', model%glacier%baseline_date
           call write_log(message)
        endif
 
@@ -3318,9 +3317,9 @@ contains
        call write_log(message)
        write(message,*) 'alpha_snow_max                :  ', model%glacier%alpha_snow_max
        call write_log(message)
-       write(message,*) 'beta_artm_aux_max (degC)      :  ', model%glacier%beta_artm_aux_max
+       write(message,*) 'beta_artm_max (degC)          :  ', model%glacier%beta_artm_max
        call write_log(message)
-       write(message,*) 'beta_artm_aux_increment (degC):  ', model%glacier%beta_artm_aux_increment
+       write(message,*) 'beta_artm_increment (degC)    :  ', model%glacier%beta_artm_increment
        call write_log(message)
 
     endif   ! enable_glaciers
@@ -3795,23 +3794,28 @@ contains
 
     if (model%options%enable_glaciers) then
        ! some fields related to glacier indexing
+       !TODO - Do we need all the SMB masks?
        call glide_add_to_restart_variable_list('rgi_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
+       call glide_add_to_restart_variable_list('cism_glacier_id_baseline')
        call glide_add_to_restart_variable_list('smb_glacier_id')
        call glide_add_to_restart_variable_list('smb_glacier_id_init')
+       call glide_add_to_restart_variable_list('smb_glacier_id_baseline')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
        ! SMB is computed at the end of each year to apply during the next year
        call glide_add_to_restart_variable_list('smb')
+       call glide_add_to_restart_variable_list('smb_rgi')
+       call glide_add_to_restart_variable_list('smb_aux')
+       ! mu_star, alpha_snow, and beta_artm are inversion parameters
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_alpha_snow')
-       call glide_add_to_restart_variable_list('glacier_beta_artm_aux')
-       ! smb_obs and smb_aux are used for glacier inversion
+       call glide_add_to_restart_variable_list('glacier_beta_artm')
+       ! smb_obs is used for glacier inversion
        call glide_add_to_restart_variable_list('glacier_smb_obs')
-       call glide_add_to_restart_variable_list('smb_aux')
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('powerlaw_c')
-          call glide_add_to_restart_variable_list('usrf_obs')
+          call glide_add_to_restart_variable_list('usrf_target_rgi')
        elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
           call glide_add_to_restart_variable_list('powerlaw_c')
        endif

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -2297,6 +2297,12 @@ contains
     call GetValue(section, 'thermal_forcing_anomaly_timescale', model%ocean_data%thermal_forcing_anomaly_timescale)
     call GetValue(section, 'thermal_forcing_anomaly_basin', model%ocean_data%thermal_forcing_anomaly_basin)
 
+    ! glacier parameters
+    !TODO - Create a separate glacier section
+    call GetValue(section, 'gamma0', model%glacier%mu_star_const)
+    call GetValue(section, 'gamma0', model%glacier%mu_star_min)
+    call GetValue(section, 'gamma0', model%glacier%mu_star_max)
+
     ! parameters to adjust input topography
     call GetValue(section, 'adjust_topg_xmin', model%paramets%adjust_topg_xmin)
     call GetValue(section, 'adjust_topg_xmax', model%paramets%adjust_topg_xmax)
@@ -3706,15 +3712,18 @@ contains
           ! no restart variables needed
     end select
 
-    !TODO - Add glacier options
     if (model%options%enable_glaciers) then
-       call glide_add_to_restart_variable_list('glacier_id')
-       call glide_add_to_restart_variable_list('glacier_id_cism')
-       ! TODO: Write model%glacier%mu_star and model%basal_physics%powerlaw_c
+!       call glide_add_to_restart_variable_list('nglacier')
+!       call glide_add_to_restart_variable_list('ngdiag')
+!       call glide_add_to_restart_variable_list('glacierid')
+       call glide_add_to_restart_variable_list('rgi_glacier_id')
+       call glide_add_to_restart_variable_list('cism_glacier_id')
+       call glide_add_to_restart_variable_list('glacier_area_target')
+       call glide_add_to_restart_variable_list('glacier_volume_target')
+       call glide_add_to_restart_variable_list('glacier_mu_star')
+       call glide_add_to_restart_variable_list('glacier_powerlaw_c')
        ! Some arrays have dimension nglacier, which isn't known initially.
-       ! These could be written out as 2D arrays, then read in and used to recompute the 1D arrays on restart.
-       ! *  glacier%area_target and glacier%volume_target should be added
-       ! Note: cism_to_glacier_id can be recomputed, given glacier_id and glacier_id_cism
+       ! Note: cism_to_rgi_glacier_id can be recomputed, given rgi_glacier_id and cism_glacier_id
     endif
     !
     ! basal processes module - requires tauf for a restart

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -1372,7 +1372,12 @@ contains
     end if
     write(message,*) 'calving_domain          : ', model%options%calving_domain, domain_calving(model%options%calving_domain)
     call write_log(message)
-    
+
+    if (model%options%read_lat_lon) then
+       write(message,*) ' Lat and lon fields will be read from input files and written to restart'
+       call write_log(message)
+    endif
+
     ! dycore-dependent options; most of these are supported for Glissade only
 
     if (model%options%whichdycore == DYCORE_GLISSADE) then
@@ -1443,11 +1448,6 @@ contains
 
        if (model%options%adjust_input_topography) then
           write(message,*) ' Input topography in a selected region will be adjusted'
-          call write_log(message)
-       endif
-
-       if (model%options%read_lat_lon) then
-          write(message,*) ' Lat and lon fields will be read from input files and written to restart'
           call write_log(message)
        endif
 
@@ -3846,14 +3846,11 @@ contains
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_alpha_snow')
        call glide_add_to_restart_variable_list('glacier_beta_artm')
-       ! smb_obs is used for glacier inversion
+       ! smb_obs and usrf_obs are used to invert for mu_star
        call glide_add_to_restart_variable_list('glacier_smb_obs')
-       if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
-          call glide_add_to_restart_variable_list('powerlaw_c')
-          call glide_add_to_restart_variable_list('usrf_target_rgi')
-       elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
-          call glide_add_to_restart_variable_list('powerlaw_c')
-       endif
+       call glide_add_to_restart_variable_list('usrf_obs')
+       ! powerlaw_c is used for power law sliding
+       call glide_add_to_restart_variable_list('powerlaw_c')
        !TODO: Are area_init and volume_init needed in the restart file?
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_init')

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -818,6 +818,9 @@ contains
     call GetValue(section, 'remove_ice_caps',             model%options%remove_ice_caps)
     call GetValue(section, 'force_retreat',               model%options%force_retreat)
     call GetValue(section, 'which_ho_ice_age',            model%options%which_ho_ice_age)
+    call GetValue(section, 'enable_glaciers',             model%options%enable_glaciers)
+    call GetValue(section, 'glacier_mu_star',             model%options%glacier_mu_star)
+    call GetValue(section, 'glacier_powerlaw_c',          model%options%glacier_powerlaw_c)
     call GetValue(section, 'glissade_maxiter',            model%options%glissade_maxiter)
     call GetValue(section, 'linear_solve_ncheck',         model%options%linear_solve_ncheck)
     call GetValue(section, 'linear_maxiters',             model%options%linear_maxiters)
@@ -1198,6 +1201,17 @@ contains
     character(len=*), dimension(0:1), parameter :: ho_whichice_age = (/ &
          'ice age computation off', &
          'ice age computation on ' /)
+
+    character(len=*), dimension(0:2), parameter :: which_glacier_mu_star = (/ &
+         'spatially uniform glacier parameter mu_star', &
+         'glacier-specific mu_star found by inversion', &
+         'glacier-specific mu_star read from file    ' /)
+
+    character(len=*), dimension(0:2), parameter :: which_glacier_powerlaw_c = (/ &
+         'spatially uniform glacier parameter Cp', &
+         'glacier-specific Cp found by inversion', &
+         'glacier-specific Cp read from file    ' /)
+
 
     call write_log('Dycore options')
     call write_log('-------------')
@@ -2080,6 +2094,24 @@ contains
           if (model%options%which_ho_ice_age < 0 .or. model%options%which_ho_ice_age >= size(ho_whichice_age)) then
              call write_log('Error, ice_age option out of range for glissade dycore', GM_FATAL)
           end if
+
+          if (model%options%enable_glaciers) then
+             call write_log('Glacier tracking and tuning is enabled')
+             write(message,*) 'glacier_mu_star         : ', model%options%glacier_mu_star, &
+                  which_glacier_mu_star(model%options%glacier_mu_star)
+             call write_log(message)
+             if (model%options%glacier_mu_star < 0 .or. &
+                  model%options%glacier_mu_star >= size(which_glacier_mu_star)) then
+                call write_log('Error, glacier_mu_star option out of range', GM_FATAL)
+             end if
+             write(message,*) 'glacier_powerlaw_c      : ', model%options%glacier_powerlaw_c, &
+                  which_glacier_powerlaw_c(model%options%glacier_powerlaw_c)
+             call write_log(message)
+             if (model%options%glacier_powerlaw_c < 0 .or. &
+                  model%options%glacier_powerlaw_c >= size(which_glacier_powerlaw_c)) then
+                call write_log('Error, glacier_powerlaw_c option out of range', GM_FATAL)
+             end if
+          endif
 
           write(message,*) 'glissade_maxiter        : ',model%options%glissade_maxiter
           call write_log(message)
@@ -3673,6 +3705,17 @@ contains
        case default
           ! no restart variables needed
     end select
+
+    !TODO - Add glacier options
+    if (model%options%enable_glaciers) then
+       call glide_add_to_restart_variable_list('glacier_id')
+       call glide_add_to_restart_variable_list('glacier_id_cism')
+       ! TODO: Write model%glacier%mu_star and model%basal_physics%powerlaw_c
+       ! Some arrays have dimension nglacier, which isn't known initially.
+       ! These could be written out as 2D arrays, then read in and used to recompute the 1D arrays on restart.
+       ! *  glacier%area_target and glacier%volume_target should be added
+       ! Note: cism_to_glacier_id can be recomputed, given glacier_id and glacier_id_cism
+    endif
     !
     ! basal processes module - requires tauf for a restart
 !!    if (options%which_bproc /= BAS_PROC_DISABLED ) then

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3187,6 +3187,7 @@ contains
     call GetValue(section,'beta_artm_aux_increment', model%glacier%beta_artm_aux_increment)
     call GetValue(section,'snow_threshold_min',      model%glacier%snow_threshold_min)
     call GetValue(section,'snow_threshold_max',      model%glacier%snow_threshold_max)
+    call GetValue(section,'precip_lapse',            model%glacier%precip_lapse)
     call GetValue(section,'diagnostic_minthck',      model%glacier%diagnostic_minthck)
 
   end subroutine handle_glaciers
@@ -3286,9 +3287,11 @@ contains
        endif
 
        if (model%glacier%snow_calc == GLACIER_SNOW_CALC_PRECIP_ARTM) then
-          write(message,*) 'snow_threshold_min (deg C)  : ', model%glacier%snow_threshold_min
+          write(message,*) 'snow_threshold_min (deg C)    : ', model%glacier%snow_threshold_min
           call write_log(message)
-          write(message,*) 'snow_threshold_max (deg C)   : ', model%glacier%snow_threshold_max
+          write(message,*) 'snow_threshold_max (deg C)    : ', model%glacier%snow_threshold_max
+          call write_log(message)
+          write(message,*) 'precip_lapse (fraction/m)     : ', model%glacier%precip_lapse
           call write_log(message)
        endif
 
@@ -3802,6 +3805,9 @@ contains
        elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
           call glide_add_to_restart_variable_list('powerlaw_c')
        endif
+       ! SMB is computed at the end of each year to apply during the next year
+       ! Alternatively, could save Tpos and snow everywhere
+       call glide_add_to_restart_variable_list('smb')
        !TODO: Are area_init and volume_init needed in the restart file?
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_init')

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -2303,6 +2303,7 @@ contains
     call GetValue(section,'bmlt_anomaly_timescale', model%basal_melt%bmlt_anomaly_timescale)
 
     ! parameters for artm anomaly option
+    call GetValue(section,'artm_anomaly_const', model%climate%artm_anomaly_const)
     call GetValue(section,'artm_anomaly_timescale', model%climate%artm_anomaly_timescale)
 
     ! basal melting parameters
@@ -2873,9 +2874,15 @@ contains
     endif
 
     ! parameters for artm anomaly option
-    if (model%climate%artm_anomaly_timescale > 0.0d0) then
-       write(message,*) 'artm_anomaly_timescale (yr): ', model%climate%artm_anomaly_timescale
-       call write_log(message)
+    if (model%options%enable_artm_anomaly) then
+       if (model%climate%artm_anomaly_const /= 0.0d0) then
+          write(message,*) 'artm_anomaly_const (degC): ', model%climate%artm_anomaly_const
+          call write_log(message)
+       endif
+       if (model%climate%artm_anomaly_timescale > 0.0d0) then
+          write(message,*) 'artm_anomaly_timescale (yr): ', model%climate%artm_anomaly_timescale
+          call write_log(message)
+       endif
     endif
 
     ! lapse rate

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3161,6 +3161,7 @@ contains
 
     call GetValue(section,'set_mu_star',        model%glacier%set_mu_star)
     call GetValue(section,'set_powerlaw_c',     model%glacier%set_powerlaw_c)
+    call GetValue(section,'match_smb_obs',      model%glacier%match_smb_obs)
     call GetValue(section,'snow_calc',          model%glacier%snow_calc)
     call GetValue(section,'t_mlt',              model%glacier%t_mlt)
     call GetValue(section,'snow_threshold_min', model%glacier%snow_threshold_min)
@@ -3213,6 +3214,16 @@ contains
           call write_log('Error, glacier_set_mu_star option out of range', GM_FATAL)
        end if
 
+       if (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION) then
+          if (model%glacier%match_smb_obs) then
+             write(message,*) 'mu_star will be adjusted to match SMB observations'
+             call write_log(message)
+          else
+             write(message,*) 'mu_star will be adjusted to give SMB = 0'
+             call write_log(message)
+          endif
+       endif
+
        write(message,*) 'set_powerlaw_c            : ', model%glacier%set_powerlaw_c, &
             glacier_set_powerlaw_c(model%glacier%set_powerlaw_c)
        call write_log(message)
@@ -3220,6 +3231,13 @@ contains
            model%glacier%set_powerlaw_c >= size(glacier_set_powerlaw_c)) then
           call write_log('Error, glacier_set_powerlaw_c option out of range', GM_FATAL)
        end if
+
+       if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
+          if (model%glacier%match_smb_obs) then
+             write(message,*) 'delta_artm will be adjusted to give SMB = 0'
+             call write_log(message)
+          endif
+       endif
 
        write(message,*) 'snow_calc                 : ', model%glacier%snow_calc, &
             glacier_snow_calc(model%glacier%snow_calc)

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3165,6 +3165,8 @@ contains
     call GetValue(section,'t_mlt',              model%glacier%t_mlt)
     call GetValue(section,'snow_threshold_min', model%glacier%snow_threshold_min)
     call GetValue(section,'snow_threshold_max', model%glacier%snow_threshold_max)
+    call GetValue(section,'diagnostic_minthck', model%glacier%diagnostic_minthck)
+    call GetValue(section,'snow_reduction_factor', model%glacier%snow_reduction_factor)
 
   end subroutine handle_glaciers
 
@@ -3227,6 +3229,15 @@ contains
           call write_log('Error, glacier_snow_calc option out of range', GM_FATAL)
        end if
 
+       if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
+          write(message,*) 'powerlaw_c_timescale      :  ', model%inversion%babc_timescale
+          call write_log(message)
+          write(message,*) 'powerlaw_c_thck_scale     :  ', model%inversion%babc_thck_scale
+          call write_log(message)
+          write(message,*) 'powerlaw_c_relax_factor   :  ', model%inversion%babc_relax_factor
+          call write_log(message)
+       endif
+
        if (model%glacier%snow_calc == GLACIER_SNOW_CALC_PRECIP_ARTM) then
           write(message,*) 'snow_threshold_min (deg C): ', model%glacier%snow_threshold_min
           call write_log(message)
@@ -3235,6 +3246,10 @@ contains
        endif
 
        write(message,*) 'glacier T_mlt (deg C)     :  ', model%glacier%t_mlt
+       call write_log(message)
+       write(message,*) 'glc snow reduction factor :  ', model%glacier%snow_reduction_factor
+       call write_log(message)
+       write(message,*) 'glc diagnostic minthck (m):  ', model%glacier%diagnostic_minthck
        call write_log(message)
 
     endif   ! enable_glaciers
@@ -3724,10 +3739,10 @@ contains
        elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
           call glide_add_to_restart_variable_list('powerlaw_c')
        endif
-       !TODO: Are area_target and volume_target needed?
+       !TODO: Are area_init and volume_init needed?
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
-       call glide_add_to_restart_variable_list('glacier_volume_target')
-       call glide_add_to_restart_variable_list('glacier_area_target')
+       call glide_add_to_restart_variable_list('glacier_volume_init')
+       call glide_add_to_restart_variable_list('glacier_area_init')
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3695,9 +3695,7 @@ contains
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_target')
        call glide_add_to_restart_variable_list('glacier_area_target')
-       ! mu_star is needed only if relaxing toward the desired value;
-       !  not needed if computed based on SMB = 0 over the target area
-!!       call glide_add_to_restart_variable_list('glacier_mu_star')
+       call glide_add_to_restart_variable_list('glacier_mu_star')
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3171,14 +3171,22 @@ contains
     type(ConfigSection), pointer :: section
     type(glide_global_type)  :: model
 
-    call GetValue(section,'set_mu_star',        model%glacier%set_mu_star)
-    call GetValue(section,'set_alpha_snow',     model%glacier%set_alpha_snow)
-    call GetValue(section,'set_powerlaw_c',     model%glacier%set_powerlaw_c)
-    call GetValue(section,'snow_calc',          model%glacier%snow_calc)
-    call GetValue(section,'tmlt',               model%glacier%tmlt)
-    call GetValue(section,'snow_threshold_min', model%glacier%snow_threshold_min)
-    call GetValue(section,'snow_threshold_max', model%glacier%snow_threshold_max)
-    call GetValue(section,'diagnostic_minthck', model%glacier%diagnostic_minthck)
+    call GetValue(section,'set_mu_star',             model%glacier%set_mu_star)
+    call GetValue(section,'set_alpha_snow',          model%glacier%set_alpha_snow)
+    call GetValue(section,'set_powerlaw_c',          model%glacier%set_powerlaw_c)
+    call GetValue(section,'snow_calc',               model%glacier%snow_calc)
+    call GetValue(section,'tmlt',                    model%glacier%tmlt)
+    call GetValue(section,'mu_star_const',           model%glacier%mu_star_const)
+    call GetValue(section,'mu_star_min',             model%glacier%mu_star_min)
+    call GetValue(section,'mu_star_max',             model%glacier%mu_star_max)
+    call GetValue(section,'alpha_snow_const',        model%glacier%alpha_snow_const)
+    call GetValue(section,'alpha_snow_min',          model%glacier%alpha_snow_min)
+    call GetValue(section,'alpha_snow_max',          model%glacier%alpha_snow_max)
+    call GetValue(section,'beta_artm_aux_max',       model%glacier%beta_artm_aux_max)
+    call GetValue(section,'beta_artm_aux_increment', model%glacier%beta_artm_aux_increment)
+    call GetValue(section,'snow_threshold_min',      model%glacier%snow_threshold_min)
+    call GetValue(section,'snow_threshold_max',      model%glacier%snow_threshold_max)
+    call GetValue(section,'diagnostic_minthck',      model%glacier%diagnostic_minthck)
 
   end subroutine handle_glaciers
 
@@ -3230,7 +3238,7 @@ contains
           call write_log('Error, glacier_set_mu_star option out of range', GM_FATAL)
        end if
 
-       write(message,*) 'set_alpha_snow           : ', model%glacier%set_alpha_snow, &
+       write(message,*) 'set_alpha_snow            : ', model%glacier%set_alpha_snow, &
             glacier_set_alpha_snow(model%glacier%set_alpha_snow)
        call write_log(message)
        if (model%glacier%set_alpha_snow < 0 .or. &
@@ -3273,15 +3281,31 @@ contains
        endif
 
        if (model%glacier%snow_calc == GLACIER_SNOW_CALC_PRECIP_ARTM) then
-          write(message,*) 'snow_threshold_min (deg C): ', model%glacier%snow_threshold_min
+          write(message,*) 'snow_threshold_min (deg C)  : ', model%glacier%snow_threshold_min
           call write_log(message)
-          write(message,*) 'snow_threshold_max (deg C): ', model%glacier%snow_threshold_max
+          write(message,*) 'snow_threshold_max (deg C)   : ', model%glacier%snow_threshold_max
           call write_log(message)
        endif
 
-       write(message,*) 'glc tmlt (deg C)          :  ', model%glacier%tmlt
+       write(message,*) 'glc diagnostic minthck (m)    :  ', model%glacier%diagnostic_minthck
        call write_log(message)
-       write(message,*) 'glc diagnostic minthck (m):  ', model%glacier%diagnostic_minthck
+       write(message,*) 'glc tmlt (deg C)              :  ', model%glacier%tmlt
+       call write_log(message)
+       write(message,*) 'mu_star_const (mm/yr/degC)    :  ', model%glacier%mu_star_const
+       call write_log(message)
+       write(message,*) 'mu_star_min (mm/yr/degC)      :  ', model%glacier%mu_star_min
+       call write_log(message)
+       write(message,*) 'mu_star_max (mm/yr/degC)      :  ', model%glacier%mu_star_max
+       call write_log(message)
+       write(message,*) 'alpha_snow_const              :  ', model%glacier%alpha_snow_const
+       call write_log(message)
+       write(message,*) 'alpha_snow_min                :  ', model%glacier%alpha_snow_min
+       call write_log(message)
+       write(message,*) 'alpha_snow_max                :  ', model%glacier%alpha_snow_max
+       call write_log(message)
+       write(message,*) 'beta_artm_aux_max (degC)      :  ', model%glacier%beta_artm_aux_max
+       call write_log(message)
+       write(message,*) 'beta_artm_aux_increment (degC):  ', model%glacier%beta_artm_aux_increment
        call write_log(message)
 
     endif   ! enable_glaciers

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3175,6 +3175,7 @@ contains
     call GetValue(section,'set_alpha_snow',          model%glacier%set_alpha_snow)
     call GetValue(section,'set_powerlaw_c',          model%glacier%set_powerlaw_c)
     call GetValue(section,'snow_calc',               model%glacier%snow_calc)
+    call GetValue(section,'scale_area',              model%glacier%scale_area)
     call GetValue(section,'tmlt',                    model%glacier%tmlt)
     call GetValue(section,'mu_star_const',           model%glacier%mu_star_const)
     call GetValue(section,'mu_star_min',             model%glacier%mu_star_min)
@@ -3201,7 +3202,7 @@ contains
     type(glide_global_type)  :: model
     character(len=100) :: message
 
-    ! glacier inversion options
+    ! glacier options
 
     character(len=*), dimension(0:2), parameter :: glacier_set_mu_star = (/ &
          'spatially uniform glacier parameter mu_star', &
@@ -3261,6 +3262,10 @@ contains
            model%glacier%snow_calc >= size(glacier_snow_calc)) then
           call write_log('Error, glacier_snow_calc option out of range', GM_FATAL)
        end if
+
+       if (model%glacier%scale_area) then
+          call write_log ('Glacier area will be scaled based on latitude')
+       endif
 
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           write(message,*) 'powerlaw_c_timescale      :  ', model%inversion%babc_timescale
@@ -3791,17 +3796,20 @@ contains
        call glide_add_to_restart_variable_list('glacier_alpha_snow')
        call glide_add_to_restart_variable_list('glacier_beta_artm_aux')
        call glide_add_to_restart_variable_list('glacier_smb_obs')
-       !TODO - would not need to write glacier_smb_obs if in a forcing file?
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('powerlaw_c')
           call glide_add_to_restart_variable_list('usrf_obs')
        elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
           call glide_add_to_restart_variable_list('powerlaw_c')
        endif
-       !TODO: Are area_init and volume_init needed?
+       !TODO: Are area_init and volume_init needed in the restart file?
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_init')
        call glide_add_to_restart_variable_list('glacier_area_init')
+       ! area scale factor
+       if (model%glacier%scale_area) then
+          call glide_add_to_restart_variable_list('glacier_area_factor')
+       endif
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3145,7 +3145,6 @@ contains
 
     call GetValue(section,'set_mu_star',    model%glacier%set_mu_star)
     call GetValue(section,'set_powerlaw_c', model%glacier%set_powerlaw_c)
-    call GetValue(section,'minthck',        model%glacier%minthck)
     call GetValue(section,'tmlt',           model%glacier%tmlt)
 
   end subroutine handle_glaciers
@@ -3197,8 +3196,6 @@ contains
           call write_log('Error, glacier_set_powerlaw_c option out of range', GM_FATAL)
        end if
 
-       write(message,*) 'glacier minthck (m)      :  ', model%glacier%minthck
-       call write_log(message)
        write(message,*) 'glacier Tmlt (deg C)     :  ', model%glacier%tmlt
        call write_log(message)
 

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3193,6 +3193,7 @@ contains
     call GetValue(section,'set_powerlaw_c',          model%glacier%set_powerlaw_c)
     call GetValue(section,'snow_calc',               model%glacier%snow_calc)
     call GetValue(section,'scale_area',              model%glacier%scale_area)
+    call GetValue(section,'length_scale_factor',     model%glacier%length_scale_factor)
     call GetValue(section,'tmlt',                    model%glacier%tmlt)
     call GetValue(section,'mu_star_const',           model%glacier%mu_star_const)
     call GetValue(section,'mu_star_min',             model%glacier%mu_star_min)
@@ -3285,6 +3286,18 @@ contains
 
        if (model%glacier%scale_area) then
           call write_log ('Glacier area will be scaled based on latitude')
+       endif
+
+       if (model%glacier%length_scale_factor /= 1.0d0) then
+          if (model%glacier%scale_area) then
+             write(message,*) 'dew and dns will be scaled by a factor of ', &
+                  model%glacier%length_scale_factor
+             call write_log(message)
+          else
+             model%glacier%length_scale_factor = 1.0d0
+             write(message,*) 'length_scale_factor will be ignored since glacier%scale_area = F'
+             write(message,*) 'Setting length_scale_factor = 1.0'
+          endif
        endif
 
        if (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION .and. &
@@ -3845,10 +3858,6 @@ contains
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_init')
        call glide_add_to_restart_variable_list('glacier_area_init')
-       ! area scale factor
-       if (model%glacier%scale_area) then
-          call glide_add_to_restart_variable_list('glacier_area_factor')
-       endif
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3667,14 +3667,13 @@ contains
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
        ! Save the arrays used to find the SMB and basal friction
+       !TODO: Not sure that area_target and volume_target are needed.
+       !      These could be computed based on cism_glacier_id_init and thck_obs.
        call glide_add_to_restart_variable_list('glacier_area_target')
        call glide_add_to_restart_variable_list('glacier_volume_target')
        ! Not sure that mu_star is needed (if computed based on SMB = 0 over init area)
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_powerlaw_c')
-       !WHL - Write to restart for now; also possible to derive from glacier_powerlaw_c
-       !      (in a subroutine to be written)
-       call glide_add_to_restart_variable_list('powerlaw_c')
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3187,7 +3187,9 @@ contains
     call GetValue(section,'beta_artm_increment',     model%glacier%beta_artm_increment)
     call GetValue(section,'snow_threshold_min',      model%glacier%snow_threshold_min)
     call GetValue(section,'snow_threshold_max',      model%glacier%snow_threshold_max)
-    call GetValue(section,'precip_lapse',            model%glacier%precip_lapse)
+    call GetValue(section,'baseline_date',           model%glacier%baseline_date)
+    call GetValue(section,'rgi_date',                model%glacier%rgi_date)
+    call GetValue(section,'recent_date',                model%glacier%recent_date)
     call GetValue(section,'diagnostic_minthck',      model%glacier%diagnostic_minthck)
 
   end subroutine handle_glaciers
@@ -3270,16 +3272,20 @@ contains
 
        if (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION .and. &
            model%glacier%set_alpha_snow == GLACIER_ALPHA_SNOW_INVERSION) then
-!!          write(message,*) 'glc baseline date         :  ', model%glacier%baseline_date
+          write(message,*) 'baseline date for inversion :  ', model%glacier%baseline_date
+          call write_log(message)
+          write(message,*) 'RGI date for inversion      :  ', model%glacier%rgi_date
+          call write_log(message)
+          write(message,*) 'recent date for inversion   :  ', model%glacier%recent_date
           call write_log(message)
        endif
 
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
-          write(message,*) 'powerlaw_c_timescale      :  ', model%inversion%babc_timescale
+          write(message,*) 'powerlaw_c_timescale        :  ', model%inversion%babc_timescale
           call write_log(message)
-          write(message,*) 'powerlaw_c_thck_scale     :  ', model%inversion%babc_thck_scale
+          write(message,*) 'powerlaw_c_thck_scale       :  ', model%inversion%babc_thck_scale
           call write_log(message)
-          write(message,*) 'powerlaw_c_relax_factor   :  ', model%inversion%babc_relax_factor
+          write(message,*) 'powerlaw_c_relax_factor     :  ', model%inversion%babc_relax_factor
           call write_log(message)
        endif
 
@@ -3293,33 +3299,31 @@ contains
        endif
 
        if (model%glacier%snow_calc == GLACIER_SNOW_CALC_PRECIP_ARTM) then
-          write(message,*) 'snow_threshold_min (deg C)    : ', model%glacier%snow_threshold_min
+          write(message,*) 'snow_threshold_min (deg C)  : ', model%glacier%snow_threshold_min
           call write_log(message)
-          write(message,*) 'snow_threshold_max (deg C)    : ', model%glacier%snow_threshold_max
-          call write_log(message)
-          write(message,*) 'precip_lapse (fraction/m)     : ', model%glacier%precip_lapse
+          write(message,*) 'snow_threshold_max (deg C)  : ', model%glacier%snow_threshold_max
           call write_log(message)
        endif
 
-       write(message,*) 'glc diagnostic minthck (m)    :  ', model%glacier%diagnostic_minthck
+       write(message,*) 'glc diagnostic minthck (m)  :  ', model%glacier%diagnostic_minthck
        call write_log(message)
-       write(message,*) 'glc tmlt (deg C)              :  ', model%glacier%tmlt
+       write(message,*) 'glc tmlt (deg C)            :  ', model%glacier%tmlt
        call write_log(message)
-       write(message,*) 'mu_star_const (mm/yr/degC)    :  ', model%glacier%mu_star_const
+       write(message,*) 'mu_star_const (mm/yr/degC)  :  ', model%glacier%mu_star_const
        call write_log(message)
-       write(message,*) 'mu_star_min (mm/yr/degC)      :  ', model%glacier%mu_star_min
+       write(message,*) 'mu_star_min (mm/yr/degC)    :  ', model%glacier%mu_star_min
        call write_log(message)
-       write(message,*) 'mu_star_max (mm/yr/degC)      :  ', model%glacier%mu_star_max
+       write(message,*) 'mu_star_max (mm/yr/degC)    :  ', model%glacier%mu_star_max
        call write_log(message)
-       write(message,*) 'alpha_snow_const              :  ', model%glacier%alpha_snow_const
+       write(message,*) 'alpha_snow_const            :  ', model%glacier%alpha_snow_const
        call write_log(message)
-       write(message,*) 'alpha_snow_min                :  ', model%glacier%alpha_snow_min
+       write(message,*) 'alpha_snow_min              :  ', model%glacier%alpha_snow_min
        call write_log(message)
-       write(message,*) 'alpha_snow_max                :  ', model%glacier%alpha_snow_max
+       write(message,*) 'alpha_snow_max              :  ', model%glacier%alpha_snow_max
        call write_log(message)
-       write(message,*) 'beta_artm_max (degC)          :  ', model%glacier%beta_artm_max
+       write(message,*) 'beta_artm_max (degC)        :  ', model%glacier%beta_artm_max
        call write_log(message)
-       write(message,*) 'beta_artm_increment (degC)    :  ', model%glacier%beta_artm_increment
+       write(message,*) 'beta_artm_increment (degC)  :  ', model%glacier%beta_artm_increment
        call write_log(message)
 
     endif   ! enable_glaciers
@@ -3806,7 +3810,7 @@ contains
        ! SMB is computed at the end of each year to apply during the next year
        call glide_add_to_restart_variable_list('smb')
        call glide_add_to_restart_variable_list('smb_rgi')
-       call glide_add_to_restart_variable_list('smb_aux')
+       call glide_add_to_restart_variable_list('smb_recent')
        ! mu_star, alpha_snow, and beta_artm are inversion parameters
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_alpha_snow')

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3177,6 +3177,7 @@ contains
     call GetValue(section,'snow_calc',               model%glacier%snow_calc)
     call GetValue(section,'scale_area',              model%glacier%scale_area)
     call GetValue(section,'tmlt',                    model%glacier%tmlt)
+    call GetValue(section,'dt_aux',                  model%glacier%dt_aux)
     call GetValue(section,'mu_star_const',           model%glacier%mu_star_const)
     call GetValue(section,'mu_star_min',             model%glacier%mu_star_min)
     call GetValue(section,'mu_star_max',             model%glacier%mu_star_max)
@@ -3268,6 +3269,12 @@ contains
           call write_log ('Glacier area will be scaled based on latitude')
        endif
 
+       if (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION .and. &
+           model%glacier%set_alpha_snow == GLACIER_ALPHA_SNOW_INVERSION) then
+          write(message,*) 'glc dt_aux (deg C)            :  ', model%glacier%dt_aux
+          call write_log(message)
+       endif
+
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           write(message,*) 'powerlaw_c_timescale      :  ', model%inversion%babc_timescale
           call write_log(message)
@@ -3279,7 +3286,7 @@ contains
 
        ! Check for combinations not allowed
        if (model%glacier%set_mu_star /= GLACIER_MU_STAR_INVERSION) then
-          if (model%glacier%set_alpha_snow == GLACIER_alpha_SNOW_INVERSION) then
+          if (model%glacier%set_alpha_snow == GLACIER_ALPHA_SNOW_INVERSION) then
              call write_log('Error, must invert for mu_star if inverting for alpha_snow', GM_FATAL)
           elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
              call write_log('Error, must invert for mu_star if inverting for powerlaw_c', GM_FATAL)
@@ -3794,20 +3801,20 @@ contains
        call glide_add_to_restart_variable_list('smb_glacier_id')
        call glide_add_to_restart_variable_list('smb_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
-       ! some fields needed for glacier inversion
+       ! SMB is computed at the end of each year to apply during the next year
+       call glide_add_to_restart_variable_list('smb')
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_alpha_snow')
        call glide_add_to_restart_variable_list('glacier_beta_artm_aux')
+       ! smb_obs and smb_aux are used for glacier inversion
        call glide_add_to_restart_variable_list('glacier_smb_obs')
+       call glide_add_to_restart_variable_list('smb_aux')
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('powerlaw_c')
           call glide_add_to_restart_variable_list('usrf_obs')
        elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_EXTERNAL) then
           call glide_add_to_restart_variable_list('powerlaw_c')
        endif
-       ! SMB is computed at the end of each year to apply during the next year
-       ! Alternatively, could save Tpos and snow everywhere
-       call glide_add_to_restart_variable_list('smb')
        !TODO: Are area_init and volume_init needed in the restart file?
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_init')

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3496,12 +3496,12 @@ contains
           endif
 
        case(ARTM_INPUT_FUNCTION_XY_LAPSE)
-          call glide_add_to_restart_variable_list('artm_ref')
+          call glide_add_to_restart_variable_list('artm_ref', model_id)
           ! Note: Instead of artm_gradz, there is a uniform lapse rate
           if (options%smb_input_function == SMB_INPUT_FUNCTION_XY_GRADZ) then
              ! usrf_ref was added to restart above; nothing to do here
           else
-             call glide_add_to_restart_variable_list('usrf_ref')
+             call glide_add_to_restart_variable_list('usrf_ref', model_id)
           endif
 
     end select  ! artm_input_function
@@ -3849,31 +3849,31 @@ contains
     if (model%options%enable_glaciers) then
        ! some fields related to glacier indexing
        !TODO - Do we need all the SMB masks?
-       call glide_add_to_restart_variable_list('rgi_glacier_id')
-       call glide_add_to_restart_variable_list('cism_glacier_id')
-       call glide_add_to_restart_variable_list('cism_glacier_id_init')
-       call glide_add_to_restart_variable_list('cism_glacier_id_baseline')
-       call glide_add_to_restart_variable_list('smb_glacier_id')
-       call glide_add_to_restart_variable_list('smb_glacier_id_init')
-       call glide_add_to_restart_variable_list('smb_glacier_id_baseline')
-       call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
+       call glide_add_to_restart_variable_list('rgi_glacier_id', model_id)
+       call glide_add_to_restart_variable_list('cism_glacier_id', model_id)
+       call glide_add_to_restart_variable_list('cism_glacier_id_init', model_id)
+       call glide_add_to_restart_variable_list('cism_glacier_id_baseline', model_id)
+       call glide_add_to_restart_variable_list('smb_glacier_id', model_id)
+       call glide_add_to_restart_variable_list('smb_glacier_id_init', model_id)
+       call glide_add_to_restart_variable_list('smb_glacier_id_baseline', model_id)
+       call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id', model_id)
        ! SMB is computed at the end of each year to apply during the next year
-       call glide_add_to_restart_variable_list('smb')
-       call glide_add_to_restart_variable_list('smb_rgi')
-       call glide_add_to_restart_variable_list('smb_recent')
+       call glide_add_to_restart_variable_list('smb', model_id)
+       call glide_add_to_restart_variable_list('smb_rgi', model_id)
+       call glide_add_to_restart_variable_list('smb_recent', model_id)
        ! mu_star, alpha_snow, and beta_artm are inversion parameters
-       call glide_add_to_restart_variable_list('glacier_mu_star')
-       call glide_add_to_restart_variable_list('glacier_alpha_snow')
-       call glide_add_to_restart_variable_list('glacier_beta_artm')
+       call glide_add_to_restart_variable_list('glacier_mu_star', model_id)
+       call glide_add_to_restart_variable_list('glacier_alpha_snow', model_id)
+       call glide_add_to_restart_variable_list('glacier_beta_artm', model_id)
        ! smb_obs and usrf_obs are used to invert for mu_star
-       call glide_add_to_restart_variable_list('glacier_smb_obs')
-       call glide_add_to_restart_variable_list('usrf_obs')
+       call glide_add_to_restart_variable_list('glacier_smb_obs', model_id)
+       call glide_add_to_restart_variable_list('usrf_obs', model_id)
        ! powerlaw_c is used for power law sliding
-       call glide_add_to_restart_variable_list('powerlaw_c')
+       call glide_add_to_restart_variable_list('powerlaw_c', model_id)
        !TODO: Are area_init and volume_init needed in the restart file?
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
-       call glide_add_to_restart_variable_list('glacier_volume_init')
-       call glide_add_to_restart_variable_list('glacier_area_init')
+       call glide_add_to_restart_variable_list('glacier_volume_init', model_id)
+       call glide_add_to_restart_variable_list('glacier_area_init', model_id)
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3172,7 +3172,7 @@ contains
     type(glide_global_type)  :: model
 
     call GetValue(section,'set_mu_star',        model%glacier%set_mu_star)
-    call GetValue(section,'set_snow_factor',    model%glacier%set_snow_factor)
+    call GetValue(section,'set_alpha_snow',     model%glacier%set_alpha_snow)
     call GetValue(section,'set_powerlaw_c',     model%glacier%set_powerlaw_c)
     call GetValue(section,'snow_calc',          model%glacier%snow_calc)
     call GetValue(section,'tmlt',               model%glacier%tmlt)
@@ -3200,10 +3200,10 @@ contains
          'glacier-specific mu_star found by inversion', &
          'glacier-specific mu_star read from file    ' /)
 
-    character(len=*), dimension(0:2), parameter :: glacier_set_snow_factor = (/ &
-         'spatially uniform glacier parameter snow_factor', &
-         'glacier-specific snow_factor found by inversion', &
-         'glacier-specific snow_factor read from file    ' /)
+    character(len=*), dimension(0:2), parameter :: glacier_set_alpha_snow = (/ &
+         'spatially uniform glacier parameter alpha_snow', &
+         'glacier-specific alpha_snow found by inversion', &
+         'glacier-specific alpha_snow read from file    ' /)
 
     character(len=*), dimension(0:2), parameter :: glacier_set_powerlaw_c = (/ &
          'spatially uniform glacier parameter Cp', &
@@ -3230,12 +3230,12 @@ contains
           call write_log('Error, glacier_set_mu_star option out of range', GM_FATAL)
        end if
 
-       write(message,*) 'set_snow_factor           : ', model%glacier%set_snow_factor, &
-            glacier_set_snow_factor(model%glacier%set_snow_factor)
+       write(message,*) 'set_alpha_snow           : ', model%glacier%set_alpha_snow, &
+            glacier_set_alpha_snow(model%glacier%set_alpha_snow)
        call write_log(message)
-       if (model%glacier%set_snow_factor < 0 .or. &
-           model%glacier%set_snow_factor >= size(glacier_set_snow_factor)) then
-          call write_log('Error, glacier_set_snow_factor option out of range', GM_FATAL)
+       if (model%glacier%set_alpha_snow < 0 .or. &
+           model%glacier%set_alpha_snow >= size(glacier_set_alpha_snow)) then
+          call write_log('Error, glacier_set_alpha_snow option out of range', GM_FATAL)
        end if
 
        write(message,*) 'set_powerlaw_c            : ', model%glacier%set_powerlaw_c, &
@@ -3265,8 +3265,8 @@ contains
 
        ! Check for combinations not allowed
        if (model%glacier%set_mu_star /= GLACIER_MU_STAR_INVERSION) then
-          if (model%glacier%set_snow_factor == GLACIER_SNOW_FACTOR_INVERSION) then
-             call write_log('Error, must invert for mu_star if inverting for snow_factor', GM_FATAL)
+          if (model%glacier%set_alpha_snow == GLACIER_alpha_SNOW_INVERSION) then
+             call write_log('Error, must invert for mu_star if inverting for alpha_snow', GM_FATAL)
           elseif (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
              call write_log('Error, must invert for mu_star if inverting for powerlaw_c', GM_FATAL)
           endif
@@ -3764,8 +3764,8 @@ contains
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
        ! some fields needed for glacier inversion
        call glide_add_to_restart_variable_list('glacier_mu_star')
-       call glide_add_to_restart_variable_list('glacier_snow_factor')
-       call glide_add_to_restart_variable_list('glacier_artm_aux_corr')
+       call glide_add_to_restart_variable_list('glacier_alpha_snow')
+       call glide_add_to_restart_variable_list('glacier_beta_artm_aux')
        call glide_add_to_restart_variable_list('glacier_smb_obs')
        !TODO - would not need to write glacier_smb_obs if in a forcing file?
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -2652,6 +2652,10 @@ contains
     elseif (model%options%which_ho_babc == HO_BABC_POWERLAW) then
        write(message,*) 'Cp for power law, Pa (m/yr)^(-1/3)           : ', model%basal_physics%powerlaw_c_const
        call write_log(message)
+       write(message,*) 'Max Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_max
+       call write_log(message)
+       write(message,*) 'Min Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_min
+       call write_log(message)
        write(message,*) 'm exponent for power law                     : ', model%basal_physics%powerlaw_m
        call write_log(message)
     elseif (model%options%which_ho_babc == HO_BABC_COULOMB_FRICTION) then
@@ -2668,6 +2672,10 @@ contains
        call write_log(message)
        write(message,*) 'Cp for Schoof power law, Pa (m/yr)^(-1/3)    : ', model%basal_physics%powerlaw_c_const
        call write_log(message)
+       write(message,*) 'Max Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_max
+       call write_log(message)
+       write(message,*) 'Min Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_min
+       call write_log(message)
        write(message,*) 'm exponent for Schoof power law              : ', model%basal_physics%powerlaw_m
        call write_log(message)
     elseif (model%options%which_ho_babc == HO_BABC_COULOMB_POWERLAW_TSAI) then
@@ -2676,6 +2684,10 @@ contains
        write(message,*) 'Cc for Tsai Coulomb law                      : ', model%basal_physics%coulomb_c_const
        call write_log(message)
        write(message,*) 'Cp for Tsai power law, Pa (m/yr)^(-1/3)      : ', model%basal_physics%powerlaw_c_const
+       call write_log(message)
+       write(message,*) 'Max Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_max
+       call write_log(message)
+       write(message,*) 'Min Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_min
        call write_log(message)
        write(message,*) 'm exponent for Tsai power law                : ', model%basal_physics%powerlaw_m
        call write_log(message)

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -949,10 +949,11 @@ contains
          'SMB and d(SMB)/dz input as function of (x,y)', &
          'SMB input as function of (x,y,z)            ' /)
 
-    character(len=*), dimension(0:2), parameter :: artm_input_function = (/ &
+    character(len=*), dimension(0:3), parameter :: artm_input_function = (/ &
          'artm input as function of (x,y)               ', &
          'artm and d(artm)/dz input as function of (x,y)', &
-         'artm input as function of (x,y,z)             ' /)
+         'artm input as function of (x,y,z)             ', &
+         'artm input as function of (x,y) w/ lapse rate ' /)
 
     character(len=*), dimension(0:3), parameter :: overwrite_acab = (/ &
          'do not overwrite acab anywhere            ', &
@@ -1599,6 +1600,9 @@ contains
        if (model%climate%nlev_smb < 2) then
           call write_log('Error, must have nlev_smb >= 2 for this input function', GM_FATAL)
        endif
+    elseif (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_LAPSE) then
+       write(message,*) 'artm lapse rate (deg/m) : ', model%climate%t_lapse
+       call write_log(message)
     endif
 
     if (model%options%enable_acab_anomaly) then
@@ -2117,6 +2121,7 @@ contains
     real(dp), pointer, dimension(:) :: tempvar => NULL()
     integer :: loglevel
 
+    !TODO - Reorganize parameters into sections based on relevant physics
     !Note: The following physical constants have default values in glimmer_physcon.F90.
     !      Some test cases (e.g., MISMIP) specify different values. The default values
     !       can therefore be overridden by the user in the config file.
@@ -2157,6 +2162,7 @@ contains
     call GetValue(section,'max_slope',          model%paramets%max_slope)
 
     ! parameters to adjust external forcing
+    call GetValue(section,'t_lapse',            model%climate%t_lapse)
     call GetValue(section,'acab_factor',        model%climate%acab_factor)
     call GetValue(section,'bmlt_float_factor',  model%basal_melt%bmlt_float_factor)
 
@@ -3145,7 +3151,7 @@ contains
 
     call GetValue(section,'set_mu_star',    model%glacier%set_mu_star)
     call GetValue(section,'set_powerlaw_c', model%glacier%set_powerlaw_c)
-    call GetValue(section,'tmlt',           model%glacier%tmlt)
+    call GetValue(section,'t_mlt',          model%glacier%t_mlt)
 
   end subroutine handle_glaciers
 
@@ -3180,7 +3186,7 @@ contains
 
        call write_log('Glacier tracking and tuning is enabled')
 
-       write(message,*) 'set_mu_star              : ', model%glacier%set_mu_star, &
+       write(message,*) 'set_mu_star               : ', model%glacier%set_mu_star, &
             glacier_set_mu_star(model%glacier%set_mu_star)
        call write_log(message)
        if (model%glacier%set_mu_star < 0 .or. &
@@ -3188,7 +3194,7 @@ contains
           call write_log('Error, glacier_set_mu_star option out of range', GM_FATAL)
        end if
 
-       write(message,*) 'set_powerlaw_c           : ', model%glacier%set_powerlaw_c, &
+       write(message,*) 'set_powerlaw_c            : ', model%glacier%set_powerlaw_c, &
             glacier_set_powerlaw_c(model%glacier%set_powerlaw_c)
        call write_log(message)
        if (model%glacier%set_powerlaw_c < 0 .or. &
@@ -3196,7 +3202,7 @@ contains
           call write_log('Error, glacier_set_powerlaw_c option out of range', GM_FATAL)
        end if
 
-       write(message,*) 'glacier Tmlt (deg C)     :  ', model%glacier%tmlt
+       write(message,*) 'glacier T_mlt (deg C)     :  ', model%glacier%t_mlt
        call write_log(message)
 
     endif   ! enable_glaciers
@@ -3298,7 +3304,7 @@ contains
     end select  ! smb_input_function
 
     ! Similarly for surface temperature (artm), based on options%artm_input
-    ! Note: These options share smb_reference_usrf and smb_levels with the SMB options above.
+    ! Note: These options share usrf_ref and smb_levels with the SMB options above.
 
     select case(options%artm_input_function)
 
@@ -3306,7 +3312,7 @@ contains
           call glide_add_to_restart_variable_list('artm_ref', model_id)
           call glide_add_to_restart_variable_list('artm_gradz', model_id)
           if (options%smb_input_function == SMB_INPUT_FUNCTION_XY_GRADZ) then
-             ! smb_reference_usrf was added to restart above; nothing to do here
+             ! usrf_ref was added to restart above; nothing to do here
           else
              call glide_add_to_restart_variable_list('smb_reference_usrf', model_id)
           endif
@@ -3317,6 +3323,15 @@ contains
              ! smb_levels was added to restart above; nothing to do here
           else
              call glide_add_to_restart_variable_list('smb_levels', model_id)
+          endif
+
+       case(ARTM_INPUT_FUNCTION_XY_LAPSE)
+          call glide_add_to_restart_variable_list('artm_ref')
+          ! Note: Instead of artm_gradz, there is a uniform lapse rate
+          if (options%smb_input_function == SMB_INPUT_FUNCTION_XY_GRADZ) then
+             ! usrf_ref was added to restart above; nothing to do here
+          else
+             call glide_add_to_restart_variable_list('usrf_ref')
           endif
 
     end select  ! artm_input_function

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -2627,6 +2627,10 @@ contains
     elseif (model%options%which_ho_babc == HO_BABC_POWERLAW) then
        write(message,*) 'Cp for power law, Pa (m/yr)^(-1/3)           : ', model%basal_physics%powerlaw_c_const
        call write_log(message)
+       write(message,*) 'Max Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_max
+       call write_log(message)
+       write(message,*) 'Min Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_min
+       call write_log(message)
        write(message,*) 'm exponent for power law                     : ', model%basal_physics%powerlaw_m
        call write_log(message)
     elseif (model%options%which_ho_babc == HO_BABC_COULOMB_FRICTION) then
@@ -2643,6 +2647,10 @@ contains
        call write_log(message)
        write(message,*) 'Cp for Schoof power law, Pa (m/yr)^(-1/3)    : ', model%basal_physics%powerlaw_c_const
        call write_log(message)
+       write(message,*) 'Max Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_max
+       call write_log(message)
+       write(message,*) 'Min Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_min
+       call write_log(message)
        write(message,*) 'm exponent for Schoof power law              : ', model%basal_physics%powerlaw_m
        call write_log(message)
     elseif (model%options%which_ho_babc == HO_BABC_COULOMB_POWERLAW_TSAI) then
@@ -2651,6 +2659,10 @@ contains
        write(message,*) 'Cc for Tsai Coulomb law                      : ', model%basal_physics%coulomb_c_const
        call write_log(message)
        write(message,*) 'Cp for Tsai power law, Pa (m/yr)^(-1/3)      : ', model%basal_physics%powerlaw_c_const
+       call write_log(message)
+       write(message,*) 'Max Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_max
+       call write_log(message)
+       write(message,*) 'Min Cp for power law, Pa (m/yr)^(-1/3)       : ', model%basal_physics%powerlaw_c_min
        call write_log(message)
        write(message,*) 'm exponent for Tsai power law                : ', model%basal_physics%powerlaw_m
        call write_log(message)
@@ -3163,11 +3175,10 @@ contains
     call GetValue(section,'set_snow_factor',    model%glacier%set_snow_factor)
     call GetValue(section,'set_powerlaw_c',     model%glacier%set_powerlaw_c)
     call GetValue(section,'snow_calc',          model%glacier%snow_calc)
-    call GetValue(section,'t_mlt',              model%glacier%t_mlt)
+    call GetValue(section,'tmlt_const',         model%glacier%tmlt_const)
     call GetValue(section,'snow_threshold_min', model%glacier%snow_threshold_min)
     call GetValue(section,'snow_threshold_max', model%glacier%snow_threshold_max)
     call GetValue(section,'diagnostic_minthck', model%glacier%diagnostic_minthck)
-    call GetValue(section,'snow_reduction_factor', model%glacier%snow_reduction_factor)
 
   end subroutine handle_glaciers
 
@@ -3268,9 +3279,7 @@ contains
           call write_log(message)
        endif
 
-       write(message,*) 'glacier T_mlt (deg C)     :  ', model%glacier%t_mlt
-       call write_log(message)
-       write(message,*) 'glc snow reduction factor :  ', model%glacier%snow_reduction_factor
+       write(message,*) 'glc tmlt_const (deg C)    :  ', model%glacier%tmlt_const
        call write_log(message)
        write(message,*) 'glc diagnostic minthck (m):  ', model%glacier%diagnostic_minthck
        call write_log(message)
@@ -3750,10 +3759,13 @@ contains
        call glide_add_to_restart_variable_list('rgi_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
+       call glide_add_to_restart_variable_list('smb_glacier_id')
+       call glide_add_to_restart_variable_list('smb_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
        ! some fields needed for glacier inversion
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_snow_factor')
+       call glide_add_to_restart_variable_list('glacier_tmlt')
        call glide_add_to_restart_variable_list('glacier_smb_obs')
        !TODO - would not need to write glacier_smb_obs if in a forcing file?
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3691,7 +3691,9 @@ contains
        call glide_add_to_restart_variable_list('cism_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
-       ! Save some arrays used to find the SMB and basal friction
+       ! Save some arrays used to find SMB and basal friction parameters
+       call glide_add_to_restart_variable_list('glacier_smb_obs')
+       call glide_add_to_restart_variable_list('glacier_mu_star')
        if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('usrf_obs')
           call glide_add_to_restart_variable_list('powerlaw_c')
@@ -3702,7 +3704,6 @@ contains
        !      These could be computed based on cism_glacier_id_init and usrf_obs.
        call glide_add_to_restart_variable_list('glacier_volume_target')
        call glide_add_to_restart_variable_list('glacier_area_target')
-       call glide_add_to_restart_variable_list('glacier_mu_star')
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -2297,12 +2297,6 @@ contains
     call GetValue(section, 'thermal_forcing_anomaly_timescale', model%ocean_data%thermal_forcing_anomaly_timescale)
     call GetValue(section, 'thermal_forcing_anomaly_basin', model%ocean_data%thermal_forcing_anomaly_basin)
 
-    ! glacier parameters
-    !TODO - Create a separate glacier section
-    call GetValue(section, 'gamma0', model%glacier%mu_star_const)
-    call GetValue(section, 'gamma0', model%glacier%mu_star_min)
-    call GetValue(section, 'gamma0', model%glacier%mu_star_max)
-
     ! parameters to adjust input topography
     call GetValue(section, 'adjust_topg_xmin', model%paramets%adjust_topg_xmin)
     call GetValue(section, 'adjust_topg_xmax', model%paramets%adjust_topg_xmax)
@@ -3713,19 +3707,19 @@ contains
     end select
 
     if (model%options%enable_glaciers) then
+       ! Save some arrays related to glacier indexing
        call glide_add_to_restart_variable_list('rgi_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id')
+       call glide_add_to_restart_variable_list('cism_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
+       ! Save the arrays used to find the SMB and basal friction
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_powerlaw_c')
-       if (model%options%glacier_mu_star == GLACIER_MU_STAR_INVERSION) then
-          call glide_add_to_restart_variable_list('glacier_area_target')
-       endif
        if (model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
           call glide_add_to_restart_variable_list('glacier_volume_target')
        endif
     endif
-    !
+
     ! basal processes module - requires tauf for a restart
 !!    if (options%which_bproc /= BAS_PROC_DISABLED ) then
 !!        call glide_add_to_restart_variable_list('tauf', model_id)

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3713,17 +3713,17 @@ contains
     end select
 
     if (model%options%enable_glaciers) then
-!       call glide_add_to_restart_variable_list('nglacier')
-!       call glide_add_to_restart_variable_list('ngdiag')
-!       call glide_add_to_restart_variable_list('glacierid')
        call glide_add_to_restart_variable_list('rgi_glacier_id')
        call glide_add_to_restart_variable_list('cism_glacier_id')
-       call glide_add_to_restart_variable_list('glacier_area_target')
-       call glide_add_to_restart_variable_list('glacier_volume_target')
+       call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_powerlaw_c')
-       ! Some arrays have dimension nglacier, which isn't known initially.
-       ! Note: cism_to_rgi_glacier_id can be recomputed, given rgi_glacier_id and cism_glacier_id
+       if (model%options%glacier_mu_star == GLACIER_MU_STAR_INVERSION) then
+          call glide_add_to_restart_variable_list('glacier_area_target')
+       endif
+       if (model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
+          call glide_add_to_restart_variable_list('glacier_volume_target')
+       endif
     endif
     !
     ! basal processes module - requires tauf for a restart

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -766,7 +766,6 @@ contains
     !      Going forward, only 'restart' is supported.
     call GetValue(section,'restart',model%options%is_restart)
     call GetValue(section,'restart_extend_velo',model%options%restart_extend_velo)
-    call GetValue(section,'forcewrite_restart',model%options%forcewrite_restart)
 
   end subroutine handle_options
 
@@ -1653,16 +1652,17 @@ contains
        call write_log('  Slightly cheated with how temperature is implemented.',GM_WARNING)
     end if
 
-    if (model%options%is_restart == RESTART_TRUE) then
+    if (model%options%is_restart == STANDARD_RESTART) then
        call write_log('Restarting model from a previous run')
        if (model%options%restart_extend_velo == RESTART_EXTEND_VELO_TRUE) then
           call write_log('Using extended velocity fields for restart')
        endif
+    elseif (model%options%is_restart == HYBRID_RESTART) then
+       call write_log('Hybrid restart from a previous run')
+       if (model%options%restart_extend_velo == RESTART_EXTEND_VELO_TRUE) then
+          call write_log('Using extended velocity fields for restart')
+       endif
     end if
-
-    if (model%options%forcewrite_restart) then
-       call write_log('Will write to output files on restart')
-    endif
 
     !HO options
 

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -3670,11 +3670,14 @@ contains
        call glide_add_to_restart_variable_list('cism_glacier_id_init')
        call glide_add_to_restart_variable_list('cism_to_rgi_glacier_id')
        ! Save the arrays used to find the SMB and basal friction
+       call glide_add_to_restart_variable_list('glacier_area_target')
+       call glide_add_to_restart_variable_list('glacier_volume_target')
+       ! Not sure that mu_star is needed (if computed based on SMB = 0 over init area)
        call glide_add_to_restart_variable_list('glacier_mu_star')
        call glide_add_to_restart_variable_list('glacier_powerlaw_c')
-       if (model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
-          call glide_add_to_restart_variable_list('glacier_volume_target')
-       endif
+       !WHL - Write to restart for now; also possible to derive from glacier_powerlaw_c
+       !      (in a subroutine to be written)
+       call glide_add_to_restart_variable_list('powerlaw_c')
     endif
 
     ! TODO bmlt was set as a restart variable, but I'm not sure when or if it is needed.

--- a/libglide/glide_stop.F90
+++ b/libglide/glide_stop.F90
@@ -43,28 +43,28 @@ module glide_stop
 
 contains
 
-  !Note: Currently, glide_finalise_all is never called. (glide_finalise is called from cism_driver)
+  !Note: Currently, glide_finalise_all is never called.
+  !      glide_finalise is called from cism_driver and glissade)
 
   subroutine glide_finalise_all(forcewrite_arg)
 
     !> Finalises all models in the model registry
-    logical, optional :: forcewrite_arg
-    
-    logical :: forcewrite
+    logical, optional, intent(in) :: forcewrite_arg
+
+    logical :: forcewrite = .false.         !> if true, then force a write to output files
     integer :: i
 
     if (present(forcewrite_arg)) then
         forcewrite = forcewrite_arg
-    else
-        forcewrite = .false.
     end if
 
     do i = 1, get_num_models()
         if (associated(registered_models(i)%p)) then
-            call glide_finalise(registered_models(i)%p, forcewrite_arg=forcewrite)
+           call glide_finalise(registered_models(i)%p, forcewrite_arg=forcewrite)
         end if
-    end do 
-  end subroutine
+    end do
+
+  end subroutine glide_finalise_all
 
 
   subroutine glide_finalise(model,forcewrite_arg)
@@ -85,9 +85,7 @@ contains
 
     ! force write to output files if specified by the optional input argument
     if (present(forcewrite_arg)) then
-       if (forcewrite_arg) then
-          forcewrite = .true.
-       end if
+       forcewrite = forcewrite_arg
     end if
 
     ! force write to output files if set by a model option

--- a/libglide/glide_temp.F90
+++ b/libglide/glide_temp.F90
@@ -199,7 +199,7 @@ contains
     !TODO - Make sure cells in the Glide temperature halo are initialized to reasonable values
     !       (not unphys_val), e.g. if reading temps from input or restart file.
 
-    if (model%options%is_restart == RESTART_TRUE) then
+    if (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) then
 
        ! Temperature has already been initialized from a restart file. 
        ! (Temperature is always a restart variable.)
@@ -291,7 +291,7 @@ contains
 
     ! ====== Calculate initial value of flwa ==================
 
-    if (model%options%is_restart == RESTART_FALSE) then
+    if (model%options%is_restart == NO_RESTART) then
        call write_log("Calculating initial flwa from temp and thk fields")
 
        ! Calculate Glen's A --------------------------------------------------------   

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -754,6 +754,10 @@ module glide_types
     !> \item[4] compute Pattyn sigma coordinates
     !> \end{description}
 
+    logical :: forcewrite_final = .false.
+    !> if true, then force a write to output and restart files when the model finishes
+
+    !TODO - Change 'is_restart' to 'restart'
     integer :: is_restart = 0
     !> if the run is a restart of a previous run
     !> \begin{description}

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1862,6 +1862,7 @@ module glide_types
           volume => null(),                 & !> glacier volume (m^3)
           area_target => null(),            & !> glacier area target (m^2) based on observations
           volume_target => null(),          & !> glacier volume target (m^3) based on observations
+          volume_in_init_region => null(),  & !> current volume (m^3) in the region defined by cism_glacier_id_init
           dvolume_dt => null(),             & !> d(volume)/dt for each glacier (m^3/s)  !TODO - Is this needed?
           mu_star => null(),                & !> tunable parameter relating SMB to monthly mean artm (mm/yr w.e./deg K)
                                               !> defined as positive for ablation
@@ -2945,6 +2946,7 @@ contains
        allocate(model%glacier%volume(model%glacier%nglacier))
        allocate(model%glacier%area_target(model%glacier%nglacier))
        allocate(model%glacier%volume_target(model%glacier%nglacier))
+       allocate(model%glacier%volume_in_init_region(model%glacier%nglacier))
        allocate(model%glacier%dvolume_dt(model%glacier%nglacier))
        allocate(model%glacier%mu_star(model%glacier%nglacier))
        allocate(model%glacier%powerlaw_c(model%glacier%nglacier))
@@ -3382,6 +3384,8 @@ contains
         deallocate(model%glacier%area_target)
     if (associated(model%glacier%volume_target)) &
         deallocate(model%glacier%volume_target)
+    if (associated(model%glacier%volume_in_init_region)) &
+        deallocate(model%glacier%volume_in_init_region)
     if (associated(model%glacier%dvolume_dt)) &
         deallocate(model%glacier%dvolume_dt)
     if (associated(model%glacier%mu_star)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1119,20 +1119,6 @@ module glide_types
     !> if true, then read glacier info at initialization and (optionally)
     !>  tune glacier parameters during the run
 
-    integer :: glacier_mu_star
-    !> \begin{description}
-    !> \item[0] apply spatially uniform mu_star
-    !> \item[1] invert for glacier-specific mu_star
-    !> \item[2] read glacier-specific mu_star from external file
-    !> \end{description}
-
-    integer :: glacier_powerlaw_c
-    !> \begin{description}
-    !> \item[0] apply spatially uniform powerlaw_c
-    !> \item[1] invert for glacier-specific powerlaw_c
-    !> \item[2] read glacier-specific powerlaw_c from external file
-    !> \end{description}
-
     !TODO - Put the next few variables in a solver derived type
     integer :: glissade_maxiter = 100    
     !> maximum number of nonlinear iterations to be used by the Glissade velocity solver
@@ -1155,7 +1141,6 @@ module glide_types
     !> \item[1] Full calculation, with at least 3 nodes to represent the till layer
     !> \item[2] Fast calculation, using Tulaczyk empirical parametrization
     !> \end{description}
-
 
   end type glide_options
 
@@ -1822,15 +1807,45 @@ module glide_types
 
   type glide_glacier
 
+     !----------------------------------------------------------------
+     ! options, fields and parameters for tracking and tuning glaciers
+     !----------------------------------------------------------------
+
      integer :: nglacier = 1                  !> number of glaciers in the global domain
 
      integer :: ngdiag = 0                    !> CISM index of diagnostic glacier
                                               !> (associated with global cell idiag, jdiag)
 
+     ! inversion options
+
+     integer :: set_mu_star
+     !> \begin{description}
+     !> \item[0] apply spatially uniform mu_star
+     !> \item[1] invert for glacier-specific mu_star
+     !> \item[2] read glacier-specific mu_star from external file
+     !> \end{description}
+
+     integer :: set_powerlaw_c
+     !> \begin{description}
+     !> \item[0] apply spatially uniform powerlaw_c
+     !> \item[1] invert for glacier-specific powerlaw_c
+     !> \item[2] read glacier-specific powerlaw_c from external file
+     !> \end{description}
+
+     ! parameters
+     ! Note: Other glacier parameters are declared at the top of module glissade_glacier.
+     !       These could be added to the derived type.
+
+     real(dp) :: minthck = 5.0d0       !> min ice thickness (m) to be counted as part of a glacier;
+                                       !> not a threshold for dynamic calculations
+     real(dp) :: tmlt = -2.0d0         !> air temperature (deg C) at which ablation occurs
+                                       !> Maussion et al. suggest -1 C; a lower value extends the ablation zone
+
+     ! 1D arrays with size nglacier
+
      integer, dimension(:), pointer :: &
           glacierid => null()                 !> glacier ID dimension variable, used for I/O
 
-     ! glacier-specific 1D arrays
      ! These will be allocated with size nglacier, once nglacier is known
      ! Note: mu_star and powerlaw_c have the suffix 'glc' to avoid confusion with the 2D fields
      !       glacier%mu_star and basal_physics%powerlaw_c
@@ -1849,7 +1864,7 @@ module glide_types
           powerlaw_c => null()                !> tunable coefficient in basal friction power law (Pa (m/yr)^(-1/3))
                                               !> copied to basal_physics%powerlaw_c, a 2D array
 
-     ! glacier-related 2D arrays
+     ! 2D arrays
 
      integer, dimension(:,:), pointer :: &
           rgi_glacier_id => null(),         & !> unique glacier ID  based on the Randolph Glacier Inventory
@@ -1866,9 +1881,6 @@ module glide_types
      integer, dimension(:,:), pointer :: &
           imask => null()                     !> 2D mask; indicates whether glaciers are present in the input file
                                               !> TODO - Remove this field?  Easily derived from initial thickness > 0.
-
-     ! Note: Several glacier parameters are declared at the top of module glissade_glacier.
-     !       These could be added to the derived type and set in the config file.
 
   end type glide_glacier
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1853,6 +1853,10 @@ module glide_types
      !> \item[2] read glacier-specific powerlaw_c from external file
      !> \end{description}
 
+     logical :: match_smb_obs = .false.
+     !> If true, then compute mu_star so that smb = smb_obs for each glacier
+     !> This implies a temperature adjustment (delta_artm /= 0) during spin-up and inversion
+
      integer :: snow_calc = 1
      !> \begin{description}
      !> \item[0] read the snowfall rate directly

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1888,18 +1888,33 @@ module glide_types
      !       Other glacier parameters are declared at the top of module glissade_glacier.
      !       These could be added to the derived type.
 
-     real(dp) :: tmlt = -4.d0                 !> spatially uniform temperature threshold for melting (deg C)
-
-     ! Note: These thresholds assume that artm is a monthly mean, not an instantaneous value
-     real(dp) :: &
-          snow_threshold_min = -5.0d0, &!> air temperature (deg C) below which all precip falls as snow
-          snow_threshold_max =  5.0d0   !> air temperature (deg C) above which all precip falls as rain
-
      real(dp) :: diagnostic_minthck = 10.0d0  !> min ice thickness to be included in glacier area and volume diagnostics
 
      real(dp) :: &
-          minthck                       !> min ice thickness (m) to be counted as part of a glacier;
-                                        !> currently set based on model%numerics%thklim
+          minthck                             !> min ice thickness (m) to be counted as part of a glacier;
+                                              !> currently set based on model%numerics%thklim
+
+     real(dp) :: &
+          tmlt = -4.d0                        !> spatially uniform temperature threshold for melting (deg C)
+
+     real(dp) :: &
+          mu_star_const = 1000.d0,          & ! uniform initial value for mu_star (mm/yr w.e/deg C)
+          mu_star_min = 200.d0,             & ! min value of mu_star (mm/yr w.e/deg C)
+          mu_star_max = 5000.d0               ! max value of mu_star (mm/yr w.e/deg C)
+
+     real(dp) :: &
+          alpha_snow_const = 1.d0,          & ! uniform initial value of alpha_snow (unitless)
+          alpha_snow_min = 0.5d0,           & ! min value of alpha_snow
+          alpha_snow_max = 3.0d0              ! max value of alpha_snow
+
+     real(dp) ::  &
+          beta_artm_aux_max = 3.0,          & ! max magnitude of beta_artm_aux (deg C)
+          beta_artm_aux_increment = 0.05d0    ! fixed increment in beta_artm_aux (deg C)
+
+     ! Note: These thresholds assume that artm is a monthly mean, not an instantaneous value
+     real(dp) :: &
+          snow_threshold_min = -5.0d0,      & !> air temperature (deg C) below which all precip falls as snow
+          snow_threshold_max =  5.0d0         !> air temperature (deg C) above which all precip falls as rain
 
      ! 1D arrays with size nglacier
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1895,6 +1895,9 @@ module glide_types
      logical :: scale_area = .false.
      !> if true, than scale glacier area based on latitude
 
+     logical :: redistribute_advanced_ice = .false.
+     !> if true, then thin and redistribute advanced ice in the accumulation zone
+
      ! parameters
      ! Note: glacier%minthck is currently set at initialization based on model%numerics%thklim.
      !       glacier%diagnostic_minthck is used only for diagnostic area and volume sums;
@@ -1938,6 +1941,15 @@ module glide_types
           baseline_date = 1980.d0,          & !> baseline date, when glaciers are assumed to be in balance
           rgi_date = 2003.d0,               & !> date of RGI observations
           recent_date = 2010.d0               !> recent date associated with SMB observations for glaciers out of balance
+
+     real(dp) :: &
+          thinning_rate_advanced_ice = 0.0d0  !> thinning rate (m/yr) for advanced ice in the accumulation zone;
+                                              !> applies when redistribute_advanced_ice = .true.
+                                              !> thinned ice volume is redistributed conservatively over the glacier
+
+     real(dp) :: &
+          smb_weight_advanced_ice = 0.5d0     !> weight (0 < w < 1) applied to advanced ice in ablation zone during inversion;
+                                              !> applied to initially glacier-free cells adjacent to glacier cells
 
      ! 1D arrays with size nglacier
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1497,13 +1497,16 @@ module glide_types
                                                     !> If set to zero, then the anomaly is applied immediately.
      real(dp) :: t_lapse = 0.0d0                    !> air temp lapse rate (deg/m); positive for T decreasing with height
 
-     ! Next several fields are used for the 'read_once' forcing option.
+     ! The next several fields are used for the 'read_once' forcing option.
      ! E.g., if we want to read in all time slices of precip at once, we would set 'read_once' = .true. in the config file.
      ! All time slices are then stored in the precip_read_once array, where the third dimension is the number of time slices.
      ! Data are copied from precip_read_once to the regular 2D precip array as the model time changes.
      real(dp), dimension(:,:,:),pointer :: precip_read_once   => null()  !> precip field, read_once version
      real(dp), dimension(:,:,:),pointer :: artm_ref_read_once => null()  !> artm_ref field, read_once version
      real(dp), dimension(:,:,:),pointer :: snow_read_once => null()      !> snow field, read_once version
+     real(dp), dimension(:,:,:),pointer :: precip_aux_read_once   => null()  !> auxiliary precip field, read_once version
+     real(dp), dimension(:,:,:),pointer :: artm_ref_aux_read_once => null()  !> auxiliary artm_ref field, read_once version
+     real(dp), dimension(:,:,:),pointer :: snow_aux_read_once => null()      !> auxiliary snow field, read_once version
 
   end type glide_climate
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -150,6 +150,7 @@ module glide_types
   integer, parameter :: ARTM_INPUT_FUNCTION_XY = 0
   integer, parameter :: ARTM_INPUT_FUNCTION_XY_GRADZ = 1
   integer, parameter :: ARTM_INPUT_FUNCTION_XYZ = 2
+  integer, parameter :: ARTM_INPUT_FUNCTION_XY_LAPSE = 3
  
   integer, parameter :: OVERWRITE_ACAB_NONE = 0
   integer, parameter :: OVERWRITE_ACAB_ZERO_ACAB = 1
@@ -592,6 +593,7 @@ module glide_types
     !> \item[0] artm(x,y); input as a function of horizontal location only
     !> \item[1] artm(x,y) + dartm/dz(x,y) * dz; input artm and its vertical gradient
     !> \item[2] artm(x,y,z); input artm at multiple elevations
+    !> \item[3] artm(x,y) + tlapse * dz; input artm and uniform lapse rate
     !> \end{description}
 
     logical :: enable_acab_anomaly = .false.
@@ -1443,16 +1445,16 @@ module glide_types
      real(dp),dimension(:,:),pointer :: artm_corrected  => null() !> Annual mean air temperature with anomaly corrections (degC)
      integer, dimension(:,:),pointer :: overwrite_acab_mask => null() !> mask for cells where acab is overwritten
 
-     ! Next several fields used for SMB_INPUT_FUNCTION_GRADZ, ARTM_INPUT_FUNCTION_GRADZ
-     ! Note: If both smb and artm are input in this format, they share the array smb_reference_ursf.
-     !       Sign convention is positive up, so artm_gradz is usually negative.
-     real(dp),dimension(:,:),pointer :: acab_ref => null()            !> SMB at reference elevation (m/yr ice)
-     real(dp),dimension(:,:),pointer :: acab_gradz => null()          !> vertical gradient of acab (m/yr ice per m), positive up
-     real(dp),dimension(:,:),pointer :: smb_ref  => null()            !> SMB at reference elevation (mm/yr w.e.)
-     real(dp),dimension(:,:),pointer :: smb_gradz  => null()          !> vertical gradient of SMB (mm/yr w.e. per m), positive up
-     real(dp),dimension(:,:),pointer :: smb_reference_usrf => null()  !> reference upper surface elevation for SMB before lapse rate correction (m)
-     real(dp),dimension(:,:),pointer :: artm_ref => null()            !> artm at reference elevation (deg C)
-     real(dp),dimension(:,:),pointer :: artm_gradz => null()          !> vertical gradient of artm (deg C per m), positive up
+     ! Next several fields used for SMB_INPUT_FUNCTION_GRADZ, ARTM_INPUT_FUNCTION_GRADZ, ARTM_INPUT_FUNCTION_LAPSE
+     ! Note: If both smb and artm are input in this format, they share the array usrf_ref.
+     !       Sign convention for gradz is positive up, so artm_gradz is usually negative.
+     real(dp),dimension(:,:),pointer :: acab_ref => null()        !> SMB at reference elevation (m/yr ice)
+     real(dp),dimension(:,:),pointer :: acab_gradz => null()      !> vertical gradient of acab (m/yr ice per m), positive up
+     real(dp),dimension(:,:),pointer :: smb_ref  => null()        !> SMB at reference elevation (mm/yr w.e.)
+     real(dp),dimension(:,:),pointer :: smb_gradz  => null()      !> vertical gradient of SMB (mm/yr w.e. per m), positive up
+     real(dp),dimension(:,:),pointer :: artm_ref => null()        !> artm at reference elevation (deg C)
+     real(dp),dimension(:,:),pointer :: artm_gradz => null()      !> vertical gradient of artm (deg C per m), positive up
+     real(dp),dimension(:,:),pointer :: usrf_ref => null()        !> reference upper surface elevation before lapse rate correction (m)
 
      ! Next several fields used for SMB_INPUT_FUNCTION_XYZ, ARTM_INPUT_FUNCTION_XYZ
      ! Note: If both smb and artm are input in this format, they share the array smb_levels(nlev_smb).
@@ -1471,6 +1473,7 @@ module glide_types
      real(dp) :: overwrite_acab_minthck = 0.0d0     !> overwrite acab where thck <= overwrite_acab_minthck
      real(dp) :: artm_anomaly_timescale = 0.0d0     !> number of years over which the artm anomaly is phased in linearly
                                                     !> If set to zero, then the anomaly is applied immediately.
+     real(dp) :: t_lapse = 0.0d0                    !> air temp lapse rate (deg/m); positive for T decreasing with height
 
   end type glide_climate
 
@@ -1839,11 +1842,10 @@ module glide_types
      !       These could be added to the derived type.
 
 
-     real(dp) :: tmlt = -2.0d0     !> air temperature (deg C) at which ablation occurs
-                                   !> Maussion et al. suggest -1 C; a lower value extends the ablation zone
-
-     real(dp) :: minthck           !> min ice thickness (m) to be counted as part of a glacier;
-                                   !> currently set based on model%numerics%thklim
+     real(dp) :: t_mlt = -2.0d0     !> air temperature (deg C) at which ablation occurs
+                                    !> Maussion et al. suggest -1 C; a lower value extends the ablation zone
+     real(dp) :: minthck            !> min ice thickness (m) to be counted as part of a glacier;
+                                    !> currently set based on model%numerics%thklim
 
      ! 1D arrays with size nglacier
 
@@ -2935,6 +2937,11 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%glacier%Tpos_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_accum)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
+       !TODO - Delete these is they are allocated with XY_LAPSE logic
+       if (.not.associated(model%climate%usrf_ref)) &
+            call coordsystem_allocate(model%general%ice_grid, model%climate%usrf_ref)
+       if (.not.associated(model%climate%artm_ref)) &
+            call coordsystem_allocate(model%general%ice_grid, model%climate%artm_ref)
        ! Allocate arrays with dimension(nglacier)
        ! Note: nglacier = 1 by default, but can be changed in subroutine glissade_glacier_init
        !        after reading the input file.  If so, these arrays will be reallocated.
@@ -2984,7 +2991,8 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%climate%acab_gradz)
        call coordsystem_allocate(model%general%ice_grid, model%climate%smb_ref)
        call coordsystem_allocate(model%general%ice_grid, model%climate%smb_gradz)
-       call coordsystem_allocate(model%general%ice_grid, model%climate%smb_reference_usrf)
+       if (.not.associated(model%climate%usrf_ref)) &
+            call coordsystem_allocate(model%general%ice_grid, model%climate%usrf_ref)
     elseif (model%options%smb_input_function == SMB_INPUT_FUNCTION_XYZ) then
        call coordsystem_allocate(model%general%ice_grid, model%climate%nlev_smb, model%climate%acab_3d)
        call coordsystem_allocate(model%general%ice_grid, model%climate%nlev_smb, model%climate%smb_3d)
@@ -2992,18 +3000,23 @@ contains
     endif
 
     ! Note: Typically, smb_input_function and acab_input_function will have the same value.
-    !       If both use a lapse rate, they will share the array smb_reference_usrf.
+    !       If both use a lapse rate, they will share the array usrf_ref
     !       If both are 3d, they will share the array smb_levels.
     if (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_GRADZ) then
        call coordsystem_allocate(model%general%ice_grid, model%climate%artm_ref)
        call coordsystem_allocate(model%general%ice_grid, model%climate%artm_gradz)
-       if (.not.associated(model%climate%smb_reference_usrf)) then
-          call coordsystem_allocate(model%general%ice_grid, model%climate%smb_reference_usrf)
+       if (.not.associated(model%climate%usrf_ref)) then
+          call coordsystem_allocate(model%general%ice_grid, model%climate%usrf_ref)
        endif
     elseif (model%options%smb_input_function == ARTM_INPUT_FUNCTION_XYZ) then
        call coordsystem_allocate(model%general%ice_grid, model%climate%nlev_smb, model%climate%artm_3d)
        if (.not.associated(model%climate%smb_levels)) then
           allocate(model%climate%smb_levels(model%climate%nlev_smb))
+       endif
+    elseif (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_LAPSE) then
+       call coordsystem_allocate(model%general%ice_grid, model%climate%artm_ref)
+       if (.not.associated(model%climate%usrf_ref)) then
+          call coordsystem_allocate(model%general%ice_grid, model%climate%usrf_ref)
        endif
     endif
 
@@ -3569,8 +3582,8 @@ contains
         deallocate(model%climate%smb_ref)
     if (associated(model%climate%smb_gradz)) &
         deallocate(model%climate%smb_gradz)
-    if (associated(model%climate%smb_reference_usrf)) &
-        deallocate(model%climate%smb_reference_usrf)
+    if (associated(model%climate%usrf_ref)) &
+        deallocate(model%climate%usrf_ref)
     if (associated(model%climate%artm_ref)) &
         deallocate(model%climate%artm_ref)
     if (associated(model%climate%artm_gradz)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1916,9 +1916,14 @@ module glide_types
           beta_artm_aux_increment = 0.05d0    ! fixed increment in beta_artm_aux (deg C)
 
      ! Note: These thresholds assume that artm is a monthly mean, not an instantaneous value
+     !       Huss and Hock (2015) have thresholds of 0.5 and 2.5 C
      real(dp) :: &
-          snow_threshold_min = -5.0d0,      & !> air temperature (deg C) below which all precip falls as snow
-          snow_threshold_max =  5.0d0         !> air temperature (deg C) above which all precip falls as rain
+          snow_threshold_min = 0.0d0,      & !> air temperature (deg C) below which all precip falls as snow
+          snow_threshold_max = 2.0d0         !> air temperature (deg C) above which all precip falls as rain
+
+     real(dp) :: &
+          precip_lapse = 0.0d0               !> fractional change in precip per m elevation above usrf_ref;
+                                             !> Huss & Hock (2015) have 1.0e-4 to 2.5e-4
 
      ! 1D arrays with size nglacier
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -379,8 +379,16 @@ module glide_types
   integer, parameter :: HO_FLOTATION_FUNCTION_LINEARB = 3
   integer, parameter :: HO_FLOTATION_FUNCTION_LINEAR_STDEV = 4
 
-  integer, parameter :: HO_ICE_AGE_NONE = 0 
+  integer, parameter :: HO_ICE_AGE_NONE = 0
   integer, parameter :: HO_ICE_AGE_COMPUTE = 1 
+
+  integer, parameter :: GLACIER_MU_STAR_CONSTANT = 0
+  integer, parameter :: GLACIER_MU_STAR_INVERSION = 1
+  integer, parameter :: GLACIER_MU_STAR_EXTERNAL = 2
+
+  integer, parameter :: GLACIER_POWERLAW_C_CONSTANT = 0
+  integer, parameter :: GLACIER_POWERLAW_C_INVERSION = 1
+  integer, parameter :: GLACIER_POWERLAW_C_EXTERNAL = 2
 
   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1107,6 +1115,24 @@ module glide_types
     !> \item[1] ice age computation on
     !> \end{description}
 
+    logical :: enable_glaciers = .false.
+    !> if true, then read glacier info at initialization and (optionally)
+    !>  tune glacier parameters during the run
+
+    integer :: glacier_mu_star
+    !> \begin{description}
+    !> \item[0] apply spatially uniform mu_star
+    !> \item[1] invert for glacier-specific mu_star
+    !> \item[2] read glacier-specific mu_star from external file
+    !> \end{description}
+
+    integer :: glacier_powerlaw_c
+    !> \begin{description}
+    !> \item[0] apply spatially uniform powerlaw_c
+    !> \item[1] invert for glacier-specific powerlaw_c
+    !> \item[2] read glacier-specific powerlaw_c from external file
+    !> \end{description}
+
     !TODO - Put the next few variables in a solver derived type
     integer :: glissade_maxiter = 100    
     !> maximum number of nonlinear iterations to be used by the Glissade velocity solver
@@ -1792,6 +1818,47 @@ module glide_types
 
   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+  type glide_glacier
+
+     integer :: nglacier = 0                      !> number of glaciers in the global domain
+
+     ! glacier-specific 1D arrays
+     ! These will be allocated with size nglacier, once nglacier is known
+     ! Note: mu_star and powerlaw_c have the suffix 'glc' to avoid confusion with the 2D fields
+     !       glacier%mu_star and basal_physics%powerlaw_c
+     ! TODO: Add 2D versions of cism_to_glacier_id, area, and volume?
+     !       Not sure it's possible to read and write arrays of dimension (nglacier),
+     !        since nglacier is not computed until runtime.
+
+     integer, dimension(:), pointer :: &
+          cism_to_glacier_id => null()            !> maps CISM glacier IDs (1:nglacier) to input glacier IDs
+
+     real(dp), dimension(:), pointer :: &
+          area => null(),                       & !> glacier area (m^2)
+          volume => null(),                     & !> glacier volume (m^3)
+          mu_star_glc => null(),                & !> tunable parameter relating SMB to monthly mean artm (mm/yr w.e./deg K)
+                                                  !> defined as positive for ablation
+          powerlaw_c_glc => null()                !> tunable coefficient in basal friction power law
+
+     ! glacier-related 2D arrays
+     ! Note: powerlaw_c is already part of the basal physics derived type.
+
+     integer, dimension(:,:), pointer :: &
+          glacier_id => null(),                 & !> unique glacier ID, usually based on the Randolph Glacier Inventory
+                                                  !> first 2 digits give the RGI region; the rest give the number within the region
+          glacier_id_cism => null()               !> derived CISM-specific glacier ID, numbered consecutively from 1 to nglacier
+
+     real(dp), dimension(:,:), pointer :: &
+          mu_star => null()                       !> mu_star_glc mapped to the 2D grid for I/O
+
+     integer, dimension(:,:), pointer :: &
+          imask => null()                         !> 2D mask; indicates whether glaciers are present in the input file
+                                                  !> TODO - Remove this field?  Easily derived from initial thickness > 0.
+
+  end type glide_glacier
+
+  !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
   type glide_plume
 
      !> Holds fields and parameters relating to a sub-shelf plume model
@@ -2345,6 +2412,7 @@ module glide_types
     type(glide_basal_physics):: basal_physics
     type(glide_basal_melt)   :: basal_melt
     type(glide_ocean_data)   :: ocean_data
+    type(glide_glacier)  :: glacier
     type(glide_inversion):: inversion
     type(glide_plume)    :: plume
     type(glide_lithot_type)  :: lithot
@@ -2404,6 +2472,13 @@ contains
     !> \item \texttt{basin_number(ewn,nsn)}
     !> \item \texttt{thermal_forcing(nzocn,ewn,nsn)}
     !> \item \texttt{thermal_forcing_lsrf(ewn,nsn)}
+    !> \end{itemize}
+
+    !> In \texttt{model\%glacier}:
+    !> \begin{itemize}
+    !> \item \texttt{glacier_id(ewn,nsn)}
+    !> \item \texttt{glacier_id_cism(ewn,nsn)}
+    !> \item \texttt{mu_star(ewn,nsn)}
     !> \end{itemize}
 
     !> In \texttt{model\%basal_physics}:
@@ -2819,6 +2894,13 @@ contains
        endif
     endif  ! Glissade
 
+    ! glacier options (Glissade only)
+    if (model%options%enable_glaciers) then
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%glacier_id)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%glacier_id_cism)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%mu_star)
+    endif
+
     ! inversion and basal physics arrays (Glissade only)
     call coordsystem_allocate(model%general%velo_grid,model%basal_physics%powerlaw_c)
     call coordsystem_allocate(model%general%velo_grid,model%basal_physics%powerlaw_c_relax)
@@ -3225,6 +3307,14 @@ contains
         deallocate(model%ocean_data%thermal_forcing)
     if (associated(model%ocean_data%thermal_forcing_lsrf)) &
         deallocate(model%ocean_data%thermal_forcing_lsrf)
+
+    ! glacier arrays
+    if (associated(model%glacier%glacier_id)) &
+        deallocate(model%glacier%glacier_id)
+    if (associated(model%glacier%glacier_id_cism)) &
+        deallocate(model%glacier%glacier_id_cism)
+    if (associated(model%glacier%mu_star)) &
+        deallocate(model%glacier%mu_star)
 
     ! inversion arrays
     if (associated(model%basal_physics%powerlaw_c)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -214,8 +214,9 @@ module glide_types
   integer, parameter :: SIGMA_COMPUTE_EVEN = 3
   integer, parameter :: SIGMA_COMPUTE_PATTYN = 4
 
-  integer, parameter :: RESTART_FALSE = 0
-  integer, parameter :: RESTART_TRUE = 1
+  integer, parameter :: NO_RESTART = 0
+  integer, parameter :: STANDARD_RESTART = 1
+  integer, parameter :: HYBRID_RESTART = 2
 
   integer, parameter :: RESTART_EXTEND_VELO_FALSE = 0
   integer, parameter :: RESTART_EXTEND_VELO_TRUE = 1
@@ -753,12 +754,12 @@ module glide_types
     !> \item[4] compute Pattyn sigma coordinates
     !> \end{description}
 
-    !TODO - Make is_restart a logical variable?
     integer :: is_restart = 0
     !> if the run is a restart of a previous run
     !> \begin{description}
     !> \item[0] normal start-up (take init fields from .nc input file OR if absent, use default options)
     !> \item[1] restart model from previous run (do not calc. temp, rate factor, or vel)
+    !> \item[2] hybrid restart; use restart from previous run as the input file, and reset the time
     !> \end{description}
 
     integer :: restart_extend_velo = 0
@@ -768,9 +769,6 @@ module glide_types
     !> \item[1] write uvel_extend and vvel_extend to restart file on extended staggered mesh
     !>          (required if restart velocities are nonzero on global boundaries)
     !> \end{description}
-
-    logical :: forcewrite_restart = .false.
-    !> flag that indicates whether to force writing of output on restart
 
     ! This is a Glimmer serial option
     ! The parallel code enforces periodic EW and NS boundary conditions by default

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1822,13 +1822,13 @@ module glide_types
 
   type glide_glacier
 
-     integer :: nglacier = 1                      !> number of glaciers in the global domain
+     integer :: nglacier = 1                  !> number of glaciers in the global domain
 
-     integer :: ngdiag = 0                        !> CISM index of diagnostic glacier
-                                                  !> (associated with global cell idiag, jdiag)
+     integer :: ngdiag = 0                    !> CISM index of diagnostic glacier
+                                              !> (associated with global cell idiag, jdiag)
 
      integer, dimension(:), pointer :: &
-          glacierid => null()                     !> glacier ID dimension variable, used for I/O
+          glacierid => null()                 !> glacier ID dimension variable, used for I/O
 
      ! glacier-specific 1D arrays
      ! These will be allocated with size nglacier, once nglacier is known
@@ -1836,7 +1836,7 @@ module glide_types
      !       glacier%mu_star and basal_physics%powerlaw_c
 
      integer, dimension(:), pointer :: &
-          cism_to_rgi_glacier_id => null()      !> maps CISM glacier IDs (1:nglacier) to input RGI glacier IDs
+          cism_to_rgi_glacier_id => null()    !> maps CISM glacier IDs (1:nglacier) to input RGI glacier IDs
 
      real(dp), dimension(:), pointer :: &
           area => null(),                   & !> glacier area (m^2)
@@ -2913,9 +2913,9 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
        ! Allocate arrays with dimension(nglacier)
        ! Note: nglacier = 1 by default, but can be changed in subroutine glissade_glacier_init
-       !       after reading the input file.  If so, these arrays will be reallocated.
-       !WHL - TODO - For restart, do these arrays need to be already allocated with the correct nglacier?
-       !             If so, then might need to put nglacier in the config file.
+       !        after reading the input file.  If so, these arrays will be reallocated.
+       !       On restart, nglacier is read from the restart file before calling glide_allocarr,
+       !        so these allocations will be correct.
        allocate(model%glacier%glacierid(model%glacier%nglacier))
        allocate(model%glacier%cism_to_rgi_glacier_id(model%glacier%nglacier))
        allocate(model%glacier%area(model%glacier%nglacier))

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1473,6 +1473,7 @@ module glide_types
                                                     !> The initMIP value is 40 yr.
      real(dp) :: overwrite_acab_value = 0.0d0       !> acab value to apply in grid cells where overwrite_acab_mask = 1
      real(dp) :: overwrite_acab_minthck = 0.0d0     !> overwrite acab where thck <= overwrite_acab_minthck
+     real(dp) :: artm_anomaly_const = 0.0d0         !> spatially uniform value of artm_anomaly (degC)
      real(dp) :: artm_anomaly_timescale = 0.0d0     !> number of years over which the artm anomaly is phased in linearly
                                                     !> If set to zero, then the anomaly is applied immediately.
      real(dp) :: t_lapse = 0.0d0                    !> air temp lapse rate (deg/m); positive for T decreasing with height
@@ -2937,7 +2938,7 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%glacier%Tpos_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%mu_star_2d)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
-       !TODO - Delete these is they are allocated with XY_LAPSE logic
+       !TODO - Delete these if they are allocated with XY_LAPSE logic
        if (.not.associated(model%climate%usrf_ref)) &
             call coordsystem_allocate(model%general%ice_grid, model%climate%usrf_ref)
        if (.not.associated(model%climate%artm_ref)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1899,6 +1899,9 @@ module glide_types
      !       Other glacier parameters are declared at the top of module glissade_glacier.
      !       These could be added to the derived type.
 
+     real(dp) :: length_scale_factor = 1.0d0  !> factor used to scale dew and dns;
+                                              !> typically equal to the cosine of an average latitude
+
      real(dp) :: diagnostic_minthck = 10.0d0  !> min ice thickness to be included in glacier area and volume diagnostics
 
      real(dp) :: &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1843,18 +1843,11 @@ module glide_types
           volume => null(),                 & !> glacier volume (m^3)
           area_target => null(),            & !> glacier area target (m^2) based on observations
           volume_target => null(),          & !> glacier volume target (m^3) based on observations
-          dvolume_dt => null(),             & !> d(volume)/dt for each glacier (m^3/s)
+          dvolume_dt => null(),             & !> d(volume)/dt for each glacier (m^3/s)  !TODO - Is this needed?
           mu_star => null(),                & !> tunable parameter relating SMB to monthly mean artm (mm/yr w.e./deg K)
                                               !> defined as positive for ablation
           powerlaw_c => null()                !> tunable coefficient in basal friction power law (Pa (m/yr)^(-1/3))
                                               !> copied to basal_physics%powerlaw_c, a 2D array
-
-     ! The following can be set in the config file
-     ! Note: The constant, max and min values for powerlaw_c are in the basal_physics type
-     real(dp) :: &
-          mu_star_const = 1000.d0,          & !> uniform initial value for mu_star (mm/yr w.e/deg K)
-          mu_star_min = 10.0d0,             & !> min value of tunable mu_star (mm/yr w.e/deg K)
-          mu_star_max = 10000.0d0             !> max value of tunable mu_star (mm/yr w.e/deg K)
 
      ! glacier-related 2D arrays
 
@@ -1862,11 +1855,20 @@ module glide_types
           rgi_glacier_id => null(),         & !> unique glacier ID  based on the Randolph Glacier Inventory
                                               !> first 2 digits give the RGI region;
                                               !> the rest give the number within the region
-          cism_glacier_id => null()           !> CISM-specific glacier ID, numbered consecutively from 1 to nglacier
+          cism_glacier_id => null(),        & !> CISM-specific glacier ID, numbered consecutively from 1 to nglacier
+          cism_glacier_id_init => null()      !> cism_glacier_id at start of run
+
+     real(dp), dimension(:,:), pointer :: &
+          snow_accum => null(),             & !> accumulated snowfall (mm/yr w.e.)
+          Tpos_accum => null(),             & !> accumulated max(artm - Tmlt,0) (deg C)
+          dthck_dt_accum => null()            !> accumulated rate of change of ice thickness (m/yr)
 
      integer, dimension(:,:), pointer :: &
           imask => null()                     !> 2D mask; indicates whether glaciers are present in the input file
                                               !> TODO - Remove this field?  Easily derived from initial thickness > 0.
+
+     ! Note: Several glacier parameters are declared at the top of module glissade_glacier.
+     !       These could be added to the derived type and set in the config file.
 
   end type glide_glacier
 
@@ -2491,6 +2493,7 @@ contains
     !> \begin{itemize}
     !> \item \texttt{rgi_glacier_id(ewn,nsn)}
     !> \item \texttt{cism_glacier_id(ewn,nsn)}
+    !> \item \texttt{cism_glacier_id_init(ewn,nsn)}
     !> \end{itemize}
 
     !> In \texttt{model\%basal_physics}:
@@ -2910,6 +2913,10 @@ contains
     if (model%options%enable_glaciers) then
        call coordsystem_allocate(model%general%ice_grid, model%glacier%rgi_glacier_id)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%cism_glacier_id)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%cism_glacier_id_init)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%snow_accum)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%Tpos_accum)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_accum)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
        ! Allocate arrays with dimension(nglacier)
        ! Note: nglacier = 1 by default, but can be changed in subroutine glissade_glacier_init
@@ -3341,8 +3348,16 @@ contains
         deallocate(model%glacier%rgi_glacier_id)
     if (associated(model%glacier%cism_glacier_id)) &
         deallocate(model%glacier%cism_glacier_id)
+    if (associated(model%glacier%cism_glacier_id_init)) &
+        deallocate(model%glacier%cism_glacier_id_init)
     if (associated(model%glacier%cism_to_rgi_glacier_id)) &
         deallocate(model%glacier%cism_to_rgi_glacier_id)
+    if (associated(model%glacier%snow_accum)) &
+        deallocate(model%glacier%snow_accum)
+    if (associated(model%glacier%Tpos_accum)) &
+        deallocate(model%glacier%Tpos_accum)
+    if (associated(model%glacier%dthck_dt_accum)) &
+        deallocate(model%glacier%dthck_dt_accum)
     if (associated(model%glacier%area)) &
         deallocate(model%glacier%area)
     if (associated(model%glacier%volume)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1951,6 +1951,15 @@ module glide_types
           smb_weight_advanced_ice = 1.0d0     !> weight applied to advanced ice in ablation zone during inversion;
                                               !> applied to initially glacier-free cells adjacent to glacier cells
                                               !> typically O(1), with larger values on finer grids
+     ! diagnostic scalars
+
+     real(dp) :: &
+          total_area = 0.d0,                & !> total area (m^2), summed over all glaciers
+          total_volume = 0.d0                 !> total volume (m^3), summed over all glaciers
+
+     integer :: &
+          nglacier_active = 0                 !> number of dynamically active glaciers (nonzero area)
+
      ! 1D arrays with size nglacier
 
      integer, dimension(:), pointer :: &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1888,7 +1888,7 @@ module glide_types
      !       Other glacier parameters are declared at the top of module glissade_glacier.
      !       These could be added to the derived type.
 
-     real(dp) :: tmlt_const = -4.d0     !> spatially uniform temperature threshold for melting (deg C)
+     real(dp) :: tmlt = -4.d0                 !> spatially uniform temperature threshold for melting (deg C)
 
      ! Note: These thresholds assume that artm is a monthly mean, not an instantaneous value
      real(dp) :: &
@@ -1913,8 +1913,6 @@ module glide_types
      integer, dimension(:), pointer :: &
           cism_to_rgi_glacier_id => null()    !> maps CISM glacier IDs (1:nglacier) to input RGI glacier IDs
 
-     !TODO - Allow tmlt to vary for glaciers where mu_star is capped.
-
      real(dp), dimension(:), pointer :: &
           area => null(),                   & !> glacier area (m^2)
           volume => null(),                 & !> glacier volume (m^3)
@@ -1923,7 +1921,7 @@ module glide_types
           mu_star => null(),                & !> glacier-specific parameter relating SMB to monthly mean artm (mm/yr w.e./deg),
                                               !> defined as positive for ablation
           snow_factor => null(),            & !> glacier-specific multiplicative snow factor (unitless)
-          tmlt => null(),                   & !> glacier-specific temperature threshold for melting (deg C)
+          artm_aux_corr => null(),          & !> bias correction to auxiliary surface temperature (deg C)
           smb => null(),                    & !> modeled glacier-average mass balance (mm/yr w.e.)
           smb_obs => null()                   !> observed glacier-average mass balance (mm/yr w.e.), e.g. from Hugonnet et al. (2021)
 
@@ -3035,7 +3033,7 @@ contains
        allocate(model%glacier%volume_init(model%glacier%nglacier))
        allocate(model%glacier%mu_star(model%glacier%nglacier))
        allocate(model%glacier%snow_factor(model%glacier%nglacier))
-       allocate(model%glacier%tmlt(model%glacier%nglacier))
+       allocate(model%glacier%artm_aux_corr(model%glacier%nglacier))
        allocate(model%glacier%smb(model%glacier%nglacier))
        allocate(model%glacier%smb_obs(model%glacier%nglacier))
     endif
@@ -3492,8 +3490,8 @@ contains
         deallocate(model%glacier%mu_star)
     if (associated(model%glacier%snow_factor)) &
         deallocate(model%glacier%snow_factor)
-    if (associated(model%glacier%tmlt)) &
-        deallocate(model%glacier%tmlt)
+    if (associated(model%glacier%artm_aux_corr)) &
+        deallocate(model%glacier%artm_aux_corr)
     if (associated(model%glacier%smb)) &
         deallocate(model%glacier%smb)
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1864,12 +1864,8 @@ module glide_types
           volume => null(),                 & !> glacier volume (m^3)
           area_target => null(),            & !> glacier area target (m^2) based on observations
           volume_target => null(),          & !> glacier volume target (m^3) based on observations
-          volume_in_init_region => null(),  & !> current volume (m^3) in the region defined by cism_glacier_id_init
-          dvolume_dt => null(),             & !> d(volume)/dt for each glacier (m^3/s)  !TODO - Is this needed?
-          mu_star => null(),                & !> tunable parameter relating SMB to monthly mean artm (mm/yr w.e./deg K)
+          mu_star => null()                   !> tunable parameter relating SMB to monthly mean artm (mm/yr w.e./deg K)
                                               !> defined as positive for ablation
-          powerlaw_c => null()                !> tunable coefficient in basal friction power law (Pa (m/yr)^(-1/3))
-                                              !> copied to basal_physics%powerlaw_c, a 2D array
 
      ! 2D arrays
 
@@ -1881,9 +1877,9 @@ module glide_types
           cism_glacier_id_init => null()      !> cism_glacier_id at start of run
 
      real(dp), dimension(:,:), pointer :: &
+          dthck_dt_accum => null(),         & !> accumulated dthck_dt (m/yr)
           snow_accum => null(),             & !> accumulated snowfall (mm/yr w.e.)
-          Tpos_accum => null(),             & !> accumulated max(artm - Tmlt,0) (deg C)
-          dthck_dt_accum => null()            !> accumulated rate of change of ice thickness (m/yr)
+          Tpos_accum => null()                !> accumulated max(artm - Tmlt,0) (deg C)
 
      integer, dimension(:,:), pointer :: &
           imask => null()                     !> 2D mask; indicates whether glaciers are present in the input file
@@ -2933,9 +2929,9 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%glacier%rgi_glacier_id)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%cism_glacier_id)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%cism_glacier_id_init)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%snow_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%Tpos_accum)
-       call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_accum)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
        !TODO - Delete these is they are allocated with XY_LAPSE logic
        if (.not.associated(model%climate%usrf_ref)) &
@@ -2953,10 +2949,7 @@ contains
        allocate(model%glacier%volume(model%glacier%nglacier))
        allocate(model%glacier%area_target(model%glacier%nglacier))
        allocate(model%glacier%volume_target(model%glacier%nglacier))
-       allocate(model%glacier%volume_in_init_region(model%glacier%nglacier))
-       allocate(model%glacier%dvolume_dt(model%glacier%nglacier))
        allocate(model%glacier%mu_star(model%glacier%nglacier))
-       allocate(model%glacier%powerlaw_c(model%glacier%nglacier))
     endif
 
     ! inversion and basal physics arrays (Glissade only)
@@ -3383,12 +3376,12 @@ contains
         deallocate(model%glacier%cism_glacier_id_init)
     if (associated(model%glacier%cism_to_rgi_glacier_id)) &
         deallocate(model%glacier%cism_to_rgi_glacier_id)
+    if (associated(model%glacier%dthck_dt_accum)) &
+        deallocate(model%glacier%dthck_dt_accum)
     if (associated(model%glacier%snow_accum)) &
         deallocate(model%glacier%snow_accum)
     if (associated(model%glacier%Tpos_accum)) &
         deallocate(model%glacier%Tpos_accum)
-    if (associated(model%glacier%dthck_dt_accum)) &
-        deallocate(model%glacier%dthck_dt_accum)
     if (associated(model%glacier%area)) &
         deallocate(model%glacier%area)
     if (associated(model%glacier%volume)) &
@@ -3397,14 +3390,8 @@ contains
         deallocate(model%glacier%area_target)
     if (associated(model%glacier%volume_target)) &
         deallocate(model%glacier%volume_target)
-    if (associated(model%glacier%volume_in_init_region)) &
-        deallocate(model%glacier%volume_in_init_region)
-    if (associated(model%glacier%dvolume_dt)) &
-        deallocate(model%glacier%dvolume_dt)
     if (associated(model%glacier%mu_star)) &
         deallocate(model%glacier%mu_star)
-    if (associated(model%glacier%powerlaw_c)) &
-        deallocate(model%glacier%powerlaw_c)
 
     ! inversion arrays
     if (associated(model%basal_physics%powerlaw_c)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1983,6 +1983,9 @@ module glide_types
           delta_usrf_recent => null()         !> change in usrf between baseline and recent climate
 
      integer, dimension(:,:), pointer :: &
+          boundary_mask => null()             !> mask that marks boundary between two glaciers; located at vertices
+
+     integer, dimension(:,:), pointer :: &
           imask => null()                     !> 2D mask; indicates whether glaciers are present in the input file
                                               !> TODO - Remove this field?  Easily derived from initial thickness > 0.
 
@@ -3040,6 +3043,7 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%climate%precip_anomaly)
        call coordsystem_allocate(model%general%ice_grid, model%climate%smb_obs)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_annmean)
+       call coordsystem_allocate(model%general%velo_grid, model%glacier%boundary_mask)
 
        !TODO - Allocate these fields based on the XY_LAPSE option?
        !       Then wouldn't have to check for previous allocation.
@@ -3554,6 +3558,8 @@ contains
         deallocate(model%glacier%smb_recent)
     if (associated(model%glacier%delta_usrf_recent)) &
         deallocate(model%glacier%delta_usrf_recent)
+    if (associated(model%glacier%boundary_mask)) &
+        deallocate(model%glacier%boundary_mask)
 
     ! inversion arrays
     if (associated(model%basal_physics%powerlaw_c)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1485,6 +1485,14 @@ module glide_types
                                                     !> If set to zero, then the anomaly is applied immediately.
      real(dp) :: t_lapse = 0.0d0                    !> air temp lapse rate (deg/m); positive for T decreasing with height
 
+     ! Next several fields are used for the 'read_once' forcing option.
+     ! E.g., if we want to read in all time slices of precip at once, we would set 'read_once' = .true. in the config file.
+     ! All time slices are then stored in the precip_read_once array, where the third dimension is the number of time slices.
+     ! Data are copied from precip_read_once to the regular 2D precip array as the model time changes.
+     real(dp), dimension(:,:,:),pointer :: precip_read_once   => null()  !> precip field, read_once version
+     real(dp), dimension(:,:,:),pointer :: artm_ref_read_once => null()  !> artm_ref field, read_once version
+     real(dp), dimension(:,:,:),pointer :: snow_read_once => null()      !> snow field, read_once version
+
   end type glide_climate
 
   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -387,9 +387,9 @@ module glide_types
   integer, parameter :: GLACIER_MU_STAR_INVERSION = 1
   integer, parameter :: GLACIER_MU_STAR_EXTERNAL = 2
 
-  integer, parameter :: GLACIER_SNOW_FACTOR_CONSTANT = 0
-  integer, parameter :: GLACIER_SNOW_FACTOR_INVERSION = 1
-  integer, parameter :: GLACIER_SNOW_FACTOR_EXTERNAL = 2
+  integer, parameter :: GLACIER_ALPHA_SNOW_CONSTANT = 0
+  integer, parameter :: GLACIER_ALPHA_SNOW_INVERSION = 1
+  integer, parameter :: GLACIER_ALPHA_SNOW_EXTERNAL = 2
 
   integer, parameter :: GLACIER_POWERLAW_C_CONSTANT = 0
   integer, parameter :: GLACIER_POWERLAW_C_INVERSION = 1
@@ -1861,11 +1861,11 @@ module glide_types
      !> \item[2] read glacier-specific mu_star from external file
      !> \end{description}
 
-     integer :: set_snow_factor = 0
+     integer :: set_alpha_snow = 0
      !> \begin{description}
-     !> \item[0] apply spatially uniform snow_factor
-     !> \item[1] invert for glacier-specific snow_factor
-     !> \item[2] read glacier-specific snow_factor from external file
+     !> \item[0] apply spatially uniform alpha_snow
+     !> \item[1] invert for glacier-specific alpha_snow
+     !> \item[2] read glacier-specific alpha_snow from external file
      !> \end{description}
 
      integer :: set_powerlaw_c = 0
@@ -1920,8 +1920,8 @@ module glide_types
           volume_init => null(),            & !> initial glacier volume (m^3) based on observations
           mu_star => null(),                & !> glacier-specific parameter relating SMB to monthly mean artm (mm/yr w.e./deg),
                                               !> defined as positive for ablation
-          snow_factor => null(),            & !> glacier-specific multiplicative snow factor (unitless)
-          artm_aux_corr => null(),          & !> bias correction to auxiliary surface temperature (deg C)
+          alpha_snow => null(),             & !> glacier-specific multiplicative snow factor (unitless)
+          beta_artm_aux => null(),          & !> bias correction to auxiliary surface temperature (deg C)
           smb => null(),                    & !> modeled glacier-average mass balance (mm/yr w.e.)
           smb_obs => null()                   !> observed glacier-average mass balance (mm/yr w.e.), e.g. from Hugonnet et al. (2021)
 
@@ -3032,8 +3032,8 @@ contains
        allocate(model%glacier%area_init(model%glacier%nglacier))
        allocate(model%glacier%volume_init(model%glacier%nglacier))
        allocate(model%glacier%mu_star(model%glacier%nglacier))
-       allocate(model%glacier%snow_factor(model%glacier%nglacier))
-       allocate(model%glacier%artm_aux_corr(model%glacier%nglacier))
+       allocate(model%glacier%alpha_snow(model%glacier%nglacier))
+       allocate(model%glacier%beta_artm_aux(model%glacier%nglacier))
        allocate(model%glacier%smb(model%glacier%nglacier))
        allocate(model%glacier%smb_obs(model%glacier%nglacier))
     endif
@@ -3488,10 +3488,10 @@ contains
         deallocate(model%glacier%volume_init)
     if (associated(model%glacier%mu_star)) &
         deallocate(model%glacier%mu_star)
-    if (associated(model%glacier%snow_factor)) &
-        deallocate(model%glacier%snow_factor)
-    if (associated(model%glacier%artm_aux_corr)) &
-        deallocate(model%glacier%artm_aux_corr)
+    if (associated(model%glacier%alpha_snow)) &
+        deallocate(model%glacier%alpha_snow)
+    if (associated(model%glacier%beta_artm_aux)) &
+        deallocate(model%glacier%beta_artm_aux)
     if (associated(model%glacier%smb)) &
         deallocate(model%glacier%smb)
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1879,7 +1879,8 @@ module glide_types
      real(dp), dimension(:,:), pointer :: &
           dthck_dt_accum => null(),         & !> accumulated dthck_dt (m/yr)
           snow_accum => null(),             & !> accumulated snowfall (mm/yr w.e.)
-          Tpos_accum => null()                !> accumulated max(artm - Tmlt,0) (deg C)
+          Tpos_accum => null(),             & !> accumulated max(artm - Tmlt,0) (deg C)
+          mu_star_2d => null()                !> glacier mu_star mapped to a 2D grid
 
      integer, dimension(:,:), pointer :: &
           imask => null()                     !> 2D mask; indicates whether glaciers are present in the input file
@@ -2932,6 +2933,7 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%snow_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%Tpos_accum)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%mu_star_2d)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
        !TODO - Delete these is they are allocated with XY_LAPSE logic
        if (.not.associated(model%climate%usrf_ref)) &
@@ -3382,6 +3384,8 @@ contains
         deallocate(model%glacier%snow_accum)
     if (associated(model%glacier%Tpos_accum)) &
         deallocate(model%glacier%Tpos_accum)
+    if (associated(model%glacier%mu_star_2d)) &
+        deallocate(model%glacier%mu_star_2d)
     if (associated(model%glacier%area)) &
         deallocate(model%glacier%area)
     if (associated(model%glacier%volume)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1875,11 +1875,15 @@ module glide_types
      !> \item[2] read glacier-specific powerlaw_c from external file
      !> \end{description}
 
+     ! other options
      integer :: snow_calc = 1
      !> \begin{description}
      !> \item[0] read the snowfall rate directly
      !> \item[1] compute the snowfall rate from precip and downscaled artm
      !> \end{description}
+
+     logical :: scale_area = .false.
+     !> if true, than scale glacier area based on latitude
 
      ! parameters
      ! Note: glacier%minthck is currently set at initialization based on model%numerics%thklim.
@@ -1956,6 +1960,7 @@ module glide_types
      !       Do all of these need to be part of the derived type? Maybe just for diagnostic I/O.
      !       Add smb_annmean?
      real(dp), dimension(:,:), pointer :: &
+          area_factor => null(),            & !> area scaling factor based on latitude
           dthck_dt_2d => null(),            & !> accumulated dthck_dt (m/yr)
           snow_2d => null(),                & !> accumulated snowfall (mm/yr w.e.)
           Tpos_2d => null(),                & !> accumulated max(artm - tmlt,0) (deg C)
@@ -3012,6 +3017,7 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%glacier%cism_glacier_id_init)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%smb_glacier_id)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%smb_glacier_id_init)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%area_factor)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_2d)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)
        call coordsystem_allocate(model%general%ice_grid, model%climate%precip)
@@ -3481,6 +3487,8 @@ contains
         deallocate(model%glacier%smb_glacier_id_init)
     if (associated(model%glacier%cism_to_rgi_glacier_id)) &
         deallocate(model%glacier%cism_to_rgi_glacier_id)
+    if (associated(model%glacier%area_factor)) &
+        deallocate(model%glacier%area_factor)
     if (associated(model%glacier%dthck_dt_2d)) &
         deallocate(model%glacier%dthck_dt_2d)
     if (associated(model%glacier%snow_2d)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -599,6 +599,8 @@ module glide_types
     logical :: enable_acab_anomaly = .false.
     !> if true, then apply a prescribed anomaly to smb/acab
 
+    !WHL - Modify to support options 0 (no anomaly), 1 (constant) and 2 (external)
+    !      Then apply option 1.
     logical :: enable_artm_anomaly = .false.
     !> if true, then apply a prescribed anomaly to artm
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1833,13 +1833,17 @@ module glide_types
      !> \end{description}
 
      ! parameters
-     ! Note: Other glacier parameters are declared at the top of module glissade_glacier.
+     ! Note: glacier%tmlt can be set by the user in the config file.
+     !       glacier%minthck is currently set at initialization based on model%numerics%thklim.
+     !       Other glacier parameters are declared at the top of module glissade_glacier.
      !       These could be added to the derived type.
 
-     real(dp) :: minthck = 5.0d0       !> min ice thickness (m) to be counted as part of a glacier;
-                                       !> not a threshold for dynamic calculations
-     real(dp) :: tmlt = -2.0d0         !> air temperature (deg C) at which ablation occurs
-                                       !> Maussion et al. suggest -1 C; a lower value extends the ablation zone
+
+     real(dp) :: tmlt = -2.0d0     !> air temperature (deg C) at which ablation occurs
+                                   !> Maussion et al. suggest -1 C; a lower value extends the ablation zone
+
+     real(dp) :: minthck           !> min ice thickness (m) to be counted as part of a glacier;
+                                   !> currently set based on model%numerics%thklim
 
      ! 1D arrays with size nglacier
 

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -1883,6 +1883,7 @@ module glide_types
           dthck_dt_accum => null(),         & !> accumulated dthck_dt (m/yr)
           snow_accum => null(),             & !> accumulated snowfall (mm/yr w.e.)
           Tpos_accum => null(),             & !> accumulated max(artm - Tmlt,0) (deg C)
+          smb_obs => null(),                & !> observed glacier mass balance, e.g. from Hugonnet et al. (2021), mm/yr w.e.
           mu_star_2d => null()                !> glacier mu_star mapped to a 2D grid
 
      integer, dimension(:,:), pointer :: &
@@ -2936,6 +2937,7 @@ contains
        call coordsystem_allocate(model%general%ice_grid, model%glacier%dthck_dt_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%snow_accum)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%Tpos_accum)
+       call coordsystem_allocate(model%general%ice_grid, model%glacier%smb_obs)
        call coordsystem_allocate(model%general%ice_grid, model%glacier%mu_star_2d)
        call coordsystem_allocate(model%general%ice_grid, model%climate%snow)  ! used for SMB
        !TODO - Delete these if they are allocated with XY_LAPSE logic
@@ -3387,6 +3389,8 @@ contains
         deallocate(model%glacier%snow_accum)
     if (associated(model%glacier%Tpos_accum)) &
         deallocate(model%glacier%Tpos_accum)
+    if (associated(model%glacier%smb_obs)) &
+        deallocate(model%glacier%smb_obs)
     if (associated(model%glacier%mu_star_2d)) &
         deallocate(model%glacier%mu_star_2d)
     if (associated(model%glacier%area)) &

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -774,6 +774,9 @@ module glide_types
     !>          (required if restart velocities are nonzero on global boundaries)
     !> \end{description}
 
+    logical :: forcewrite_restart = .false.
+    !> flag that indicates whether to force writing of output on restart
+
     ! This is a Glimmer serial option
     ! The parallel code enforces periodic EW and NS boundary conditions by default
     logical :: periodic_ew = .false.

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -81,7 +81,13 @@ units:         meter
 long_name:     ocean_z_coordinate
 data:          data%ocean_data%zocn
 positive:      up
-dimlen:        data%ocean_data%nzocn
+dimlen:        model%ocean_data%nzocn
+
+[glacierid]
+dimensions:    glacierid
+units:         1
+long_name:     glacier_id_coordinate
+dimlen:        model%glacier%nglacier
 
 [nlev_smb]
 dimensions:    nlev_smb
@@ -751,6 +757,15 @@ long_name:     surface mass balance
 data:          data%climate%smb
 factor:        1.0
 standard_name: land_ice_surface_specific_mass_balance
+load:          1
+
+[snow]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     snowfall rate
+data:          data%climate%snow
+factor:        1.0
+standard_name: land_ice_surface_snowfall_rate
 load:          1
 
 [acab]
@@ -1602,23 +1617,56 @@ units:         years
 long_name:     diffusive CFL maximum time step
 data:          data%numerics%diff_cfl_dt
 
-[glacier_id]
+[rgi_glacier_id]
 dimensions:    time, y1, x1
 units:         1
-long_name:     input integer glacier ID
-data:          data%glacier%glacier_id
+long_name:     input RGI glacier ID
+data:          data%glacier%rgi_glacier_id
 load:          1
 
-[glacier_id_cism]
+[cism_glacier_id]
 dimensions:    time, y1, x1
 units:         1
-long_name:     CISM-specific integer glacier ID
-data:          data%glacier%glacier_id_cism
+long_name:     CISM-specific glacier ID
+data:          data%glacier%cism_glacier_id
 load:          1
 
-[mu_star]
-dimensions:    time, y1, x1
-units:         mm/yr w.e. per deg K
-long_name:     glacier ablation parameter
+[glacier_area]
+dimensions:    time, glacierid
+units:         m2
+long_name:     glacier area
+data:          data%glacier%area
+
+[glacier_volume]
+dimensions:    time, glacierid
+units:         m3
+long_name:     glacier volume
+data:          data%glacier%volume
+
+[glacier_area_target]
+dimensions:    time, glacierid
+units:         m2
+long_name:     glacier area target
+data:          data%glacier%area_target
+load:          1
+
+[glacier_volume_target]
+dimensions:    time, glacierid
+units:         m3
+long_name:     glacier volume target
+data:          data%glacier%volume_target
+load:          1
+
+[glacier_mu_star]
+dimensions:    time, glacierid
+units:         mm w.e./yr/deg
+long_name:     glacier SMB coefficient
+data:          data%glacier%mu_star
+load:          1
+
+[glacier_powerlaw_c]
+dimensions:    time, glacierid
+units:         Pa (m/yr)**(-1/3)
+long_name:     glacier basal friction coefficient
 data:          data%glacier%mu_star
 load:          1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1630,6 +1630,13 @@ long_name:     CISM-specific glacier ID
 data:          data%glacier%cism_glacier_id
 load:          1
 
+[cism_glacier_id_init]
+dimensions:    time, y1, x1
+units:         1
+long_name:     initial CISM-specific glacier ID
+data:          data%glacier%cism_glacier_id_init
+load:          1
+
 [cism_to_rgi_glacier_id]
 dimensions:    time, glacierid
 units:         1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -986,6 +986,20 @@ data:          data%climate%smb_aux
 factor:        1.0
 load:          1
 
+[smb_rgi]
+dimensions:    time, y1, x1
+units:         m
+long_name:     surface mass balance at RGI date
+data:          data%glacier%smb_rgi
+load:          1
+
+[usrf_target_rgi]
+dimensions:    time, y1, x1
+units:         m
+long_name:     thickness target for RGI date
+data:          data%glacier%usrf_target_rgi
+load:          1
+
 #WHL: Note sign convention: positive downward
 [bheatflx]
 dimensions:    time, y1, x1
@@ -1766,11 +1780,11 @@ long_name:     glacier snow factor
 data:          data%glacier%alpha_snow
 load:          1
 
-[glacier_beta_artm_aux]
+[glacier_beta_artm]
 dimensions:    time, glacierid
 units:         1
-long_name:     glacier surface temperature correction
-data:          data%glacier%beta_artm_aux
+long_name:     glacier temperature correction
+data:          data%glacier%beta_artm
 load:          1
 
 [glacier_smb_obs]

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1641,17 +1641,23 @@ long_name:     RGI glacier ID corresponding to CISM ID
 data:          data%glacier%cism_to_rgi_glacier_id
 load:          1
 
-[snow_accum]
+[glacier_snow_accum]
 dimensions:    time, y1, x1
 units:         mm/yr w.e.
 long_name:     annual accumulated snowfall
 data:          data%glacier%snow_accum
 
-[Tpos_accum]
+[glacier_Tpos_accum]
 dimensions:    time, y1, x1
 units:         degree_Celsius
 long_name:     annual accumulated positive degrees
 data:          data%glacier%Tpos_accum
+
+[glacier_mu_star_2d]
+dimensions:    time, y1, x1
+units:         mm w.e./yr/deg
+long_name:     glacier SMB coefficient in 2D
+data:          data%glacier%mu_star_2d
 
 [glacier_area]
 dimensions:    time, glacierid

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1690,6 +1690,20 @@ long_name:     initial CISM-specific glacier ID
 data:          data%glacier%cism_glacier_id_init
 load:          1
 
+[smb_glacier_id]
+dimensions:    time, y1, x1
+units:         1
+long_name:     glacier ID for applying SMB
+data:          data%glacier%smb_glacier_id
+load:          1
+
+[smb_glacier_id_init]
+dimensions:    time, y1, x1
+units:         1
+long_name:     initial glacier ID for applying SMB
+data:          data%glacier%smb_glacier_id_init
+load:          1
+
 [cism_to_rgi_glacier_id]
 dimensions:    time, glacierid
 units:         1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1653,6 +1653,13 @@ units:         degree_Celsius
 long_name:     annual accumulated positive degrees
 data:          data%glacier%Tpos_accum
 
+[glacier_smb_obs]
+dimensions:    time, y1, x1
+units:         mm w.e./yr
+long_name:     observed glacier SMB
+data:          data%glacier%smb_obs
+load:          1
+
 [glacier_mu_star_2d]
 dimensions:    time, y1, x1
 units:         mm w.e./yr/deg
@@ -1691,4 +1698,3 @@ units:         mm w.e./yr/deg
 long_name:     glacier SMB coefficient
 data:          data%glacier%mu_star
 load:          1
-

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -966,13 +966,6 @@ long_name:     surface mass balance at RGI date
 data:          data%glacier%smb_rgi
 load:          1
 
-[usrf_target_rgi]
-dimensions:    time, y1, x1
-units:         m
-long_name:     thickness target for RGI date
-data:          data%glacier%usrf_target_rgi
-load:          1
-
 [smb_recent]
 dimensions:    time, y1, x1
 units:         mm/year water equivalent

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1751,6 +1751,13 @@ long_name:     glacier snow factor
 data:          data%glacier%snow_factor
 load:          1
 
+[glacier_artm_aux_corr]
+dimensions:    time, glacierid
+units:         1
+long_name:     glacier surface temperature correction
+data:          data%glacier%artm_aux_corr
+load:          1
+
 [glacier_smb_obs]
 dimensions:    time, glacierid
 units:         mm w.e./yr

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -946,6 +946,7 @@ units:         mm/year water equivalent
 long_name:     auxiliary snowfall rate
 data:          data%climate%snow_aux
 load:          1
+read_once:     1
 
 [precip_aux]
 dimensions:    time, y1, x1
@@ -953,6 +954,7 @@ units:         mm/year water equivalent
 long_name:     auxiliary precipitation rate
 data:          data%climate%precip_aux
 load:          1
+read_once:     1
 
 [artm_aux]
 dimensions:    time, y1, x1
@@ -967,6 +969,7 @@ units:         deg Celsius
 long_name:     auxiliary surface temperature at reference elevation
 data:          data%climate%artm_ref_aux
 load:          1
+read_once:     1
 
 [usrf_ref_aux]
 dimensions:    time, y1, x1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1601,3 +1601,24 @@ dimensions:    time
 units:         years
 long_name:     diffusive CFL maximum time step
 data:          data%numerics%diff_cfl_dt
+
+[glacier_id]
+dimensions:    time, y1, x1
+units:         1
+long_name:     input integer glacier ID
+data:          data%glacier%glacier_id
+load:          1
+
+[glacier_id_cism]
+dimensions:    time, y1, x1
+units:         1
+long_name:     CISM-specific integer glacier ID
+data:          data%glacier%glacier_id_cism
+load:          1
+
+[mu_star]
+dimensions:    time, y1, x1
+units:         mm/yr w.e. per deg K
+long_name:     glacier ablation parameter
+data:          data%glacier%mu_star
+load:          1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -855,14 +855,6 @@ data:          data%climate%artm_gradz
 standard_name: land_ice_surface_temperature_vertical_gradient
 load:          1
 
-[artm_anomaly]
-dimensions:    time, y1, x1
-units:         deg Celsius
-long_name:     surface temperature anomaly
-data:          data%climate%artm_anomaly
-standard_name: land_ice_surface_temperature_anomaly
-load:          1
-
 [usrf_ref]
 dimensions:    time, y1, x1
 units:         m
@@ -871,12 +863,12 @@ data:          data%climate%usrf_ref
 standard_name: land_ice_reference_surface_elevation
 load:          1
 
-[artm_ref_anomaly]
+[artm_anomaly]
 dimensions:    time, y1, x1
 units:         deg Celsius
-long_name:     reference surface temperature anomaly
-data:          data%climate%artm_ref_anomaly
-standard_name: land_ice_reference_surface_temperature_anomaly
+long_name:     surface temperature anomaly
+data:          data%climate%artm_anomaly
+standard_name: land_ice_surface_temperature_anomaly
 load:          1
 read_once:     1
 

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -961,7 +961,7 @@ load:          1
 
 [smb_rgi]
 dimensions:    time, y1, x1
-units:         m
+units:         mm/year water equivalent
 long_name:     surface mass balance at RGI date
 data:          data%glacier%smb_rgi
 load:          1
@@ -973,6 +973,13 @@ long_name:     surface mass balance, recent date
 data:          data%glacier%smb_recent
 factor:        1.0
 load:          1
+
+[thck_target]
+dimensions:    time, y1, x1
+units:         m
+long_name:     glacier thickness target
+data:          data%glacier%thck_target
+factor:        1.0
 
 #WHL: Note sign convention: positive downward
 [bheatflx]

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1711,6 +1711,13 @@ long_name:     RGI glacier ID corresponding to CISM ID
 data:          data%glacier%cism_to_rgi_glacier_id
 load:          1
 
+[glacier_area_factor]
+dimensions:    time, y1, x1
+units:         1
+long_name:     glacier area scale factor
+data:          data%glacier%area_factor
+load:          1
+
 [glacier_area]
 dimensions:    time, glacierid
 units:         m2

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -978,6 +978,14 @@ long_name:     auxiliary reference upper surface elevation for input forcing
 data:          data%climate%usrf_ref_aux
 load:          1
 
+[smb_aux]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     auxiliary surface mass balance
+data:          data%climate%smb_aux
+factor:        1.0
+load:          1
+
 #WHL: Note sign convention: positive downward
 [bheatflx]
 dimensions:    time, y1, x1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1763,7 +1763,7 @@ load:          1
 
 [glacier_beta_artm]
 dimensions:    time, glacierid
-units:         1
+units:         degC
 long_name:     glacier temperature correction
 data:          data%glacier%beta_artm
 load:          1
@@ -1780,3 +1780,23 @@ dimensions:    time, glacierid
 units:         mm w.e./yr
 long_name:     modeled glacier-average SMB
 data:          data%glacier%smb
+
+[glacier_total_area]
+dimensions:    time
+units:         km2
+long_name:     total glacier area
+factor:        1.e-06
+data:          data%glacier%total_area
+
+[glacier_total_volume]
+dimensions:    time
+units:         km3
+long_name:     total glacier volume
+factor:        1.e-09
+data:          data%glacier%total_volume
+
+[nglacier_active]
+dimensions:    time
+units:         1
+long_name:     number of active glaciers
+data:          data%glacier%nglacier_active

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -773,6 +773,7 @@ long_name:     snowfall rate
 data:          data%climate%snow
 factor:        1.0
 load:          1
+read_once:     1
 
 [precip]
 dimensions:    time, y1, x1
@@ -781,6 +782,7 @@ long_name:     precipitation rate
 data:          data%climate%precip
 factor:        1.0
 load:          1
+read_once:     1
 
 [acab]
 dimensions:    time, y1, x1
@@ -851,6 +853,7 @@ long_name:     surface temperature at reference elevation
 data:          data%climate%artm_ref
 standard_name: land_ice_surface_temperature_reference
 load:          1
+read_once:     1
 
 [artm_gradz]
 dimensions:    time, y1, x1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -758,14 +758,6 @@ factor:        1.0
 standard_name: land_ice_surface_specific_mass_balance
 load:          1
 
-[smb_obs]
-dimensions:    time, y1, x1
-units:         mm/year water equivalent
-long_name:     observed surface mass balance
-data:          data%climate%smb_obs
-factor:        1.0
-load:          1
-
 [snow]
 dimensions:    time, y1, x1
 units:         mm/year water equivalent
@@ -938,6 +930,49 @@ long_name:     cells where acab is overwritten
 data:          data%climate%overwrite_acab_mask
 standard_name: land_ice_overwrite_acab_mask
 type:          int
+load:          1
+
+[smb_obs]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     observed surface mass balance
+data:          data%climate%smb_obs
+factor:        1.0
+load:          1
+
+[snow_aux]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     auxiliary snowfall rate
+data:          data%climate%snow_aux
+load:          1
+
+[precip_aux]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     auxiliary precipitation rate
+data:          data%climate%precip_aux
+load:          1
+
+[artm_aux]
+dimensions:    time, y1, x1
+units:         deg Celsius
+long_name:     auxiliary surface temperature
+data:          data%climate%artm_aux
+load:          1
+
+[artm_ref_aux]
+dimensions:    time, y1, x1
+units:         deg Celsius
+long_name:     auxiliary surface temperature at reference elevation
+data:          data%climate%artm_ref_aux
+load:          1
+
+[usrf_ref_aux]
+dimensions:    time, y1, x1
+units:         m
+long_name:     auxiliary reference upper surface elevation for input forcing
+data:          data%climate%usrf_ref_aux
 load:          1
 
 #WHL: Note sign convention: positive downward
@@ -1692,11 +1727,11 @@ long_name:     glacier SMB coefficient
 data:          data%glacier%mu_star
 load:          1
 
-[glacier_delta_artm]
+[glacier_snow_factor]
 dimensions:    time, glacierid
-units:         degree_Celsius
-long_name:     glacier artm adjustment
-data:          data%glacier%delta_artm
+units:         1
+long_name:     glacier snow factor
+data:          data%glacier%snow_factor
 load:          1
 
 [glacier_smb_obs]

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1744,18 +1744,18 @@ long_name:     glacier SMB coefficient
 data:          data%glacier%mu_star
 load:          1
 
-[glacier_snow_factor]
+[glacier_alpha_snow]
 dimensions:    time, glacierid
 units:         1
 long_name:     glacier snow factor
-data:          data%glacier%snow_factor
+data:          data%glacier%alpha_snow
 load:          1
 
-[glacier_artm_aux_corr]
+[glacier_beta_artm_aux]
 dimensions:    time, glacierid
 units:         1
 long_name:     glacier surface temperature correction
-data:          data%glacier%artm_aux_corr
+data:          data%glacier%beta_artm_aux
 load:          1
 
 [glacier_smb_obs]

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -772,7 +772,14 @@ units:         mm/year water equivalent
 long_name:     snowfall rate
 data:          data%climate%snow
 factor:        1.0
-standard_name: land_ice_surface_snowfall_rate
+load:          1
+
+[precip]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     precipitation rate
+data:          data%climate%precip
+factor:        1.0
 load:          1
 
 [acab]
@@ -1680,6 +1687,13 @@ dimensions:    time, glacierid
 units:         mm w.e./yr/deg
 long_name:     glacier SMB coefficient
 data:          data%glacier%mu_star
+load:          1
+
+[glacier_delta_artm]
+dimensions:    time, glacierid
+units:         degree_Celsius
+long_name:     glacier artm adjustment
+data:          data%glacier%delta_artm
 load:          1
 
 [glacier_smb_obs]

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -790,7 +790,6 @@ dimensions:    time, y1, x1
 units:         mm/year water equivalent per m
 long_name:     surface mass balance vertical gradient
 data:          data%climate%smb_gradz
-factor:        1.0/thk0
 standard_name: land_ice_surface_specific_mass_balance_vertical_gradient
 load:          1
 
@@ -817,7 +816,7 @@ dimensions:    time, y1, x1
 units:         m/year ice per m
 long_name:     surface mass balance vertical gradient
 data:          data%climate%acab_gradz
-factor:        scale_acab/thk0
+factor:        scale_acab
 standard_name: land_ice_surface_specific_mass_balance_vertical_gradient
 load:          1
 
@@ -844,7 +843,6 @@ units:         deg Celsius per m
 long_name:     surface temperature vertical gradient
 data:          data%climate%artm_gradz
 standard_name: land_ice_surface_temperature_vertical_gradient
-factor:        1./thk0
 load:          1
 
 [artm_anomaly]
@@ -855,13 +853,12 @@ data:          data%climate%artm_anomaly
 standard_name: land_ice_surface_temperature_anomaly
 load:          1
 
-[smb_reference_usrf]
+[usrf_ref]
 dimensions:    time, y1, x1
 units:         m
-long_name:     reference upper surface elevation for SMB forcing
-data:          data%climate%smb_reference_usrf
-factor:        thk0
-standard_name: land_ice_specific_surface_mass_balance_reference_elevation
+long_name:     reference upper surface elevation for input forcing
+data:          data%climate%usrf_ref
+standard_name: land_ice_reference_surface_elevation
 load:          1
 
 [smb_3d]
@@ -1643,6 +1640,18 @@ units:         1
 long_name:     RGI glacier ID corresponding to CISM ID
 data:          data%glacier%cism_to_rgi_glacier_id
 load:          1
+
+[snow_accum]
+dimensions:    time, y1, x1
+units:         mm/yr w.e.
+long_name:     annual accumulated snowfall
+data:          data%glacier%snow_accum
+
+[Tpos_accum]
+dimensions:    time, y1, x1
+units:         degree_Celsius
+long_name:     annual accumulated positive degrees
+data:          data%glacier%Tpos_accum
 
 [glacier_area]
 dimensions:    time, glacierid

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -843,7 +843,7 @@ dimensions:    time, y1, x1
 units:         deg Celsius
 long_name:     surface temperature at reference elevation
 data:          data%climate%artm_ref
-standard_name: land_ice_surface_temperature_reference
+standard_name: land_ice_reference_surface_temperature
 load:          1
 read_once:     1
 
@@ -870,6 +870,33 @@ long_name:     reference upper surface elevation for input forcing
 data:          data%climate%usrf_ref
 standard_name: land_ice_reference_surface_elevation
 load:          1
+
+[artm_ref_anomaly]
+dimensions:    time, y1, x1
+units:         deg Celsius
+long_name:     reference surface temperature anomaly
+data:          data%climate%artm_ref_anomaly
+standard_name: land_ice_reference_surface_temperature_anomaly
+load:          1
+read_once:     1
+
+[snow_anomaly]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     anomaly snowfall rate
+data:          data%climate%snow_anomaly
+factor:        1.0
+load:          1
+read_once:     1
+
+[precip_anomaly]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     anomaly precipitation rate
+data:          data%climate%precip_anomaly
+factor:        1.0
+load:          1
+read_once:     1
 
 [smb_3d]
 dimensions:    time, nlev_smb, y1, x1
@@ -940,52 +967,6 @@ data:          data%climate%smb_obs
 factor:        1.0
 load:          1
 
-[snow_aux]
-dimensions:    time, y1, x1
-units:         mm/year water equivalent
-long_name:     auxiliary snowfall rate
-data:          data%climate%snow_aux
-load:          1
-read_once:     1
-
-[precip_aux]
-dimensions:    time, y1, x1
-units:         mm/year water equivalent
-long_name:     auxiliary precipitation rate
-data:          data%climate%precip_aux
-load:          1
-read_once:     1
-
-[artm_aux]
-dimensions:    time, y1, x1
-units:         deg Celsius
-long_name:     auxiliary surface temperature
-data:          data%climate%artm_aux
-load:          1
-
-[artm_ref_aux]
-dimensions:    time, y1, x1
-units:         deg Celsius
-long_name:     auxiliary surface temperature at reference elevation
-data:          data%climate%artm_ref_aux
-load:          1
-read_once:     1
-
-[usrf_ref_aux]
-dimensions:    time, y1, x1
-units:         m
-long_name:     auxiliary reference upper surface elevation for input forcing
-data:          data%climate%usrf_ref_aux
-load:          1
-
-[smb_aux]
-dimensions:    time, y1, x1
-units:         mm/year water equivalent
-long_name:     auxiliary surface mass balance
-data:          data%climate%smb_aux
-factor:        1.0
-load:          1
-
 [smb_rgi]
 dimensions:    time, y1, x1
 units:         m
@@ -998,6 +979,14 @@ dimensions:    time, y1, x1
 units:         m
 long_name:     thickness target for RGI date
 data:          data%glacier%usrf_target_rgi
+load:          1
+
+[smb_recent]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     surface mass balance, recent date
+data:          data%glacier%smb_recent
+factor:        1.0
 load:          1
 
 #WHL: Note sign convention: positive downward

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1671,18 +1671,18 @@ units:         m3
 long_name:     glacier volume
 data:          data%glacier%volume
 
-[glacier_area_target]
+[glacier_area_init]
 dimensions:    time, glacierid
 units:         m2
-long_name:     glacier area target
-data:          data%glacier%area_target
+long_name:     initial glacier area
+data:          data%glacier%area_init
 load:          1
 
-[glacier_volume_target]
+[glacier_volume_init]
 dimensions:    time, glacierid
 units:         m3
-long_name:     glacier volume target
-data:          data%glacier%volume_target
+long_name:     initial glacier volume
+data:          data%glacier%volume_init
 load:          1
 
 [glacier_mu_star]

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -1686,9 +1686,3 @@ long_name:     glacier SMB coefficient
 data:          data%glacier%mu_star
 load:          1
 
-[glacier_powerlaw_c]
-dimensions:    time, glacierid
-units:         Pa (m/yr)**(-1/3)
-long_name:     glacier basal friction coefficient
-data:          data%glacier%powerlaw_c
-load:          1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -55,7 +55,6 @@ dimensions:    level
 units:         1
 long_name:     sigma layers
 standard_name: land_ice_sigma_coordinate
-#formula_terms: sigma: level topo: topg thick: thk
 positive:      down
 dimlen:        model%general%upn
 
@@ -1631,6 +1630,13 @@ long_name:     CISM-specific glacier ID
 data:          data%glacier%cism_glacier_id
 load:          1
 
+[cism_to_rgi_glacier_id]
+dimensions:    time, glacierid
+units:         1
+long_name:     RGI glacier ID corresponding to CISM ID
+data:          data%glacier%cism_to_rgi_glacier_id
+load:          1
+
 [glacier_area]
 dimensions:    time, glacierid
 units:         m2
@@ -1668,5 +1674,5 @@ load:          1
 dimensions:    time, glacierid
 units:         Pa (m/yr)**(-1/3)
 long_name:     glacier basal friction coefficient
-data:          data%glacier%mu_star
+data:          data%glacier%powerlaw_c
 load:          1

--- a/libglide/glide_vars.def
+++ b/libglide/glide_vars.def
@@ -758,6 +758,14 @@ factor:        1.0
 standard_name: land_ice_surface_specific_mass_balance
 load:          1
 
+[smb_obs]
+dimensions:    time, y1, x1
+units:         mm/year water equivalent
+long_name:     observed surface mass balance
+data:          data%climate%smb_obs
+factor:        1.0
+load:          1
+
 [snow]
 dimensions:    time, y1, x1
 units:         mm/year water equivalent
@@ -1641,31 +1649,6 @@ long_name:     RGI glacier ID corresponding to CISM ID
 data:          data%glacier%cism_to_rgi_glacier_id
 load:          1
 
-[glacier_snow_accum]
-dimensions:    time, y1, x1
-units:         mm/yr w.e.
-long_name:     annual accumulated snowfall
-data:          data%glacier%snow_accum
-
-[glacier_Tpos_accum]
-dimensions:    time, y1, x1
-units:         degree_Celsius
-long_name:     annual accumulated positive degrees
-data:          data%glacier%Tpos_accum
-
-[glacier_smb_obs]
-dimensions:    time, y1, x1
-units:         mm w.e./yr
-long_name:     observed glacier SMB
-data:          data%glacier%smb_obs
-load:          1
-
-[glacier_mu_star_2d]
-dimensions:    time, y1, x1
-units:         mm w.e./yr/deg
-long_name:     glacier SMB coefficient in 2D
-data:          data%glacier%mu_star_2d
-
 [glacier_area]
 dimensions:    time, glacierid
 units:         m2
@@ -1698,3 +1681,16 @@ units:         mm w.e./yr/deg
 long_name:     glacier SMB coefficient
 data:          data%glacier%mu_star
 load:          1
+
+[glacier_smb_obs]
+dimensions:    time, glacierid
+units:         mm w.e./yr
+long_name:     observed glacier-average SMB
+data:          data%glacier%smb_obs
+load:          1
+
+[glacier_smb]
+dimensions:    time, glacierid
+units:         mm w.e./yr
+long_name:     modeled glacier-average SMB
+data:          data%glacier%smb

--- a/libglimmer/glimmer_map_init.F90
+++ b/libglimmer/glimmer_map_init.F90
@@ -475,6 +475,10 @@ contains
     ! This code is adapted from a Matlab script provided by Heiko Goelzer, based on this reference:
     ! J. P. Snyder (1987): Map Projections--A Working Manual, US Geological Survey Professional Paper 1395.
     !
+    ! Note: What's called area_factor here should probably be called scale_factor.
+    !       It corresponds to the factor 'k' in Snyder, which is a length distortion factor.
+    !       To adjust areas in CISM, one needs to divide by k^2.
+    !
     ! Note: This subroutine should not be called until the input file has been read in,
     !       and we have the relevant grid info (ewn, nsn, dx, dy).
 
@@ -597,7 +601,6 @@ contains
        call write_log ('Set area scale factor = 1 for polar stereographic projection')
 
     endif  ! compute_area_factor
-
 
   end subroutine glimmap_stere_area_factor
 

--- a/libglimmer/glimmer_map_init.F90
+++ b/libglimmer/glimmer_map_init.F90
@@ -472,7 +472,7 @@ contains
     ! Compute area scale factors for each grid cell.
     ! These scale factors describe the distortion of areas in a stereographic projection.
     !
-    ! This code is adapted a Matlab script provided by Heiko Goelzer, based on this reference:
+    ! This code is adapted from a Matlab script provided by Heiko Goelzer, based on this reference:
     ! J. P. Snyder (1987): Map Projections--A Working Manual, US Geological Survey Professional Paper 1395.
     !
     ! Note: This subroutine should not be called until the input file has been read in,

--- a/libglimmer/glimmer_ncdf.F90
+++ b/libglimmer/glimmer_ncdf.F90
@@ -83,6 +83,8 @@ module glimmer_ncdf
      integer :: nstagwbndlevel = 0
      !WHL - added to handle ocean vertical coordinate
      integer :: nzocn = 0
+     !WHL - added to handle glacier coordinate
+     integer :: nglacier = 0
 
      !> size of vertical and stag vertical coordinate
 
@@ -145,7 +147,7 @@ module glimmer_ncdf
      !> element of linked list describing netCDF output file
      !NO_RESTART previous
 
-     type(glimmer_nc_stat) :: nc                          !< structure containg file info
+     type(glimmer_nc_stat) :: nc                          !< structure containing file info
      real(dp) :: freq = 1000.d0                           !< frequency at which data is written to file
      logical  :: write_init = .true.                      !< if true, then write at the start of the run (tstep_count = 0)
      real(dp) :: end_write = glimmer_nc_max_time          !< stop writing after this year
@@ -372,6 +374,7 @@ contains
     print*,'nstaglevel:      ',stat%nstaglevel
     print*,'nstagwbndlevel:  ',stat%nstagwbndlevel
     print*,'nzocn:           ',stat%nzocn
+    print*,'nglacier:        ',stat%nglacier
     print*,'timedim:         ',stat%timedim
     print*,'internal_timevar:',stat%internal_timevar
     print*,'timevar:         ',stat%timevar

--- a/libglimmer/glimmer_ncdf.F90
+++ b/libglimmer/glimmer_ncdf.F90
@@ -208,6 +208,11 @@ module glimmer_ncdf
      integer                        :: nyear_cycle = 0            !> Cycle repeatedly through nyear_cycle years of forcing data
                                                                   !> No cycling unless nyear_cycle > 0
 
+     ! The following parameter can be set to .true. to read all forcing time slices at initialization.
+     ! This increases the required storage, but can reduce computational time if applying the same N years
+     ! of forcing repeatedly, either cycled or shuffled.
+     logical                        :: read_once = .false.
+
   end type glimmer_nc_input
 
 

--- a/libglimmer/glimmer_ncdf.F90
+++ b/libglimmer/glimmer_ncdf.F90
@@ -208,6 +208,9 @@ module glimmer_ncdf
      integer                        :: nyear_cycle = 0            !> Cycle repeatedly through nyear_cycle years of forcing data
                                                                   !> No cycling unless nyear_cycle > 0
 
+     ! if shuffle_file is present, then read an ASCII file with a shuffled list of forcing years
+     character(len=fname_length)    :: shuffle_file = ''
+
      ! The following parameter can be set to .true. to read all forcing time slices at initialization.
      ! This increases the required storage, but can reduce computational time if applying the same N years
      ! of forcing repeatedly, either cycled or shuffled.

--- a/libglimmer/glimmer_ncio.F90
+++ b/libglimmer/glimmer_ncio.F90
@@ -210,6 +210,9 @@ contains
     ! WHL - adding a vertical coordinate for ocean data
     NCO%nzocn = model%ocean_data%nzocn
 
+    ! WHL - adding a vertical coordinate for glacier data
+    NCO%nglacier = model%glacier%nglacier
+
   end subroutine glimmer_nc_openappend
 
   !------------------------------------------------------------------------------
@@ -344,6 +347,9 @@ contains
 
     ! WHL - adding a vertical coordinate for ocean data
     NCO%nzocn = model%ocean_data%nzocn
+
+    ! WHL - adding a vertical coordinate for glacier data
+    NCO%nglacier = model%glacier%nglacier
 
   end subroutine glimmer_nc_createfile
 
@@ -581,6 +587,9 @@ contains
 
     ! WHL - adding a vertical coordinate for ocean data
     NCI%nzocn = model%ocean_data%nzocn
+
+    ! WHL - adding a vertical coordinate for glacier data
+    NCI%nglacier = model%glacier%nglacier
 
     ! checking if dimensions and grid spacing are the same as in the configuration file
     ! x1

--- a/libglimmer/glimmer_ncio.F90
+++ b/libglimmer/glimmer_ncio.F90
@@ -784,6 +784,11 @@ contains
        end if
     end if
 
+    ! For read_once files, suppress the call to glide_io_read by setting just_processed = false
+    if (infile%read_once) then
+       NCI%just_processed = .FALSE.
+    endif
+
   contains
 
     real(dp) function sub_time(model, time)

--- a/libglimmer/glimmer_ncparams.F90
+++ b/libglimmer/glimmer_ncparams.F90
@@ -364,7 +364,12 @@ contains
     call GetValue(section,'time_offset',handle_forcing%time_offset)
     call GetValue(section,'nyear_cycle',handle_forcing%nyear_cycle)
     call GetValue(section,'time_start_cycle',handle_forcing%time_start_cycle)
-    call GetValue(section,'read_once', handle_forcing%read_once) ! WHL - if true, then read in all time slices just once, at initialization
+
+    ! if shuffle_file is present, then read an ASCII file with a shuffled list of forcing years
+    call GetValue(section,'shuffle_file', handle_forcing%shuffle_file)
+
+    ! if read_once = true, then read in all time slices just once, at initialization
+    call GetValue(section,'read_once', handle_forcing%read_once)
 
     handle_forcing%current_time = handle_forcing%get_time_slice
 
@@ -381,6 +386,10 @@ contains
           write(message,*) '   time_start_cycle:', handle_forcing%time_start_cycle
           call write_log(message)
           write(message,*) '   nyear_cycle:', handle_forcing%nyear_cycle
+          call write_log(message)
+       endif
+       if (trim(handle_forcing%shuffle_file) /= '') then
+          write(message,*) '   shuffle_file: ', trim(handle_forcing%shuffle_file)
           call write_log(message)
        endif
        if (handle_forcing%read_once) then

--- a/libglimmer/glimmer_ncparams.F90
+++ b/libglimmer/glimmer_ncparams.F90
@@ -364,6 +364,7 @@ contains
     call GetValue(section,'time_offset',handle_forcing%time_offset)
     call GetValue(section,'nyear_cycle',handle_forcing%nyear_cycle)
     call GetValue(section,'time_start_cycle',handle_forcing%time_start_cycle)
+    call GetValue(section,'read_once', handle_forcing%read_once) ! WHL - if true, then read in all time slices just once, at initialization
 
     handle_forcing%current_time = handle_forcing%get_time_slice
 
@@ -381,6 +382,9 @@ contains
           call write_log(message)
           write(message,*) '   nyear_cycle:', handle_forcing%nyear_cycle
           call write_log(message)
+       endif
+       if (handle_forcing%read_once) then
+          call write_log('All time slices will be read just once, at initialization')
        endif
     end if
 

--- a/libglimmer/glimmer_ncparams.F90
+++ b/libglimmer/glimmer_ncparams.F90
@@ -75,17 +75,25 @@ contains
     character(len=fname_length) :: restart_filename
     character(len=256) :: message
 
-    ! Note on restart files:
+    ! Notes on restart files:
     ! If a file is listed in the 'CF restart' section, then it is added to the glimmer_nc_output data structure
     !  and written at the specified frequency.
-    ! If model%options%is_restart = RESTART_TRUE, then the file listed in 'CF restart' (provided it exists) 
+    !
+    ! If model%options%is_restart = STANDARD_RESTART, then the file listed in 'CF restart' (provided it exists)
     !  is added to the glimmer_nc_input data structure, overriding any file listed in the 'CF input' section.
     !  The latest time slice will be read in.
-    ! Thus when restarting the model, it is only necessary to set restart = RESTART_TRUE (i.e, restart = 1)
-    !  in the config file; it is not necesssary to change filenames in 'CF input' or 'CF restart'.
-    ! At most one file should be listed in the 'CF restart' section, and it should contain the string 'restart'
-    ! If model%options%is_restart = RESTART_TRUE and there is no 'CF restart' section, then the model will restart
+    ! Thus when restarting the model, it is only necessary to set restart = 1 (i.e., STANDARD_RESTART)
+    !  in the config file; it is not necesssary to change the filenames in 'CF input' or 'CF restart'.
+    ! At most one file should be listed in the 'CF restart' section, and it should contain the string 'restart' or '.r.'
+    ! If model%options%is_restart = STANDARD_RESTART and there is no 'CF restart' section, then the model will restart
     !  from the file and time slice specified in the 'CF input' section. (This is the old Glimmer behavior.)
+    !
+    ! If model%options%is_restart = HYBRID_RESTART, then the file listed in 'CF input' is used to initialize the model.
+    ! This file should be a restart file from a previous run (e.g., a long ice-sheet spin-up),
+    !  which provides the initial ice state for the hybrid run.
+    ! The differences from STANDARD_RESTART (besides the config section where the filename is given) are
+    ! (1) tstep_count is set to 0, replacing the value in the CF input file.
+    ! (2) model%numerics%time is set to tstart from the config file, replacing the value in the CF input file.
 
     ! get config string
     call ConfigAsString(config,configstring)
@@ -135,7 +143,7 @@ contains
     end do
 
     ! set up restart input
-    if (model%options%is_restart == RESTART_TRUE) then
+    if (model%options%is_restart == STANDARD_RESTART) then
 
        ! If there is a 'CF restart' section, the model will restart from the file listed there (if it exists).
        ! Else the model will start from the input file in the 'CF input' section.
@@ -187,7 +195,7 @@ contains
 
        endif   ! associated(section)
 
-    endif  ! model%options%is_restart = RESTART_TRUE
+    endif  ! model%options%is_restart
 
     ! setup forcings
     call GetSection(config,section,'CF forcing')

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -526,7 +526,7 @@ contains
     integer :: nx, ny, nt                ! dimension sizes
     real(dp) :: eps                      ! a tolerance to use for stepwise constant forcing
     real(dp) :: global_sum               ! global sum of an input field
-    logical, parameter :: verbose_read_forcing = .false.
+    logical, parameter :: verbose_read_forcing = .true.
 
     ! Make eps a fraction of the time step.
     eps = model%numerics%tinc * 1.0d-3

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -439,7 +439,15 @@ contains
 
 !       if (main_task .and. verbose_read_forcing) print *, 'possible forcing times', ic%times
 
-       if (.not.ic%read_once) then
+       if (ic%read_once) then  ! read once at initialization; do not re-read at runtime
+
+          ic%nc%just_processed = .true.  ! prevent the file from being read
+          if (main_task .and. verbose_read_forcing) then
+             print*, ' '
+             print*, 'In NAME_read_forcing; will not re-read the read_once file ', trim(ic%nc%filename)
+          endif
+
+       else  ! not a read_once file
 
           ic%nc%just_processed = .true. ! until we find an acceptable time, set this to true which will prevent the file from being read.
 
@@ -494,7 +502,7 @@ contains
 
           end do  ! if we get to end of loop without exiting, then this file will not be read at this time
 
-       endif  ! not a read_once file
+       endif  ! read_once file
 
        ! move on to the next forcing file
        ic=>ic%next
@@ -511,7 +519,9 @@ contains
   subroutine NAME_read_forcing_once(data, model)
 
     ! Read data from forcing files with read_once = .true.
-    ! Read all time slices in a single call and write to arrays with a time index
+    ! Read all time slices in a single call and write to arrays with a time index.
+
+    use glimmer_global, only: msg_length
     use glimmer_log
     use glide_types
     use cism_parallel, only: main_task, parallel_reduce_sum
@@ -526,6 +536,7 @@ contains
     integer :: nx, ny, nt                ! dimension sizes
     real(dp) :: eps                      ! a tolerance to use for stepwise constant forcing
     real(dp) :: global_sum               ! global sum of an input field
+    character(len=msg_length) :: message
     logical, parameter :: verbose_read_forcing = .true.
 
     ! Make eps a fraction of the time step.
@@ -543,6 +554,9 @@ contains
              print*, 'Filename =', trim(ic%nc%filename)
              print*, 'Number of slices =', ic%nt
           endif
+
+          write(message,*) 'Reading', ic%nt, 'slices of file ', trim(ic%nc%filename), ' just once at initialization'
+          call write_log(message)
 
           nt = ic%nt
           ic%nc%vars = ''
@@ -590,6 +604,7 @@ contains
     ! Retrieve a single time slice of forcing from arrays that contain all the forcing.
     ! Called repeatedly at runtime, after calling the read_forcing_once subroutine at initialization.
 
+    use glimmer_global, only: msg_length
     use glimmer_log
     use glide_types
     use cism_parallel, only: main_task
@@ -608,6 +623,7 @@ contains
     integer :: this_year               ! current simulation year relative to tstart; starts at 0
     integer :: year1, year2            ! years read from the shuffle file
     real(dp) :: decimal_year           ! decimal part of the current year
+    character(len=msg_length) :: message
     logical, parameter :: verbose_read_forcing = .false.
 
     ! Make eps a fraction of the time step
@@ -646,37 +662,37 @@ contains
              print*, 'variable list:', trim(ic%nc%vars)
           endif
 
-           ! Optionally, associate the current forcing time with a different date in the forcing file.
-           ! This is done by reading a file that associates each simulation year (relative to tstart)
-           !  with a year that is read from a 'shuffle file'. The shuffle file typically consists of
-           !  consecutive integers (in column 1), followed by years chosen at random from all the years
-           !  in the forcing file (in column 2).
+          ! Optionally, associate the current forcing time with a different date in the forcing file.
+          ! This is done by reading a file that associates each simulation year (relative to tstart)
+          !  with a year that is read from a 'shuffle file'. The shuffle file typically consists of
+          !  consecutive integers (in column 1), followed by years chosen at random from all the years
+          !  in the forcing file (in column 2).
 
-           if (trim(ic%shuffle_file) /= '') then  ! shuffle_file exists
-              open(unit=11, file=trim(ic%shuffle_file), status='old')
-              this_year = int(current_forcing_time - model%numerics%tstart)
-              if (main_task .and. verbose_read_forcing) then
-                 print*, 'shuffle_file = ', trim(ic%shuffle_file)
-                 print*, 'tstart, this_year =', model%numerics%tstart, this_year
-              endif
-              forcing_year = 0
-              do while (forcing_year == 0)
-                 read(11,'(i6,i8)') year1, year2
-                 if (this_year == year1) then
-                    forcing_year = year2
-                    exit
-                 endif
-              enddo
-              close(11)
-              decimal_year = current_forcing_time - floor(current_forcing_time)
-              current_forcing_time = real(forcing_year,dp) + decimal_year
-              if (main_task .and. verbose_read_forcing) then
-                 print*, 'forcing_year, decimal =', forcing_year, decimal_year
-                 print*, 'shuffled forcing_time =', current_forcing_time
-              endif
-           else
-              if (main_task .and. verbose_read_forcing) print*, 'no shuffle_file'
-           endif  ! shuffle_file exists
+          if (trim(ic%shuffle_file) /= '') then  ! shuffle_file exists
+             open(unit=11, file=trim(ic%shuffle_file), status='old')
+             this_year = int(current_forcing_time - model%numerics%tstart)
+             if (main_task .and. verbose_read_forcing) then
+                print*, 'shuffle_file = ', trim(ic%shuffle_file)
+                print*, 'tstart, this_year =', model%numerics%tstart, this_year
+             endif
+             forcing_year = 0
+             do while (forcing_year == 0)
+                read(11,'(i6,i8)') year1, year2
+                if (this_year == year1) then
+                   forcing_year = year2
+                   exit
+                endif
+             enddo
+             close(11)
+             decimal_year = current_forcing_time - floor(current_forcing_time)
+             current_forcing_time = real(forcing_year,dp) + decimal_year
+             if (main_task .and. verbose_read_forcing) then
+                print*, 'forcing_year, decimal =', forcing_year, decimal_year
+                print*, 'shuffled forcing_time =', current_forcing_time
+             endif
+          else
+             if (main_task .and. verbose_read_forcing) print*, 'no shuffle_file'
+          endif  ! shuffle_file exists
 
           ! Find the time index associated with the previous model time step
           t_prev = 0
@@ -701,6 +717,9 @@ contains
                    ic%current_time = t
                    retrieve_new_slice = .true.
                    if (main_task .and. verbose_read_forcing) print*, 'Retrieve new forcing slice'
+                   write(message,*) &
+                        'Retrieve slice', t, 'at forcing time', ic%times(t), 'from file ', trim(ic%nc%filename)
+                   call write_log(message)
                 endif ! t > t_prev
 
                 exit  ! once we find the time, exit the loop

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -590,6 +590,11 @@ contains
     real(dp) :: current_forcing_time   ! current time with reference to the forcing file
     real(dp) :: eps                    ! a tolerance to use for stepwise constant forcing
     logical :: retrieve_new_slice      ! if true, then retrieve data for this forcing time slice
+    integer :: forcing_year            ! year of data from the forcing file
+    integer :: this_year               ! current simulation year relative to tstart; starts at 0
+    integer :: year1, year2            ! years read from the shuffle file
+    real(dp) :: decimal_year           ! decimal part of the current year
+
     logical, parameter :: verbose_read_forcing = .false.
 
     ! Make eps a fraction of the time step
@@ -622,11 +627,43 @@ contains
 
           if (main_task .and. verbose_read_forcing) then
              print*, 'In NAME_retrieve_forcing, model time + eps =', model%numerics%time + eps
-             print*, 'Filename =', trim(ic%nc%filename)
+             print*, 'Filename = ', trim(ic%nc%filename)
              print*, 'Forcing file nt, time_offset =', ic%nt, ic%time_offset
              print*, 'time_start_cycle, nyear_cycle:', ic%time_start_cycle, ic%nyear_cycle
              print*, 'current forcing time =', current_forcing_time
           endif
+
+           ! Optionally, associate the current forcing time with a different date in the forcing file.
+           ! This is done by reading a file that associates each simulation year (relative to tstart)
+           !  with a year that is read from a 'shuffle file'. The shuffle file typically consists of
+           !  consecutive integers (in column 1), followed by years chosen at random from all the years
+           !  in the forcing file (in column 2).
+
+           if (trim(ic%shuffle_file) /= '') then  ! shuffle_file exists
+              open(unit=11, file=trim(ic%shuffle_file), status='old')
+              this_year = int(current_forcing_time - model%numerics%tstart)
+              if (main_task .and. verbose_read_forcing) then
+                 print*, 'shuffle_file = ', trim(ic%shuffle_file)
+                 print*, 'tstart, this_year =', model%numerics%tstart, this_year
+              endif
+              forcing_year = 0
+              do while (forcing_year == 0)
+                 read(11,'(i6,i8)') year1, year2
+                 if (this_year == year1) then
+                    forcing_year = year2
+                    exit
+                 endif
+              enddo
+              close(11)
+              decimal_year = current_forcing_time - floor(current_forcing_time)
+              current_forcing_time = real(forcing_year,dp) + decimal_year
+              if (main_task) then
+                 print*, 'forcing_year, decimal =', forcing_year, decimal_year
+                 print*, 'shuffled forcing_time =', current_forcing_time
+              endif
+           else
+              if (main_task .and. verbose_read_forcing) print*, 'no shuffle_file'
+           endif  ! shuffle_file exists
 
           ! Find the time index associated with the previous model time step
           t_prev = 0

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -523,7 +523,6 @@ contains
 
     use glimmer_global, only: msg_length
     use glimmer_log
-    use glide_types
     use cism_parallel, only: main_task, parallel_reduce_sum
 
     implicit none
@@ -606,9 +605,7 @@ contains
 
     use glimmer_global, only: msg_length
     use glimmer_log
-    use glide_types
     use cism_parallel, only: main_task
-
     implicit none
     type(DATATYPE) :: data
     type(glide_global_type), intent(inout) :: model

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -439,61 +439,67 @@ contains
 
 !       if (main_task .and. verbose_read_forcing) print *, 'possible forcing times', ic%times
 
-       ic%nc%just_processed = .true. ! until we find an acceptable time, set this to true which will prevent the file from being read.
+       if (.not.ic%read_once) then
 
-       ! Compute the current forcing time.
-       ! This is the current model time, plus any offset to be consistent with the time in the forcing file,
-       !  plus a small number to allow for roundoff error.
-       current_forcing_time = model%numerics%time + ic%time_offset + eps
+          ic%nc%just_processed = .true. ! until we find an acceptable time, set this to true which will prevent the file from being read.
 
-       ! If cycling repeatedly through a subset of the forcing data, make a further correction:
-       ! compute the current time relative to time_start_cycle.
-       if (ic%nyear_cycle > 0 .and. current_forcing_time > ic%time_start_cycle) then
-          current_forcing_time = ic%time_start_cycle &
-               + mod(current_forcing_time - ic%time_start_cycle, real(ic%nyear_cycle,dp))
-       endif
+          ! Compute the current forcing time.
+          ! This is the current model time, plus any offset to be consistent with the time in the forcing file,
+          !  plus a small number to allow for roundoff error.
+          current_forcing_time = model%numerics%time + ic%time_offset + eps
 
-       if (main_task .and. verbose_read_forcing) then
-          print*, 'In NAME_read_forcing, model time + eps =', model%numerics%time + eps
-          print*, 'Forcing file nt, time_offset =', ic%nt, ic%time_offset
-          print*, 'time_start_cycle, nyear_cycle:', ic%time_start_cycle, ic%nyear_cycle
-          print*, 'current forcing time =', current_forcing_time
-       endif
+          ! If cycling repeatedly through a subset of the forcing data, make a further correction:
+          ! compute the current time relative to time_start_cycle.
+          if (ic%nyear_cycle > 0 .and. current_forcing_time > ic%time_start_cycle) then
+             current_forcing_time = ic%time_start_cycle &
+                  + mod(current_forcing_time - ic%time_start_cycle, real(ic%nyear_cycle,dp))
+          endif
 
-       ! Find the time index associated with the previous model time step
-       t_prev = 0
-       do t = ic%nt, 1, -1  ! look through the time array backwards
-          if (ic%times(t) <= current_forcing_time - model%numerics%tinc) then
-             t_prev = t
-             if (main_task .and. verbose_read_forcing) print*, 'Previous time index =', t_prev
-             exit
-          end if
-       enddo
+          if (main_task .and. verbose_read_forcing) then
+             print*, ' '
+             print*, 'In NAME_read_forcing, model time + eps =', model%numerics%time + eps
+             print*, 'Forcing file nt, time_offset =', ic%nt, ic%time_offset
+             print*, 'time_start_cycle, nyear_cycle:', ic%time_start_cycle, ic%nyear_cycle
+             print*, 'current forcing time =', current_forcing_time
+          endif
 
-       ! Find the current time in the file
-       do t = ic%nt, 1, -1  ! look through the time array backwards
-          if ( ic%times(t) <= current_forcing_time) then
-             ! use the largest time that is smaller or equal to the current time (stepwise forcing)
-             if (main_task .and. verbose_read_forcing) &
-                  print*, 'Largest time less than current forcing time: t, times(t):', t, ic%times(t)
+          ! Find the time index associated with the previous model time step
+          t_prev = 0
+          do t = ic%nt, 1, -1  ! look through the time array backwards
+             if (ic%times(t) <= current_forcing_time - model%numerics%tinc) then
+                t_prev = t
+                if (main_task .and. verbose_read_forcing) print*, 'Previous time index =', t_prev
+                exit
+             end if
+          enddo
 
-             ! If this time index (t) is larger than the previous index (t_prev), then read a new time slice.
-             ! Otherwise, we already have the current slice, and there is nothing new to read.
-             if (t > t_prev) then
-                ! Set the desired time to be read
-                ic%current_time = t
-                ic%nc%just_processed = .false.  ! set this to false so file will be read.
-                if (main_task .and. verbose_read_forcing) print*, 'Read new forcing slice: t, times(t) =', t, ic%times(t)
-             endif ! t > t_prev
+          ! Find the current time in the file
+          do t = ic%nt, 1, -1  ! look through the time array backwards
+             if ( ic%times(t) <= current_forcing_time) then
+                ! use the largest time that is smaller or equal to the current time (stepwise forcing)
+                if (main_task .and. verbose_read_forcing) &
+                     print*, 'Largest time less than current forcing time: t, times(t):', t, ic%times(t)
 
-             exit  ! once we find the time, exit the loop
-          end if   ! ic%times(t) <= model%numerics%time + eps
+                ! If this time index (t) is larger than the previous index (t_prev), then read a new time slice.
+                ! Otherwise, we already have the current slice, and there is nothing new to read.
+                if (t > t_prev) then
+                   ! Set the desired time to be read
+                   ic%current_time = t
+                   ic%nc%just_processed = .false.  ! set this to false so file will be read.
+                   if (main_task .and. verbose_read_forcing) print*, 'Read new forcing slice: t, times(t) =', t, ic%times(t)
+                endif ! t > t_prev
 
-       end do  ! if we get to end of loop without exiting, then this file will not be read at this time
+                exit  ! once we find the time, exit the loop
+             end if   ! ic%times(t) <= model%numerics%time + eps
+
+          end do  ! if we get to end of loop without exiting, then this file will not be read at this time
+
+       endif  ! not a read_once file
 
        ! move on to the next forcing file
        ic=>ic%next
-    end do
+
+    end do   ! while(associated)
 
     ! Now that we've updated metadata for each forcing file, actually perform the read.
     ! This call will only read forcing files where just_processed=.false.
@@ -504,11 +510,11 @@ contains
 
   subroutine NAME_read_forcing_once(data, model)
 
-    ! Read data from forcing files
+    ! Read data from forcing files with read_once = .true.
     ! Read all time slices in a single call and write to arrays with a time index
     use glimmer_log
     use glide_types
-    use cism_parallel, only: main_task
+    use cism_parallel, only: main_task, parallel_reduce_sum
 
     implicit none
     type(DATATYPE) :: data
@@ -519,6 +525,7 @@ contains
     integer :: t                         ! time index
     integer :: nx, ny, nt                ! dimension sizes
     real(dp) :: eps                      ! a tolerance to use for stepwise constant forcing
+    real(dp) :: global_sum               ! global sum of an input field
     logical, parameter :: verbose_read_forcing = .false.
 
     ! Make eps a fraction of the time step.
@@ -538,12 +545,12 @@ contains
           endif
 
           nt = ic%nt
+          ic%nc%vars = ''
 
           ! Allocate 3D arrays that contain all time slices for each 2D field
           ! Note: Variables with the 'read_once' attribute must be 2D
 
           !GENVAR_READ_ONCE_ALLOCATE!
-
           ! Loop over all time slices in the file
           do t = 1, ic%nt
 
@@ -557,12 +564,19 @@ contains
              ! Read one time slice into the data derived type
              call NAME_io_read(ic,data)
 
-             ! Copy data from this time slice into the 3D array
-             !GENVAR_READ_ONCE_FILL!
+             ! Copy data from this time slice into the 3D array.
+             ! Once the fields have been copied, zero them out.
+             ! Also increment the string ic%nc%vars.
+             ! This string contains a list of field names with a space before and after each name.
 
+             !GENVAR_READ_ONCE_COPY!
           enddo   ! ic%nt
 
        endif  ! read_once
+
+       if (main_task .and. verbose_read_forcing) then
+          print*, 'Final ic%nc%vars = ', trim(ic%nc%vars)
+       endif
 
        ic=>ic%next
 
@@ -594,7 +608,6 @@ contains
     integer :: this_year               ! current simulation year relative to tstart; starts at 0
     integer :: year1, year2            ! years read from the shuffle file
     real(dp) :: decimal_year           ! decimal part of the current year
-
     logical, parameter :: verbose_read_forcing = .false.
 
     ! Make eps a fraction of the time step
@@ -614,8 +627,6 @@ contains
           !  plus a small number to allow for roundoff error.
           ! Code adapted from the read_forcing subroutine above
 
-          !TODO - Add code to deal with shuffled years of forcing data
-
           current_forcing_time = model%numerics%time + ic%time_offset + eps
 
           ! If cycling repeatedly through a subset of the forcing data, make a further correction:
@@ -626,11 +637,13 @@ contains
           endif
 
           if (main_task .and. verbose_read_forcing) then
+             print*, ' '
              print*, 'In NAME_retrieve_forcing, model time + eps =', model%numerics%time + eps
              print*, 'Filename = ', trim(ic%nc%filename)
              print*, 'Forcing file nt, time_offset =', ic%nt, ic%time_offset
              print*, 'time_start_cycle, nyear_cycle:', ic%time_start_cycle, ic%nyear_cycle
              print*, 'current forcing time =', current_forcing_time
+             print*, 'variable list:', trim(ic%nc%vars)
           endif
 
            ! Optionally, associate the current forcing time with a different date in the forcing file.
@@ -657,7 +670,7 @@ contains
               close(11)
               decimal_year = current_forcing_time - floor(current_forcing_time)
               current_forcing_time = real(forcing_year,dp) + decimal_year
-              if (main_task) then
+              if (main_task .and. verbose_read_forcing) then
                  print*, 'forcing_year, decimal =', forcing_year, decimal_year
                  print*, 'shuffled forcing_time =', current_forcing_time
               endif
@@ -695,11 +708,13 @@ contains
 
           end do  ! if we get to end of loop without exiting, then there is nothing to retrieve at this time
 
-          ! Copy the data for this time slice from the 3D arrays to the 2D arrays
+          ! Check whether each potential read_once field is part of this forcing file.
+          ! If so, then copy the data for this time slice from the 3D array to the 2D array.
 
           if (retrieve_new_slice) then
+
              !GENVAR_READ_ONCE_RETRIEVE!
-          endif
+          endif   ! retrieve_new_slice
 
        endif   ! read_once
 

--- a/libglimmer/ncdf_template.F90.in
+++ b/libglimmer/ncdf_template.F90.in
@@ -431,7 +431,7 @@ contains
     logical, parameter :: verbose_read_forcing = .false.
 
     ! Make eps a fraction of the time step.
-    eps = model%numerics%tinc * 1.0d-4
+    eps = model%numerics%tinc * 1.0d-3
 
     ! read forcing files
     ic=>model%funits%frc_first
@@ -454,7 +454,7 @@ contains
        endif
 
        if (main_task .and. verbose_read_forcing) then
-          print*, 'In glide_read_forcing, model time + eps =', model%numerics%time + eps
+          print*, 'In NAME_read_forcing, model time + eps =', model%numerics%time + eps
           print*, 'Forcing file nt, time_offset =', ic%nt, ic%time_offset
           print*, 'time_start_cycle, nyear_cycle:', ic%time_start_cycle, ic%nyear_cycle
           print*, 'current forcing time =', current_forcing_time
@@ -502,7 +502,176 @@ contains
   end subroutine NAME_read_forcing
 
 
-!------------------------------------------------------------------------------
+  subroutine NAME_read_forcing_once(data, model)
+
+    ! Read data from forcing files
+    ! Read all time slices in a single call and write to arrays with a time index
+    use glimmer_log
+    use glide_types
+    use cism_parallel, only: main_task
+
+    implicit none
+    type(DATATYPE) :: data
+    type(glide_global_type), intent(inout) :: model
+
+    ! Locals
+    type(glimmer_nc_input), pointer :: ic
+    integer :: t                         ! time index
+    integer :: nx, ny, nt                ! dimension sizes
+    real(dp) :: eps                      ! a tolerance to use for stepwise constant forcing
+    logical, parameter :: verbose_read_forcing = .false.
+
+    ! Make eps a fraction of the time step.
+    eps = model%numerics%tinc * 1.0d-3
+
+    ! read forcing files
+    ic=>model%funits%frc_first
+    do while(associated(ic))
+
+       if (ic%read_once) then
+
+          if (main_task .and. verbose_read_forcing) then
+             print*, ' '
+             print*, 'In NAME_read_forcing_once'
+             print*, 'Filename =', trim(ic%nc%filename)
+             print*, 'Number of slices =', ic%nt
+          endif
+
+          nt = ic%nt
+
+          ! Allocate 3D arrays that contain all time slices for each 2D field
+          ! Note: Variables with the 'read_once' attribute must be 2D
+
+          !GENVAR_READ_ONCE_ALLOCATE!
+
+          ! Loop over all time slices in the file
+          do t = 1, ic%nt
+
+             if (main_task .and. verbose_read_forcing) then
+                print*, 'Read new forcing slice: t index, times(t) =', t, ic%times(t)
+             endif
+
+             ! Set the desired time to be read
+             ic%current_time = t
+
+             ! Read one time slice into the data derived type
+             call NAME_io_read(ic,data)
+
+             ! Copy data from this time slice into the 3D array
+             !GENVAR_READ_ONCE_FILL!
+
+          enddo   ! ic%nt
+
+       endif  ! read_once
+
+       ic=>ic%next
+
+    enddo   ! while(associated)
+
+  end subroutine NAME_read_forcing_once
+
+
+  subroutine NAME_retrieve_forcing(data, model)
+
+    ! Retrieve a single time slice of forcing from arrays that contain all the forcing.
+    ! Called repeatedly at runtime, after calling the read_forcing_once subroutine at initialization.
+
+    use glimmer_log
+    use glide_types
+    use cism_parallel, only: main_task
+
+    implicit none
+    type(DATATYPE) :: data
+    type(glide_global_type), intent(inout) :: model
+
+    ! Locals
+    type(glimmer_nc_input), pointer :: ic
+    integer :: t, t_prev
+    real(dp) :: current_forcing_time   ! current time with reference to the forcing file
+    real(dp) :: eps                    ! a tolerance to use for stepwise constant forcing
+    logical :: retrieve_new_slice      ! if true, then retrieve data for this forcing time slice
+    logical, parameter :: verbose_read_forcing = .false.
+
+    ! Make eps a fraction of the time step
+    eps = model%numerics%tinc * 1.0d-3
+
+    ! read forcing files
+
+    ic=>model%funits%frc_first
+    do while(associated(ic))
+
+       if (ic%read_once) then
+
+          retrieve_new_slice = .false.   ! default is to do nothing
+
+          ! Compute the current forcing time.
+          ! This is the current model time, plus any offset to be consistent with the time in the forcing file,
+          !  plus a small number to allow for roundoff error.
+          ! Code adapted from the read_forcing subroutine above
+
+          !TODO - Add code to deal with shuffled years of forcing data
+
+          current_forcing_time = model%numerics%time + ic%time_offset + eps
+
+          ! If cycling repeatedly through a subset of the forcing data, make a further correction:
+          ! compute the current time relative to time_start_cycle.
+          if (ic%nyear_cycle > 0 .and. current_forcing_time > ic%time_start_cycle) then
+             current_forcing_time = ic%time_start_cycle &
+                  + mod(current_forcing_time - ic%time_start_cycle, real(ic%nyear_cycle,dp))
+          endif
+
+          if (main_task .and. verbose_read_forcing) then
+             print*, 'In NAME_retrieve_forcing, model time + eps =', model%numerics%time + eps
+             print*, 'Filename =', trim(ic%nc%filename)
+             print*, 'Forcing file nt, time_offset =', ic%nt, ic%time_offset
+             print*, 'time_start_cycle, nyear_cycle:', ic%time_start_cycle, ic%nyear_cycle
+             print*, 'current forcing time =', current_forcing_time
+          endif
+
+          ! Find the time index associated with the previous model time step
+          t_prev = 0
+          do t = ic%nt, 1, -1  ! look through the time array backwards
+             if (ic%times(t) <= current_forcing_time - model%numerics%tinc) then
+                t_prev = t
+                if (main_task .and. verbose_read_forcing) print*, 'Previous time index =', t_prev
+                exit
+             end if
+          enddo
+
+          ! Find the current time in the file
+          do t = ic%nt, 1, -1  ! look through the time array backwards
+             if ( ic%times(t) <= current_forcing_time) then
+                ! use the largest time that is smaller or equal to the current time (stepwise forcing)
+                if (main_task .and. verbose_read_forcing) &
+                     print*, 'Largest time less than current forcing time: t, times(t):', t, ic%times(t)
+                ! If this time index (t) is larger than the previous index (t_prev), then retrieve a new time slice.
+                ! Otherwise, we already have the current slice, and there is nothing new to read.
+                if (t > t_prev) then
+                   ! Set the desired time to be read
+                   ic%current_time = t
+                   retrieve_new_slice = .true.
+                   if (main_task .and. verbose_read_forcing) print*, 'Retrieve new forcing slice'
+                endif ! t > t_prev
+
+                exit  ! once we find the time, exit the loop
+             end if   ! ic%times(t) <= model%numerics%time + eps
+
+          end do  ! if we get to end of loop without exiting, then there is nothing to retrieve at this time
+
+          ! Copy the data for this time slice from the 3D arrays to the 2D arrays
+
+          if (retrieve_new_slice) then
+             !GENVAR_READ_ONCE_RETRIEVE!
+          endif
+
+       endif   ! read_once
+
+       ! move on to the next forcing file
+       ic=>ic%next
+
+    enddo   ! while(associated)
+
+  end subroutine NAME_retrieve_forcing
 
 
   subroutine NAME_io_read(infile,data)

--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -335,6 +335,7 @@ module cism_parallel
 
   interface parallel_put_var
      module procedure parallel_put_var_integer
+     module procedure parallel_put_var_integer_1d
      module procedure parallel_put_var_real4
      module procedure parallel_put_var_real8
      module procedure parallel_put_var_real8_1d
@@ -7856,6 +7857,26 @@ contains
     call broadcast(parallel_put_var_integer)
 
   end function parallel_put_var_integer
+
+
+  function parallel_put_var_integer_1d(ncid, varid, values, start)
+
+    implicit none
+    integer :: ncid,parallel_put_var_integer_1d,varid
+    integer,dimension(:) :: values
+    integer,dimension(:),optional :: start
+
+    ! begin
+    if (main_task) then
+       if (present(start)) then
+          parallel_put_var_integer_1d = nf90_put_var(ncid,varid,values,start)
+       else
+          parallel_put_var_integer_1d = nf90_put_var(ncid,varid,values)
+       endif
+    endif
+    call broadcast(parallel_put_var_integer_1d)
+
+  end function parallel_put_var_integer_1d
 
 
   function parallel_put_var_real4(ncid, varid, values, start)

--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -694,6 +694,7 @@ contains
        allocate(recvcounts(1))
        allocate(recvbuf(1))
     end if
+
     allocate(sendbuf(d_gs_mybounds(1):d_gs_mybounds(2),&
                      d_gs_mybounds(3):d_gs_mybounds(4)))
     sendbuf(:,:) = values(1+lhalo:local_ewn-uhalo,1+lhalo:local_nsn-uhalo)
@@ -4223,6 +4224,8 @@ contains
     ! values = local portion of distributed variable
     ! global_values = reference to allocateable array into which the main_task holds the variable.
     ! global_values is deallocated at the end.
+    ! This subroutine expects global_values to be allocated on all tasks.
+    ! It can be allocated with zero size on tasks other than main_task.
     use mpi_mod
     implicit none
     integer,dimension(:,:),intent(inout) :: values  ! populated from values on main_task
@@ -4268,7 +4271,6 @@ contains
     call fc_gather_int(d_gs_mybounds,4,mpi_integer,d_gs_bounds,4,&
          mpi_integer,main_rank,comm)
 
-
     if (main_task) then
        allocate(displs(tasks+1))
        allocate(sendcounts(tasks))
@@ -4279,7 +4281,6 @@ contains
           displs(i+1) = displs(i)+sendcounts(i)
        end do
        allocate(sendbuf(displs(tasks+1)))
-
        do i = 1,tasks
           sendbuf(displs(i)+1:displs(i+1)) = &
              reshape(global_values(d_gs_bounds(1,i):d_gs_bounds(2,i),&
@@ -4291,6 +4292,7 @@ contains
        allocate(sendcounts(1))
        allocate(sendbuf(1))
     end if
+
     allocate(recvbuf(d_gs_mybounds(1):d_gs_mybounds(2),&
                      d_gs_mybounds(3):d_gs_mybounds(4)))
     call mpi_scatterv(sendbuf,sendcounts,displs,mpi_integer,&
@@ -4310,6 +4312,8 @@ contains
     ! values = local portion of distributed variable
     ! global_values = reference to allocateable array into which the main_task holds the variable.
     ! global_values is deallocated at the end.
+    ! This subroutine expects global_values to be allocated on all tasks.
+    ! It can be allocated with zero size on tasks other than main_task.
     use mpi_mod
     implicit none
     logical,dimension(:,:),intent(inout) :: values  ! populated from values on main_task
@@ -4396,6 +4400,8 @@ contains
     ! values = local portion of distributed variable
     ! global_values = reference to allocateable array into which the main_task holds the variable.
     ! global_values is deallocated at the end.
+    ! This subroutine expects global_values to be allocated on all tasks.
+    ! It can be allocated with zero size on tasks other than main_task.
     use mpi_mod
     implicit none
     real(sp),dimension(:,:),intent(inout) :: values  ! populated from values on main_task
@@ -4482,6 +4488,8 @@ contains
     ! values = local portion of distributed variable
     ! global_values = reference to allocateable array into which the main_task holds the variable.
     ! global_values is deallocated at the end.
+    ! This subroutine expects global_values to be allocated on all tasks.
+    ! It can be allocated with zero size on tasks other than main_task.
     use mpi_mod
     implicit none
     real(sp),dimension(:,:,:),intent(inout) :: values  ! populated from values on main_task
@@ -4570,6 +4578,8 @@ contains
     ! values = local portion of distributed variable
     ! global_values = reference to allocateable array into which the main_task holds the variable.
     ! global_values is deallocated at the end.
+    ! This subroutine expects global_values to be allocated on all tasks.
+    ! It can be allocated with zero size on tasks other than main_task.
     use mpi_mod
     implicit none
     real(dp),dimension(:,:),intent(inout) :: values  ! populated from values on main_task
@@ -4656,6 +4666,8 @@ contains
     ! values = local portion of distributed variable
     ! global_values = reference to allocateable array into which the main_task holds the variable.
     ! global_values is deallocated at the end.
+    ! This subroutine expects global_values to be allocated on all tasks.
+    ! It can be allocated with zero size on tasks other than main_task.
     use mpi_mod
     implicit none
     real(dp),dimension(:,:,:),intent(inout) :: values  ! populated from values on main_task
@@ -9567,7 +9579,7 @@ contains
          gather_block_size = min(max(1,flow_cntl),max_gather_block_size)
          fc_gather = .true.
       else
-        fc_gather = .false.
+         fc_gather = .false.
       endif
    else
       gather_block_size = max(1,max_gather_block_size)
@@ -9623,7 +9635,7 @@ contains
                             comm, ier )
          end if
 
-     endif
+      endif
 
    else
  

--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -345,6 +345,7 @@ module cism_parallel
      module procedure parallel_reduce_max_integer
      module procedure parallel_reduce_max_real4
      module procedure parallel_reduce_max_real8
+     module procedure parallel_reduce_max_real8_1d
   end interface
 
   ! This reduce interface determines the global max value and the processor on which it occurs
@@ -358,6 +359,7 @@ module cism_parallel
      module procedure parallel_reduce_min_integer
      module procedure parallel_reduce_min_real4
      module procedure parallel_reduce_min_real8
+     module procedure parallel_reduce_min_real8_1d
   end interface
 
   ! This reduce interface determines the global min value and the processor on which it occurs
@@ -8095,6 +8097,22 @@ contains
 
   end function parallel_reduce_max_real8
 
+  function parallel_reduce_max_real8_1d(x)
+
+    use mpi_mod
+    implicit none
+    real(dp), dimension(:) :: x
+
+    integer :: ierror
+    real(dp), dimension(size(x)) :: recvbuf,sendbuf, parallel_reduce_max_real8_1d
+
+    ! begin
+    sendbuf = x
+    call mpi_allreduce(sendbuf,recvbuf,size(x),mpi_real8,mpi_max,comm,ierror)
+    parallel_reduce_max_real8_1d = recvbuf
+
+  end function parallel_reduce_max_real8_1d
+
 !=======================================================================
 
   ! functions belonging to the parallel_reduce_maxloc interface
@@ -8215,6 +8233,23 @@ contains
     parallel_reduce_min_real8 = recvbuf
 
   end function parallel_reduce_min_real8
+
+
+  function parallel_reduce_min_real8_1d(x)
+
+    use mpi_mod
+    implicit none
+    real(dp), dimension(:) :: x
+
+    integer :: ierror
+    real(dp), dimension(size(x)) :: recvbuf,sendbuf, parallel_reduce_min_real8_1d
+
+    ! begin
+    sendbuf = x
+    call mpi_allreduce(sendbuf,recvbuf,size(x),mpi_real8,mpi_min,comm,ierror)
+    parallel_reduce_min_real8_1d = recvbuf
+
+  end function parallel_reduce_min_real8_1d
 
 !=======================================================================
 

--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -2723,7 +2723,7 @@ contains
     integer, dimension(:), allocatable ::  &
          task_to_block                ! block associated with each task
 
-    logical, parameter :: verbose_active_blocks = .true.
+    logical :: verbose_active_blocks = .false.
 
     associate(  &
          periodic_bc => parallel%periodic_bc,  &
@@ -2765,6 +2765,7 @@ contains
 
     if (present(inquire_only)) then
        only_inquire = inquire_only
+       if (only_inquire) verbose_active_blocks = .true.
     else
        only_inquire = .false.
     endif

--- a/libglimmer/parallel_slap.F90
+++ b/libglimmer/parallel_slap.F90
@@ -302,6 +302,7 @@ module cism_parallel
 
   interface parallel_put_var
      module procedure parallel_put_var_integer
+     module procedure parallel_put_var_integer_1d
      module procedure parallel_put_var_real4
      module procedure parallel_put_var_real8
      module procedure parallel_put_var_real8_1d
@@ -3637,7 +3638,7 @@ contains
 
     implicit none
     integer :: ncid,parallel_put_var_integer,varid
-    integer,dimension(:) :: start
+    integer,dimension(:),optional :: start
     integer :: values
 
     ! begin
@@ -3648,11 +3649,31 @@ contains
   end function parallel_put_var_integer
 
 
+  function parallel_put_var_integer_1d(ncid, varid, values, start)
+
+    implicit none
+    integer :: ncid,parallel_put_var_integer_1d,varid
+    integer,dimension(:),optional :: start
+    integer,dimension(:) :: values
+
+    ! begin
+    if (main_task) then
+       if (present(start)) then
+          parallel_put_var_integer_1d = nf90_put_var(ncid,varid,values,start)
+       else
+          parallel_put_var_integer_1d = nf90_put_var(ncid,varid,values)
+       end if
+    end if
+    call broadcast(parallel_put_var_integer_1d)
+
+  end function parallel_put_var_integer_1d
+
+
   function parallel_put_var_real4(ncid, varid, values, start)
 
     implicit none
     integer :: ncid,parallel_put_var_real4,varid
-    integer,dimension(:) :: start
+    integer,dimension(:),optional :: start
     real(sp) :: values
 
     ! begin
@@ -3667,7 +3688,7 @@ contains
 
     implicit none
     integer :: ncid,parallel_put_var_real8,varid
-    integer,dimension(:) :: start
+    integer,dimension(:),optional :: start
     real(dp) :: values
 
     ! begin

--- a/libglimmer/parallel_slap.F90
+++ b/libglimmer/parallel_slap.F90
@@ -312,6 +312,7 @@ module cism_parallel
      module procedure parallel_reduce_max_integer
      module procedure parallel_reduce_max_real4
      module procedure parallel_reduce_max_real8
+     module procedure parallel_reduce_max_real8_1d
   end interface
 
   ! This reduce interface determines the global min value and the processor on which it occurs
@@ -325,6 +326,7 @@ module cism_parallel
      module procedure parallel_reduce_min_integer
      module procedure parallel_reduce_min_real4
      module procedure parallel_reduce_min_real8
+     module procedure parallel_reduce_min_real8_1d
   end interface
 
   ! This reduce interface determines the global min value and the processor on which it occurs
@@ -3770,6 +3772,19 @@ contains
 
   end function parallel_reduce_max_real8
 
+
+  function parallel_reduce_max_real8_1d(x)
+
+    ! Max x across all of the nodes.
+    ! In parallel_slap mode just return x.
+    implicit none
+    real(dp), dimension(:) :: x
+    real(dp), dimension(size(x)) :: parallel_reduce_max_real8_1d
+
+    parallel_reduce_max_real8_1d = x
+
+  end function parallel_reduce_max_real8_1d
+
 !=======================================================================
 
   ! subroutines belonging to the parallel_reduce_maxloc interface
@@ -3856,6 +3871,19 @@ contains
     parallel_reduce_min_real8 = x
 
   end function parallel_reduce_min_real8
+
+  
+  function parallel_reduce_min_real8_1d(x)
+
+    ! Min x across all of the nodes.
+    ! In parallel_slap mode just return x.
+    implicit none
+    real(dp), dimension(:) :: x
+    real(dp), dimension(size(x)) :: parallel_reduce_min_real8_1d
+
+    parallel_reduce_min_real8_1d = x
+
+  end function parallel_reduce_min_real8_1d
 
 !=======================================================================
 

--- a/libglint/glint_initialise.F90
+++ b/libglint/glint_initialise.F90
@@ -559,6 +559,7 @@ contains
     use glide
     use glide_stop, only : glide_finalise
     use glimmer_ncio
+    use glide_stop, only : glide_finalise
     implicit none
     type(glint_instance),  intent(inout) :: instance    !> The instance being initialised.
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2516,7 +2516,7 @@ contains
           !        a suite of automated stability tests, e.g. with the stabilitySlab.py script.
           if (advective_cfl > 1.0d0) then
              if (main_task) print*, 'advective CFL violation; call glide_finalise and exit cleanly'
-             call glide_finalise(model, crash=.true.)
+             call glide_finalise(model)
              stop
           else
              nsubcyc = model%numerics%subcyc

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1862,6 +1862,7 @@ contains
 
     !WHL - debug
     use cism_parallel, only: parallel_reduce_max
+    use glissade_glacier, only : verbose_glacier
 
     implicit none
 
@@ -1941,13 +1942,14 @@ contains
     ! (0) artm(x,y); no dependence on surface elevation
     ! (1) artm(x,y) + d(artm)/dz(x,y) * dz; artm depends on input field at reference elevation, plus vertical correction
     ! (2) artm(x,y,z); artm obtained by linear interpolation between values prescribed at adjacent vertical levels
-    ! For options (1) and (2), the elevation-dependent artm is computed here.
+    ! (3) artm(x,y) adjusted with a uniform lapse rate
+    ! For options (1) - (3), the elevation-dependent artm is computed here.
 
     if (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_GRADZ) then
 
        ! compute artm by a lapse-rate correction to the reference value
        model%climate%artm(:,:) = model%climate%artm_ref(:,:) + &
-            (model%geometry%usrf(:,:) - model%climate%smb_reference_usrf(:,:)) * model%climate%artm_gradz(:,:)
+            (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref(:,:)) * model%climate%artm_gradz(:,:)
 
     elseif (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XYZ) then
 
@@ -1964,7 +1966,22 @@ contains
                                           model%climate%artm,                                &
                                           linear_extrapolate_in = .true.)
 
-       call parallel_halo(model%climate%artm, parallel)
+    elseif (model%options%artm_input_function == ARTM_INPUT_FUNCTION_XY_LAPSE) then
+
+       ! compute artm by a lapse-rate correction to artm_ref
+       ! T_lapse is defined as positive for T decreasing with height
+       ! Note: This option is currently used for glaciers lapse rate adjustments
+
+       model%climate%artm(:,:) = model%climate%artm_ref(:,:) - &
+            (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref(:,:)) * model%climate%t_lapse
+       if (verbose_glacier .and. this_rank == rtest) then
+          i = itest; j = jtest
+          print*, ' '
+          print*, 'rank, i, j, usrf, usrf_ref, dz:', this_rank, i, j, &
+               model%geometry%usrf(i,j)*thk0, model%climate%usrf_ref(i,j), &
+               model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref(i,j)
+          print*, '   artm_ref, artm:', model%climate%artm_ref(i,j), model%climate%artm(i,j)
+       endif
 
     endif   ! artm_input_function
 
@@ -2572,7 +2589,7 @@ contains
 
           ! compute acab by a lapse-rate correction to the reference value
           model%climate%acab(:,:) = model%climate%acab_ref(:,:) + &
-               (model%geometry%usrf(:,:) - model%climate%smb_reference_usrf(:,:)) * model%climate%acab_gradz(:,:)
+               (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref(:,:)) * model%climate%acab_gradz(:,:)
 
        elseif (model%options%smb_input_function == SMB_INPUT_FUNCTION_XYZ) then
 
@@ -2628,12 +2645,12 @@ contains
 
           if (model%options%smb_input_function == SMB_INPUT_FUNCTION_XY_GRADZ) then
              write(6,*) ' '
-             write(6,*) 'usrf - smb_ref_elevation'
+             write(6,*) 'usrf - usrf_ref'
              do j = jtest+3, jtest-3, -1
                 write(6,'(i6)',advance='no') j
                 do i = itest-3, itest+3
                    write(6,'(f10.3)',advance='no') &
-                        (model%geometry%usrf(i,j) - model%climate%smb_reference_usrf(i,j)) * thk0
+                        (model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref(i,j))
                 enddo
                 write(6,*) ' '
              enddo
@@ -2760,17 +2777,17 @@ contains
 
           ! Halo updates for snow and artm
           ! (Not sure the artm update is needed; there is one above)
-          call parallel_halo(model%climate%artm, parallel)
           call parallel_halo(model%climate%snow, parallel)
+          call parallel_halo(model%climate%artm, parallel)
 
           call glissade_glacier_smb(&
                ewn,      nsn,                          &
                itest,    jtest,    rtest,              &
                model%glacier%nglacier,                 &
                model%glacier%cism_glacier_id,          &
+               model%glacier%t_mlt,                    &  ! deg C
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%artm,                     &  ! deg C
-               model%glacier%tmlt,                     &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
                model%climate%smb)                         ! mm/yr w.e.
 
@@ -4006,7 +4023,7 @@ contains
          glissade_inversion_bmlt_basin, glissade_inversion_deltaT_ocn, &
          glissade_inversion_flow_enhancement_factor, &
          usrf_to_thck
-    use glissade_glacier, only: verbose_glacier, glissade_glacier_inversion
+    use glissade_glacier, only: glissade_glacier_inversion
 
     implicit none
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -368,6 +368,8 @@ contains
        if (global_maxval < eps11) then
           call write_log('Failed to read longitude (lon) field from input file', GM_FATAL)
        endif
+       call parallel_halo(model%general%lat, parallel)
+       call parallel_halo(model%general%lon, parallel)
     endif
 
     ! Some input fields may have a netCDF fill value, typically a very large positive number.

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -668,10 +668,6 @@ contains
           endif
        endif
 
-       call glissade_add_2d_anomaly(model%climate%artm_corrected,          &   ! degC
-                                    model%climate%artm_anomaly,            &   ! degC
-                                    model%climate%artm_anomaly_timescale,  &   ! yr
-                                    model%numerics%time)                       ! yr
     endif
 
     ! Initialize the temperature profile in each column
@@ -1989,23 +1985,6 @@ contains
 !               model%climate%usrf_ref(i,j), model%geometry%usrf(i,j)*thk0, &
 !               model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref(i,j)
 !          print*, '   artm_ref, artm:', model%climate%artm_ref(i,j), model%climate%artm(i,j)
-       endif
-
-       ! optionally, do the same for an auxiliary field, artm_aux
-       ! Currently used only for 2-parameter glacier inversion
-
-       if (associated(model%climate%artm_aux)) then  ! artm_ref_aux and usrf_ref_aux should also be associated
-          model%climate%artm_aux(:,:) = model%climate%artm_ref_aux(:,:) - &
-               (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref_aux(:,:)) * model%climate%t_lapse
-          if (verbose_glacier .and. this_rank == rtest) then
-             i = itest; j = jtest
-!             print*, ' '
-!             print*, 'rank, i, j, usrf_ref_aux, usrf, dz:', this_rank, i, j, &
-!                  model%climate%usrf_ref_aux(i,j), model%geometry%usrf(i,j)*thk0, &
-!                  model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref_aux(i,j)
-!             print*, '   artm_ref_aux, artm_aux:', model%climate%artm_ref_aux(i,j), &
-!                  model%climate%artm_aux(i,j)
-          endif
        endif
 
     endif   ! artm_input_function

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -3044,14 +3044,17 @@ contains
 
        !-------------------------------------------------------------------------
        ! If running with glaciers, then adjust glacier indices based on advance and retreat.
+       ! Call once per year.
        ! Note: This subroutine limits the ice thickness in grid cells that do not yet have
-       !       a nonzero cism_glacier_id.  The acab_applied field is adjusted accordingly.
-       ! Note: It would probably be OK to call this subroutine annually instead of every step.
-       !       In that case, we might want to separate the special glacier acab adjustment
-       !       from the rest of acab_applied.
+       !       a nonzero cism_glacier_id.  The acab_applied field is adjusted accordingly,
+       !       which means that acab_applied will be more negative during timesteps
+       !       when this subroutine is called.
+       ! TODO: To make acab_applied more uniform on subannual time scales, create a new flux
+       !       (e.g., correction_flux) for artificial thickness changes, distinct from SMB, BMB and calving.
        !-------------------------------------------------------------------------
 
-       if (model%options%enable_glaciers) then
+       if (model%options%enable_glaciers .and. &
+          mod(model%numerics%tstep_count, model%numerics%nsteps_per_year) == 0) then
 
           call glissade_glacier_advance_retreat(&
                ewn,             nsn,                &
@@ -3066,9 +3069,6 @@ contains
                parallel)
 
        endif   ! enable_glaciers
-
-       !WHL - debug
-       call parallel_halo(thck_unscaled, parallel)
 
        !-------------------------------------------------------------------------
        ! Cleanup

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -4493,23 +4493,19 @@ contains
     endif   ! which_ho_flow_enhancement_factor
 
 
-    ! If glaciers are enabled, invert for mu_star and powerlaw_c based on area and volume targets
+    ! If glaciers are enabled, invert for mu_star and powerlaw_c.
+    ! Note: If reading mu_star and powerlaw_c from external files, the subroutine is called
+    !       for diagnostics only.
 
-    if (model%options%enable_glaciers .and. &
-         (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION .or.  &
-          model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION)) then
+    if (model%options%enable_glaciers) then
 
        if (model%numerics%time == model%numerics%tstart) then
-
-           ! first call at start-up or after a restart; do not invert
-
+           ! first call at start-up or after a restart; do nothing
        else
-
           call glissade_glacier_inversion(model, model%glacier)
-
        endif   ! time = tstart
 
-    endif   ! enable_glaciers with inversion
+    endif   ! enable_glaciers
 
     ! ------------------------------------------------------------------------ 
     ! Calculate Glen's A

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2297,8 +2297,8 @@ contains
     real(dp) :: local_maxval, global_maxval
     character(len=100) :: message
 
-!!    logical, parameter :: verbose_smb = .false.
-    logical, parameter :: verbose_smb = .true.
+    logical, parameter :: verbose_smb = .false.
+!!    logical, parameter :: verbose_smb = .true.
 
     rtest = -999
     itest = 1

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1998,7 +1998,7 @@ contains
     ! Optionally, add an anomaly to the surface air temperature
     ! Typically, artm_corrected = artm, but sometimes (e.g., for ISMIP6 forcing experiments),
     !  it includes a time-dependent anomaly.
-    ! Note that artm itself does not change in time, unless it is elevation-dependent..
+    ! Note that artm itself does not change in time, unless it is elevation-dependent.
 
     ! initialize
     model%climate%artm_corrected(:,:) = model%climate%artm(:,:)
@@ -2814,12 +2814,19 @@ contains
 
        if (model%options%enable_glaciers) then
 
+          !TODO - Pass artm instead of artm_corrected?  I.e., disable the anomaly for glaciers?
           ! Halo updates for snow and artm
           ! Note: artm_corrected is the input artm, possible corrected to include an anomaly term.
           !       delta_artm is a glacier-specific correction whose purpose is to give SMB ~ 0.
           !        This term is zero by default, but is nonzero during spin-up when inverting for powerlaw_c.
+          ! Note: snow_calc is the snow calculation option:  Either use the snowfall rate directly,
+          !       or compute the snowfall rate from the precip rate and downscaled artm.
 
-          call parallel_halo(model%climate%snow, parallel)
+          if (model%glacier%snow_calc == GLACIER_SNOW_CALC_SNOW) then
+             call parallel_halo(model%climate%snow, parallel)
+          elseif (model%glacier%snow_calc == GLACIER_SNOW_CALC_PRECIP_ARTM) then
+             call parallel_halo(model%climate%precip, parallel)
+          endif
           call parallel_halo(model%climate%artm_corrected, parallel)
 
           call glissade_glacier_smb(&
@@ -2828,7 +2835,11 @@ contains
                model%glacier%nglacier,                 &
                model%glacier%cism_glacier_id,          &
                model%glacier%t_mlt,                    &  ! deg C
+               model%glacier%snow_threshold_min,       &  ! deg C
+               model%glacier%snow_threshold_max,       &  ! deg C
+               model%glacier%snow_calc,                &
                model%climate%snow,                     &  ! mm/yr w.e.
+               model%climate%precip,                   &  ! mm/yr w.e.
                model%climate%artm_corrected,           &  ! deg C
                model%glacier%delta_artm,               &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2238,8 +2238,7 @@ contains
     use glissade_bmlt_float, only: verbose_bmlt_float
     use glissade_calving, only: verbose_calving
     use glissade_grid_operators, only: glissade_vertical_interpolate
-    use glissade_glacier, only: verbose_glacier, glissade_glacier_smb, &
-                                glissade_glacier_advance_retreat
+    use glissade_glacier, only: verbose_glacier, glissade_glacier_smb
     use glide_stop, only: glide_finalise
 
     implicit none
@@ -2848,20 +2847,17 @@ contains
                ewn,      nsn,                          &
                itest,    jtest,    rtest,              &
                model%glacier%nglacier,                 &
-               model%glacier%cism_glacier_id_init,     &
-               model%glacier%cism_glacier_id,          &
-               model%glacier%t_mlt,                    &  ! deg C
+               model%glacier%smb_glacier_id,           &
+               model%glacier%snow_calc,                &
                model%glacier%snow_threshold_min,       &  ! deg C
                model%glacier%snow_threshold_max,       &  ! deg C
-               model%glacier%snow_reduction_factor,    &
-               model%glacier%snow_calc,                &
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%precip,                   &  ! mm/yr w.e.
                model%climate%artm_corrected,           &  ! deg C
+               model%glacier%tmlt,                     &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
                model%glacier%snow_factor,              &  ! unitless
-               model%climate%smb,                      &  ! mm/yr w.e.
-               model%glacier%smb)                         ! mm/yr w.e.
+               model%climate%smb)                         ! mm/yr w.e.
 
           ! Convert SMB (mm/yr w.e.) to acab (CISM model units)
           model%climate%acab(:,:) = (model%climate%smb(:,:) * (rhow/rhoi)/1000.d0) / scale_acab
@@ -3112,34 +3108,6 @@ contains
                                          model%geometry%tracers_usrf(:,:,:),                   &
                                          model%geometry%tracers_lsrf(:,:,:),                   &
                                          model%options%which_ho_vertical_remap)
-
-       !-------------------------------------------------------------------------
-       ! If running with glaciers, then adjust glacier indices based on advance and retreat.
-       ! Call once per year.
-       ! Note: This subroutine limits the ice thickness in grid cells that do not yet have
-       !       a nonzero cism_glacier_id.  The acab_applied field is adjusted accordingly,
-       !       which means that acab_applied will be more negative during timesteps
-       !       when this subroutine is called.
-       ! TODO: To make acab_applied more uniform on subannual time scales, create a new flux
-       !       (e.g., correction_flux) for artificial thickness changes, distinct from SMB, BMB and calving.
-       !-------------------------------------------------------------------------
-
-       if (model%options%enable_glaciers .and. &
-          mod(model%numerics%tstep_count, model%numerics%nsteps_per_year) == 0) then
-
-          call glissade_glacier_advance_retreat(&
-               ewn,             nsn,                &
-               itest,   jtest,  rtest,              &
-               model%geometry%usrf*thk0,            &  ! m
-               thck_unscaled,                       &  ! m
-               model%climate%acab_applied,          &  ! m/s
-               model%numerics%dt * tim0,            &  ! s
-               model%glacier%minthck,               &  ! m
-               model%glacier%cism_glacier_id_init,  &
-               model%glacier%cism_glacier_id,       &
-               parallel)
-
-       endif   ! enable_glaciers
 
        !-------------------------------------------------------------------------
        ! Cleanup
@@ -4111,7 +4079,7 @@ contains
          glissade_inversion_bmlt_basin, glissade_inversion_deltaT_ocn, &
          glissade_inversion_flow_enhancement_factor
     use glissade_utils, only: glissade_usrf_to_thck
-    use glissade_glacier, only: glissade_glacier_inversion
+    use glissade_glacier, only: glissade_glacier_update
 
     implicit none
 
@@ -4377,7 +4345,7 @@ contains
     ! Note: This subroutine used to be called earlier, but now is called here
     !       in order to have f_ground_cell up to date.
     ! If running with glaciers, inversion for powerlaw_c is done elsewhere,
-    !  in subroutine glissade_glacier_inversion.
+    !  in subroutine glissade_glacier_update.
     !TODO: Call when the inversion options are set, not the external options.
     !      Currently, the only thing done for the external options is to remove
     !       zero values.
@@ -4564,16 +4532,18 @@ contains
     endif   ! which_ho_flow_enhancement_factor
 
 
-    ! If glaciers are enabled, invert for mu_star and powerlaw_c.
-    ! Note: If reading mu_star and powerlaw_c from external files, the subroutine is called
-    !       for diagnostics only.
+    ! If glaciers are enabled, then do various updates:
+    ! (1) If inverting for mu_star, snow_factor, or powerlaw_c, then
+    !     (a) Accumulate the fields needed for the inversion.
+    !     (b) Once a year, average the fields and do the inversion.
+    ! (2) Once a year, update the glacier masks as glaciers advance and retreat.
 
     if (model%options%enable_glaciers) then
 
        if (model%numerics%time == model%numerics%tstart) then
            ! first call at start-up or after a restart; do nothing
        else
-          call glissade_glacier_inversion(model, model%glacier)
+          call glissade_glacier_update(model, model%glacier)
        endif   ! time = tstart
 
     endif   ! enable_glaciers

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -887,9 +887,23 @@ contains
                                              model%basal_physics)
     endif
 
+    ! Initialize powerlaw_c and coulomb_c.
+    ! Note: This can set powerlaw_c and coulomb_c to nonzero values when they are never used,
+    !       but is simpler than checking all possible basal friction options.
+
+    if (model%options%is_restart == RESTART_FALSE) then
+       if (model%options%which_ho_powerlaw_c == HO_POWERLAW_C_CONSTANT) then
+          model%basal_physics%powerlaw_c = model%basal_physics%powerlaw_c_const
+       endif
+       if (model%options%which_ho_coulomb_c == HO_COULOMB_C_CONSTANT) then
+          model%basal_physics%coulomb_c = model%basal_physics%coulomb_c_const
+       endif
+    endif
+
     ! Optionally, do initial calculations for inversion
     ! At the start of the run (but not on restart), this might lead to further thickness adjustments,
     !  so it should be called before computing the calving mask.
+    !TODO: Separate the basal friction inversion from the bmlt_basin inversion.
 
     if (model%options%which_ho_powerlaw_c == HO_POWERLAW_C_INVERSION .or.  &
         model%options%which_ho_coulomb_c  == HO_COULOMB_C_INVERSION  .or.  &
@@ -2762,6 +2776,7 @@ contains
 
           ! Convert SMB (mm/yr w.e.) to acab (CISM model units)
           model%climate%acab(:,:) = (model%climate%smb(:,:) * (rhow/rhoi)/1000.d0) / scale_acab
+          call parallel_halo(model%climate%acab, parallel)
 
           if (verbose_glacier .and. this_rank == rtest) then
              i = itest
@@ -2994,28 +3009,28 @@ contains
                                          model%options%which_ho_vertical_remap)
 
        !-------------------------------------------------------------------------
-       ! If running with glaciers, then adjust glacier indices based on advance and retreat,
-       ! Call once a year to avoid subannual variability.
+       ! If running with glaciers, then adjust glacier indices based on advance and retreat.
+       ! Note: This subroutine limits the ice thickness in grid cells that do not yet have
+       !       a nonzero cism_glacier_id.  The acab_applied field is adjusted accordingly.
+       ! Note: It would probably be OK to call this subroutine annually instead of every step.
+       !       In that case, we might want to separate the special glacier acab adjustment
+       !       from the rest of acab_applied.
        !-------------------------------------------------------------------------
 
        if (model%options%enable_glaciers) then
 
-          ! Determine whether a year has passed, asssuming an integer number of timesteps per year.
-          ! model%numerics%time is real(dp) with units of yr
-          if (abs(model%numerics%time - nint(model%numerics%time)) < eps08) then
+          call glissade_glacier_advance_retreat(&
+               ewn,             nsn,                &
+               itest,   jtest,  rtest,              &
+               model%geometry%usrf*thk0,            &  ! m
+               thck_unscaled,                       &  ! m
+               model%climate%acab_applied,          &  ! m/s
+               model%numerics%dt * tim0,            &  ! s
+               model%glacier%minthck,               &  ! m
+               model%glacier%cism_glacier_id_init,  &
+               model%glacier%cism_glacier_id,       &
+               parallel)
 
-             ! TODO - Correct acab_applied for glacier mass removed?
-             call glissade_glacier_advance_retreat(&
-                  ewn,             nsn,                &
-                  itest,   jtest,  rtest,              &
-                  thck_unscaled,                       &  ! m
-                  model%geometry%usrf*thk0,            &  ! m
-                  model%glacier%minthck,               &  ! m
-                  model%glacier%cism_glacier_id_init,  &
-                  model%glacier%cism_glacier_id,  &
-                  parallel)   !WHL - debug
-
-          endif   ! 1-year interval has passed
        endif   ! enable_glaciers
 
        !WHL - debug
@@ -4256,11 +4271,16 @@ contains
     ! If inverting for Cp = powerlaw_c or Cc = coulomb_c, then update it here.
     ! Note: This subroutine used to be called earlier, but now is called here
     !       in order to have f_ground_cell up to date.
+    ! If running with glaciers, inversion for powerlaw_c is done elsewhere,
+    !  in subroutine glissade_glacier_inversion.
+    !TODO: Call when the inversion options are set, not the external options.
+    !      Currently, the only thing done for the external options is to remove
+    !       zero values.
 
     if ( model%options%which_ho_powerlaw_c == HO_POWERLAW_C_INVERSION .or. &
          model%options%which_ho_powerlaw_c == HO_POWERLAW_C_EXTERNAL  .or. &
          model%options%which_ho_coulomb_c  == HO_COULOMB_C_INVERSION  .or. &
-         model%options%which_ho_coulomb_c  == HO_COULOMB_C_EXTERNAL) then
+         model%options%which_ho_coulomb_c  == HO_COULOMB_C_EXTERNAL ) then
 
        if ( (model%options%is_restart == RESTART_TRUE) .and. &
             (model%numerics%time == model%numerics%tstart) ) then
@@ -4270,7 +4290,6 @@ contains
        endif
 
     endif   ! which_ho_powerlaw_c/coulomb_c
-
 
     ! If inverting for deltaT_ocn at the basin level, then update it here
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2856,7 +2856,7 @@ contains
                model%climate%artm_corrected,           &  ! deg C
                model%glacier%tmlt,                     &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
-               model%glacier%snow_factor,              &  ! unitless
+               model%glacier%alpha_snow,               &  ! unitless
                model%climate%smb)                         ! mm/yr w.e.
 
           ! Convert SMB (mm/yr w.e.) to acab (CISM model units)
@@ -2872,8 +2872,8 @@ contains
              print*, '   Local smb (mm/yr w.e.) =', model%climate%smb(i,j)
              print*, '   Local acab (m/yr ice)  =', model%climate%acab(i,j)*thk0*scyr/tim0
              if (ng > 0) then
-                print*, '   Glacier-specific smb (mm/yr w.e.), snow_factor =', &
-                     model%glacier%smb(ng), model%glacier%snow_factor(ng)
+                print*, '   Glacier-specific smb (mm/yr w.e.), alpha_snow =', &
+                     model%glacier%smb(ng), model%glacier%alpha_snow(ng)
              endif
 
              !WHL - debug
@@ -4533,7 +4533,7 @@ contains
 
 
     ! If glaciers are enabled, then do various updates:
-    ! (1) If inverting for mu_star, snow_factor, or powerlaw_c, then
+    ! (1) If inverting for mu_star, alpha_snow, or powerlaw_c, then
     !     (a) Accumulate the fields needed for the inversion.
     !     (b) Once a year, average the fields and do the inversion.
     ! (2) Once a year, update the glacier masks as glaciers advance and retreat.

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1985,8 +1985,8 @@ contains
        if (verbose_glacier .and. this_rank == rtest) then
           i = itest; j = jtest
           print*, ' '
-          print*, 'rank, i, j, usrf, usrf_ref, dz:', this_rank, i, j, &
-               model%geometry%usrf(i,j)*thk0, model%climate%usrf_ref(i,j), &
+          print*, 'rank, i, j, usrf_ref, usrf, dz:', this_rank, i, j, &
+               model%climate%usrf_ref(i,j), model%geometry%usrf(i,j)*thk0, &
                model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref(i,j)
           print*, '   artm_ref, artm:', model%climate%artm_ref(i,j), model%climate%artm(i,j)
        endif

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -553,7 +553,24 @@ contains
     !  computes a few remaining variable.
 
     if (model%options%enable_glaciers) then
+
+       !WHL - debug
+       ! Glaciers are run with a no-ice BC to allow removal of inactive regions.
+       ! This can be problematic when running in a sub-region that has glaciers along the global boundary.
+       ! A halo update here for 'thck' will remove ice from cells along the global boundary.
+       ! It is best to do this before initializing glaciers, so that ice that initially exists
+       !  in these cells is removed before computing the area and thickness targets.
+       !TODO - These calls are repeated a few lines below.  Try moving them up, before the call
+       !       to glissade_glacier_init.  I don't think it's possible to move the glissade_glacier_init call
+       !       down, because we need to compute nglacier before setting up output files.
+
+       call parallel_halo(model%geometry%thck, parallel)
+       ! calculate the lower and upper ice surface
+       call glide_calclsrf(model%geometry%thck, model%geometry%topg, model%climate%eus, model%geometry%lsrf)
+       model%geometry%usrf = max(0.d0, model%geometry%thck + model%geometry%lsrf)
+
        call glissade_glacier_init(model, model%glacier)
+
     endif
 
     ! open all output files
@@ -586,7 +603,7 @@ contains
     !        treat it as ice-free ocean. For this reason, topg is extrapolated from adjacent cells.
     !       Similarly, for no_ice BCs, we want to zero out ice state variables adjacent to the global boundary,
     !        but we do not want to zero out the topography.
-    ! Note: For periodic BCs, there is an optional aargument periodic_offset_ew for topg.
+    ! Note: For periodic BCs, there is an optional argument periodic_offset_ew for topg.
     !       This is for ismip-hom experiments. A positive EW offset means that
     !        the topography in west halo cells will be raised, and the topography
     !        in east halo cells will be lowered.  This ensures that the topography

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2282,7 +2282,8 @@ contains
     real(dp) :: local_maxval, global_maxval
     character(len=100) :: message
 
-    logical, parameter :: verbose_smb = .false.
+!!    logical, parameter :: verbose_smb = .false.
+    logical, parameter :: verbose_smb = .true.
 
     rtest = -999
     itest = 1
@@ -2833,10 +2834,12 @@ contains
                ewn,      nsn,                          &
                itest,    jtest,    rtest,              &
                model%glacier%nglacier,                 &
+               model%glacier%cism_glacier_id_init,     &
                model%glacier%cism_glacier_id,          &
                model%glacier%t_mlt,                    &  ! deg C
                model%glacier%snow_threshold_min,       &  ! deg C
                model%glacier%snow_threshold_max,       &  ! deg C
+               model%glacier%snow_reduction_factor,    &
                model%glacier%snow_calc,                &
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%precip,                   &  ! mm/yr w.e.
@@ -2855,12 +2858,25 @@ contains
              j = jtest
              ng = model%glacier%ngdiag
              print*, ' '
-             print*, 'Computed glacier SMB, rank, i, j =', this_rank, i, j
-             print*, '   delta_artm =', model%glacier%delta_artm(ng)
-             print*, '   smb (mm/yr w.e.) =', model%climate%smb(i,j)
-             print*, '   acab (m/yr ice)  =', model%climate%acab(i,j)*thk0*scyr/tim0
-          endif
+             print*, 'Computed glacier SMB, rank, i, j, ng =', this_rank, i, j, ng
+             print*, '   Local smb (mm/yr w.e.) =', model%climate%smb(i,j)
+             print*, '   Local acab (m/yr ice)  =', model%climate%acab(i,j)*thk0*scyr/tim0
+             if (ng > 0) then
+                print*, '   delta_artm =', model%glacier%delta_artm(ng)
+                print*, '   Glacier-specific smb (mm/yr w.e.) =', model%glacier%smb(ng)
+             endif
 
+             !WHL - debug
+             write(6,*) ' '
+             write(6,*) 'acab (m/yr ice)'
+             do j = jtest+3, jtest-3, -1
+                write(6,'(i6)',advance='no') j
+                do i = itest-3, itest+3
+                   write(6,'(f10.3)',advance='no') model%climate%acab(i,j)*thk0*scyr/tim0
+                enddo
+                write(6,*) ' '
+             enddo
+          endif
        endif   ! enable_glaciers
 
        ! Compute a corrected acab field that includes any prescribed anomalies.

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -97,7 +97,7 @@ contains
          parallel_create_comm_row, parallel_create_comm_col, not_parallel
 
     use glide_setup
-    use glimmer_ncio
+    use glimmer_ncio, only: openall_in, openall_out, glimmer_nc_get_var, glimmer_nc_get_dimlength
     use glide_velo, only: init_velo  !TODO - Remove call to init_velo?
     use glissade_therm, only: glissade_init_therm
     use glissade_transport, only: glissade_overwrite_acab_mask, glissade_add_2d_anomaly
@@ -301,6 +301,16 @@ contains
     model%general%velo_grid = coordsystem_new(model%numerics%dew/2.d0, model%numerics%dns/2.d0, &
                                               model%numerics%dew,      model%numerics%dns,      &
                                               model%general%ewn-1,     model%general%nsn-1)
+
+    ! If the length of any dimension is unknown, then get the length now, before allocating arrays.
+    ! Currently, the length of most dimensions is set in the config file.
+    ! An exception is dimension glacierid, whose length (nglacier) is computed internally by CISM.
+    ! On restart, we can get the length from the restart file.
+
+    if (model%options%enable_glaciers .and. model%options%is_restart == RESTART_TRUE) then
+       infile => model%funits%in_first   ! assume glacierid is a dimension in the restart file
+       call glimmer_nc_get_dimlength(infile, 'glacierid', model%glacier%nglacier)
+    endif
 
     ! allocate arrays
     call glide_allocarr(model)
@@ -537,10 +547,12 @@ contains
     model%geometry%cell_area = model%numerics%dew*model%numerics%dns
 
     ! If running with glaciers, then process the input glacier data
-    ! Note: This subroutine counts the glaciers.  It should be called before glide_io_createall,
-    !       which needs to know nglacier to set up glacier output files with the right dimensions.
+    ! On start-up, this subroutine counts the glaciers.  It should be called before glide_io_createall,
+    !  which needs to know nglacier to set up glacier output files with the right dimensions.
+    ! On restart, most of the required glacier arrays are in the restart file, and this subroutine
+    !  computes a few remaining variable.
 
-    if (model%options%enable_glaciers .and. model%options%is_restart == RESTART_FALSE) then
+    if (model%options%enable_glaciers) then
        call glissade_glacier_init(model)
     endif
 
@@ -2729,19 +2741,19 @@ contains
 
        ! If using a glacier-specific SMB index method, then compute the SMB and convert to acab
 
-!!       if (0 == 1) then
        if (model%options%enable_glaciers) then
 
-          !WHL - debug
           if (verbose_glacier .and. main_task) then
              print*, 'call glissade_glacier_smb, nglacier =', model%glacier%nglacier
           endif
 
-          ! Halo update for snow; halo update for artm is done above
+          ! Halo updates for snow and artm
+          ! (Not sure the artm update is needed; there is one above)
+          call parallel_halo(model%climate%artm, parallel)
           call parallel_halo(model%climate%snow, parallel)
 
           call glissade_glacier_smb(&
-               model%general%ewn,  model%general%nsn,  &
+               ewn,      nsn,                          &
                itest,    jtest,    rtest,              &
                model%glacier%nglacier,                 &
                model%glacier%cism_glacier_id,          &
@@ -4403,48 +4415,56 @@ contains
 
 
     ! If glaciers are enabled, then invert for mu_star and powerlaw_c
-    !  based on glacier area and volume targets
+    !  based on glacier area and volume targets.  Do not invert on restart.
 
-!!    if (0 == 1 .and. &
     if (model%options%enable_glaciers .and. &
          (model%options%glacier_mu_star == GLACIER_MU_STAR_INVERSION .or.  &
           model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION)) then
 
-       call glissade_glacier_inversion(&
-            model%options%glacier_mu_star,                         &
-            model%options%glacier_powerlaw_c,                      &
-            model%numerics%dt * tim0/scyr,                         &  ! yr
-            itest,       jtest,         rtest,                     &
-            ewn,                        nsn,                       &
-            model%numerics%dew * len0,  model%numerics%dns * len0, &  ! m
-            model%geometry%thck * thk0,                            &  ! m
-            model%geometry%dthck_dt * scyr,                        &  ! m/yr
-            model%basal_physics%powerlaw_c_min,                    &
-            model%basal_physics%powerlaw_c_max,                    &
-            model%glacier)
+       if ( (model%options%is_restart == RESTART_TRUE) .and. &
+            (model%numerics%time == model%numerics%tstart) ) then
+          ! first call after a restart; do not invert for glacier parameters
 
-       ! Copy glacier%powerlaw_c(ng) to the unstaggered ice grid.
+       else
 
-       powerlaw_c_icegrid(:,:) = 0.0d0
-       do j = 1, nsn
-          do i = 1, ewn
-             ng = model%glacier%cism_glacier_id(i,j)
-             if (ng >= 1) then
-                powerlaw_c_icegrid(i,j) = model%glacier%powerlaw_c(ng)
-             endif
+          call glissade_glacier_inversion(&
+               model%options%glacier_mu_star,                         &
+               model%options%glacier_powerlaw_c,                      &
+               model%numerics%dt * tim0/scyr,                         &  ! yr
+               itest,       jtest,         rtest,                     &
+               ewn,                        nsn,                       &
+               model%numerics%dew * len0,  model%numerics%dns * len0, &  ! m
+               model%geometry%thck * thk0,                            &  ! m
+               model%geometry%dthck_dt * scyr,                        &  ! m/yr
+               model%basal_physics%powerlaw_c_min,                    &
+               model%basal_physics%powerlaw_c_max,                    &
+               model%glacier)
+
+          ! Copy glacier%powerlaw_c(ng) to the unstaggered ice grid.
+
+          powerlaw_c_icegrid(:,:) = 0.0d0
+          do j = 1, nsn
+             do i = 1, ewn
+                ng = model%glacier%cism_glacier_id(i,j)
+                if (ng >= 1) then
+                   powerlaw_c_icegrid(i,j) = model%glacier%powerlaw_c(ng)
+                endif
+             enddo
           enddo
-       enddo
 
-       ! Interpolate powerlaw_c to the staggered velocity grid.
-       ! At glacier margins, ignoring powerlaw_c in adjacent ice-free cells
-       !  (by setting stagger_margin_in = 1).
-       ! Thus, powerlaw_c = 0 at vertices surrounded by ice-free cells.
-       ! Note: Here, 'ice-free' means thck < thklim.
+          ! Interpolate powerlaw_c to the staggered velocity grid.
+          ! At glacier margins, ignoring powerlaw_c in adjacent ice-free cells
+          !  (by setting stagger_margin_in = 1).
+          ! Thus, powerlaw_c = 0 at vertices surrounded by ice-free cells.
+          ! Note: Here, 'ice-free' means thck < thklim.
 
-       call glissade_stagger(ewn,                 nsn,                             &
-                             powerlaw_c_icegrid,  model%basal_physics%powerlaw_c,  &
-                             ice_mask = ice_mask,                                  &
-                             stagger_margin_in = 1)
+          call glissade_stagger(&
+               ewn,                 nsn,                             &
+               powerlaw_c_icegrid,  model%basal_physics%powerlaw_c,  &
+               ice_mask = ice_mask,                                  &
+               stagger_margin_in = 1)
+
+       endif   ! first call after restart
 
     endif   ! enable_glaciers with inversion
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2272,7 +2272,7 @@ contains
 
     integer :: ntracers             ! number of tracers to be transported
 
-    integer :: i, j, k
+    integer :: i, j, k, ng
     integer :: ewn, nsn, upn, nlev_smb
     integer :: itest, jtest, rtest
 
@@ -2815,9 +2815,12 @@ contains
        if (model%options%enable_glaciers) then
 
           ! Halo updates for snow and artm
-          ! (Not sure the artm update is needed; there is one above)
+          ! Note: artm_corrected is the input artm, possible corrected to include an anomaly term.
+          !       delta_artm is a glacier-specific correction whose purpose is to give SMB ~ 0.
+          !        This term is zero by default, but is nonzero during spin-up when inverting for powerlaw_c.
+
           call parallel_halo(model%climate%snow, parallel)
-          call parallel_halo(model%climate%artm, parallel)
+          call parallel_halo(model%climate%artm_corrected, parallel)
 
           call glissade_glacier_smb(&
                ewn,      nsn,                          &
@@ -2827,8 +2830,10 @@ contains
                model%glacier%t_mlt,                    &  ! deg C
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%artm_corrected,           &  ! deg C
+               model%glacier%delta_artm,               &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
-               model%climate%smb)                         ! mm/yr w.e.
+               model%climate%smb,                      &  ! mm/yr w.e.
+               model%glacier%smb)                         ! mm/yr w.e.
 
           ! Convert SMB (mm/yr w.e.) to acab (CISM model units)
           model%climate%acab(:,:) = (model%climate%smb(:,:) * (rhow/rhoi)/1000.d0) / scale_acab
@@ -2837,9 +2842,12 @@ contains
           if (verbose_glacier .and. this_rank == rtest) then
              i = itest
              j = jtest
+             ng = model%glacier%ngdiag
              print*, ' '
              print*, 'Computed glacier SMB, rank, i, j =', this_rank, i, j
-             print*, '   acab (m/yr ice) =', model%climate%acab(i,j)*thk0*scyr/tim0
+             print*, '   delta_artm =', model%glacier%delta_artm(ng)
+             print*, '   smb (mm/yr w.e.) =', model%climate%smb(i,j)
+             print*, '   acab (m/yr ice)  =', model%climate%acab(i,j)*thk0*scyr/tim0
           endif
 
        endif   ! enable_glaciers

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -68,7 +68,8 @@ module glissade
   implicit none
 
   integer, private, parameter :: dummyunit=99
-  logical, parameter :: verbose_glissade = .false.
+!!  logical, parameter :: verbose_glissade = .false.
+  logical, parameter :: verbose_glissade = .true.
 
   ! Change any of the following logical parameters to true to carry out simple tests
   logical, parameter :: test_transport = .false.    ! if true, call test_transport subroutine
@@ -499,24 +500,10 @@ contains
 
     end select
 
-    ! open all output files
-    call openall_out(model)
-
-    ! create glide variables
-    call glide_io_createall(model, model)
-
-    ! Compute the cell areas of the grid
-    model%geometry%cell_area = model%numerics%dew*model%numerics%dns
-
-    ! If running with glaciers, then process the input glacier data
-    if (model%options%enable_glaciers .and. model%options%is_restart == RESTART_FALSE) then
-       call glissade_glacier_init(model)
-    endif
-
-    ! If a 2D bheatflx field is present in the input file, it will have been written 
+    ! If a 2D bheatflx field is present in the input file, it will have been written
     !  to model%temper%bheatflx.  For the case model%options%gthf = 0, we want to use
     !  a uniform heat flux instead.
-    ! If no bheatflx field is present in the input file, then we default to the 
+    ! If no bheatflx field is present in the input file, then we default to the
     !  prescribed uniform value, model%paramets%geot.
 
     if (model%options%gthf == GTHF_UNIFORM) then
@@ -545,6 +532,23 @@ contains
        endif
 
     endif  ! geothermal heat flux
+
+    ! Compute the cell areas of the grid
+    model%geometry%cell_area = model%numerics%dew*model%numerics%dns
+
+    ! If running with glaciers, then process the input glacier data
+    ! Note: This subroutine counts the glaciers.  It should be called before glide_io_createall,
+    !       which needs to know nglacier to set up glacier output files with the right dimensions.
+
+    if (model%options%enable_glaciers .and. model%options%is_restart == RESTART_FALSE) then
+       call glissade_glacier_init(model)
+    endif
+
+    ! open all output files
+    call openall_out(model)
+
+    ! create glide I/O variables
+    call glide_io_createall(model, model)
 
     ! initialize glissade components
 
@@ -1274,6 +1278,14 @@ contains
        do j = jtest+3, jtest-3, -1
           do i = itest-3, itest+3
              write(6,'(f10.3)',advance='no') model%basal_melt%bmlt_ground(i,j)*scyr
+          enddo
+          write(6,*) ' '
+       enddo
+       print*, ' '
+       print*, 'bmlt_float (m/yr):'
+       do j = jtest+3, jtest-3, -1
+          do i = itest-3, itest+3
+             write(6,'(f10.3)',advance='no') model%basal_melt%bmlt_float(i,j)*scyr
           enddo
           write(6,*) ' '
        enddo
@@ -2128,6 +2140,7 @@ contains
     use glissade_bmlt_float, only: verbose_bmlt_float
     use glissade_calving, only: verbose_calving
     use glissade_grid_operators, only: glissade_vertical_interpolate
+    use glissade_glacier, only: glissade_glacier_smb, verbose_glacier
     use glide_stop, only: glide_finalise
 
     implicit none
@@ -2713,6 +2726,42 @@ contains
           endif   ! artm_input_function
 
        endif  ! verbose_smb and this_rank
+
+       ! If using a glacier-specific SMB index method, then compute the SMB and convert to acab
+
+!!       if (0 == 1) then
+       if (model%options%enable_glaciers) then
+
+          !WHL - debug
+          if (verbose_glacier .and. main_task) then
+             print*, 'call glissade_glacier_smb, nglacier =', model%glacier%nglacier
+          endif
+
+          ! Halo update for snow; halo update for artm is done above
+          call parallel_halo(model%climate%snow, parallel)
+
+          call glissade_glacier_smb(&
+               model%general%ewn,  model%general%nsn,  &
+               itest,    jtest,    rtest,              &
+               model%glacier%nglacier,                 &
+               model%glacier%cism_glacier_id,          &
+               model%glacier%mu_star,                  &  ! mm/yr w.e./deg
+               model%climate%snow,                     &  ! mm/yr w.e.
+               model%climate%artm,                     &  ! deg C
+               model%climate%smb)                         ! mm/yr w.e.
+
+          ! Convert SMB (mm/yr w.e.) to acab (CISM model units)
+          model%climate%acab(:,:) = (model%climate%smb(:,:) * (rhow/rhoi)/1000.d0) / scale_acab
+
+          if (verbose_glacier .and. this_rank == rtest) then
+             i = itest
+             j = jtest
+             print*, ' '
+             print*, 'Computed glacier SMB, rank, i, j =', this_rank, i, j
+             print*, '   acab (m/yr ice) =', model%climate%acab(i,j)*thk0*scyr/tim0
+          endif
+
+       endif   ! enable_glaciers
 
        ! Compute a corrected acab field that includes any prescribed anomalies.
        ! Typically, acab_corrected = acab, but sometimes (e.g., for initMIP) it includes a time-dependent anomaly.
@@ -3907,6 +3956,7 @@ contains
          glissade_inversion_bmlt_basin, glissade_inversion_deltaT_ocn, &
          glissade_inversion_flow_enhancement_factor, &
          usrf_to_thck
+    use glissade_glacier, only: glissade_glacier_inversion
 
     implicit none
 
@@ -3914,7 +3964,7 @@ contains
 
     ! Local variables
 
-    integer :: i, j, k, n
+    integer :: i, j, k, n, ng
     integer :: itest, jtest, rtest
 
     integer, dimension(model%general%ewn, model%general%nsn) :: &
@@ -3932,7 +3982,8 @@ contains
          f_ground_cell_obs,  & ! f_ground_cell as a function of thck_obs (instead of current thck)
          f_ground_obs,       & ! f_ground as a function of thck_obs (instead of current thck)
          f_flotation_obs,    & ! f_flotation_obs as a function of thck_obs (instead of current thck)
-         thck_calving_front    ! effective thickness of ice at the calving front
+         thck_calving_front,   & ! effective thickness of ice at the calving front
+         powerlaw_c_icegrid      ! powerlaw_c on the unstaggered ice grid
 
     real(dp) :: &
          dsigma,                   & ! layer thickness in sigma coordinates
@@ -3951,8 +4002,8 @@ contains
     integer :: ewn, nsn, upn
 
     !WHL - debug
-    real(dp) :: my_max, my_min, global_max, global_min
     integer :: iglobal, jglobal, ii, jj
+    real(dp) :: my_max, my_min, global_max, global_min
     real(dp) :: sum_cell, sum1, sum2  ! temporary sums
 
     integer, dimension(model%general%ewn, model%general%nsn) :: &
@@ -4193,7 +4244,7 @@ contains
 
        else
 
-          call glissade_inversion_bmlt_basin(model%numerics%dt * tim0,                  &
+          call glissade_inversion_bmlt_basin(model%numerics%dt * tim0,                  &  ! s
                                              ewn, nsn,                                  &
                                              model%numerics%dew * len0,                 &  ! m
                                              model%numerics%dns * len0,                 &  ! m
@@ -4350,6 +4401,52 @@ contains
 
     endif   ! which_ho_flow_enhancement_factor
 
+
+    ! If glaciers are enabled, then invert for mu_star and powerlaw_c
+    !  based on glacier area and volume targets
+
+!!    if (0 == 1 .and. &
+    if (model%options%enable_glaciers .and. &
+         (model%options%glacier_mu_star == GLACIER_MU_STAR_INVERSION .or.  &
+          model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION)) then
+
+       call glissade_glacier_inversion(&
+            model%options%glacier_mu_star,                         &
+            model%options%glacier_powerlaw_c,                      &
+            model%numerics%dt * tim0/scyr,                         &  ! yr
+            itest,       jtest,         rtest,                     &
+            ewn,                        nsn,                       &
+            model%numerics%dew * len0,  model%numerics%dns * len0, &  ! m
+            model%geometry%thck * thk0,                            &  ! m
+            model%geometry%dthck_dt * scyr,                        &  ! m/yr
+            model%basal_physics%powerlaw_c_min,                    &
+            model%basal_physics%powerlaw_c_max,                    &
+            model%glacier)
+
+       ! Copy glacier%powerlaw_c(ng) to the unstaggered ice grid.
+
+       powerlaw_c_icegrid(:,:) = 0.0d0
+       do j = 1, nsn
+          do i = 1, ewn
+             ng = model%glacier%cism_glacier_id(i,j)
+             if (ng >= 1) then
+                powerlaw_c_icegrid(i,j) = model%glacier%powerlaw_c(ng)
+             endif
+          enddo
+       enddo
+
+       ! Interpolate powerlaw_c to the staggered velocity grid.
+       ! At glacier margins, ignoring powerlaw_c in adjacent ice-free cells
+       !  (by setting stagger_margin_in = 1).
+       ! Thus, powerlaw_c = 0 at vertices surrounded by ice-free cells.
+       ! Note: Here, 'ice-free' means thck < thklim.
+
+       call glissade_stagger(ewn,                 nsn,                             &
+                             powerlaw_c_icegrid,  model%basal_physics%powerlaw_c,  &
+                             ice_mask = ice_mask,                                  &
+                             stagger_margin_in = 1)
+
+    endif   ! enable_glaciers with inversion
 
     ! ------------------------------------------------------------------------ 
     ! Calculate Glen's A

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1991,6 +1991,22 @@ contains
           print*, '   artm_ref, artm:', model%climate%artm_ref(i,j), model%climate%artm(i,j)
        endif
 
+       ! optionally, do the same for an auxiliary field, artm_aux
+       ! Currently used only for 2-parameter glacier inversion
+
+       if (associated(model%climate%artm_aux)) then  ! artm_ref_aux and usrf_ref_aux should also be associated
+          model%climate%artm_aux(:,:) = model%climate%artm_ref_aux(:,:) - &
+               (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref_aux(:,:)) * model%climate%t_lapse
+          if (verbose_glacier .and. this_rank == rtest) then
+             i = itest; j = jtest
+             print*, ' '
+             print*, 'rank, i, j, usrf_ref_aux, usrf, dz:', this_rank, i, j, &
+                  model%climate%usrf_ref_aux(i,j), model%geometry%usrf(i,j)*thk0, &
+                  model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref_aux(i,j)
+             print*, '   artm_ref_aux, artm_aux:', model%climate%artm_ref_aux(i,j), model%climate%artm_aux(i,j)
+          endif
+       endif
+
     endif   ! artm_input_function
 
     call parallel_halo(model%climate%artm, parallel)
@@ -2818,8 +2834,6 @@ contains
           !TODO - Pass artm instead of artm_corrected?  I.e., disable the anomaly for glaciers?
           ! Halo updates for snow and artm
           ! Note: artm_corrected is the input artm, possible corrected to include an anomaly term.
-          !       delta_artm is a glacier-specific correction whose purpose is to give SMB ~ 0.
-          !        This term is zero by default, but is nonzero during spin-up when inverting for powerlaw_c.
           ! Note: snow_calc is the snow calculation option:  Either use the snowfall rate directly,
           !       or compute the snowfall rate from the precip rate and downscaled artm.
 
@@ -2844,8 +2858,8 @@ contains
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%precip,                   &  ! mm/yr w.e.
                model%climate%artm_corrected,           &  ! deg C
-               model%glacier%delta_artm,               &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
+               model%glacier%snow_factor,              &  ! unitless
                model%climate%smb,                      &  ! mm/yr w.e.
                model%glacier%smb)                         ! mm/yr w.e.
 
@@ -2862,8 +2876,8 @@ contains
              print*, '   Local smb (mm/yr w.e.) =', model%climate%smb(i,j)
              print*, '   Local acab (m/yr ice)  =', model%climate%acab(i,j)*thk0*scyr/tim0
              if (ng > 0) then
-                print*, '   delta_artm =', model%glacier%delta_artm(ng)
-                print*, '   Glacier-specific smb (mm/yr w.e.) =', model%glacier%smb(ng)
+                print*, '   Glacier-specific smb (mm/yr w.e.), snow_factor =', &
+                     model%glacier%smb(ng), model%glacier%snow_factor(ng)
              endif
 
              !WHL - debug

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -646,12 +646,11 @@ contains
     model%climate%artm_corrected(:,:) = model%climate%artm(:,:)
 
     if (model%options%enable_artm_anomaly) then
-
        ! Check whether artm_anomaly was read from an external file.
        ! If so, then use this field as the anomaly.
        ! If not, then set artm_anomaly = artm_anomaly_constant everywhere.
        ! Note: The artm_anomaly field does not change during the run,
-       !       but it is possible to ramp in the anomaly using artm_anomaly_timescale.
+       !       but it is possible to ramp up the anomaly using artm_anomaly_timescale.
        ! TODO - Write a short utility function to compute global_maxval of any field.
 
        local_maxval = maxval(abs(model%climate%artm_anomaly))
@@ -662,13 +661,12 @@ contains
                'Setting artm_anomaly = constant value (degC):', model%climate%artm_anomaly_const
           call write_log(trim(message))
        else
-          print*, 'global_maxval(artm_anomaly) =', global_maxval  !WHL - debug
           if (model%options%is_restart == RESTART_FALSE) then
              call write_log('Setting artm_anomaly from external file')
           endif
        endif
-
     endif
+    !TODO - Repeat for snow and precip anomalies
 
     ! Initialize the temperature profile in each column
     call glissade_init_therm(model%options%temp_init,    model%options%is_restart,  &
@@ -1679,6 +1677,7 @@ contains
        ! Add the bmlt_float anomaly where ice is present and floating
        call glissade_add_2d_anomaly(model%basal_melt%bmlt_float,              &   ! scaled model units
                                     model%basal_melt%bmlt_float_anomaly,      &   ! scaled model units
+                                    model%basal_melt%bmlt_anomaly_tstart,     &   ! yr
                                     model%basal_melt%bmlt_anomaly_timescale,  &   ! yr
                                     previous_time)                                ! yr
 
@@ -1996,7 +1995,6 @@ contains
     !  it includes a time-dependent anomaly.
     ! Note that artm itself does not change in time, unless it is elevation-dependent.
 
-    ! initialize
     model%climate%artm_corrected(:,:) = model%climate%artm(:,:)
 
     if (model%options%enable_artm_anomaly) then
@@ -2007,18 +2005,60 @@ contains
 
        call glissade_add_2d_anomaly(model%climate%artm_corrected,          &   ! degC
                                     model%climate%artm_anomaly,            &   ! degC
+                                    model%climate%artm_anomaly_tstart,     &   ! yr
                                     model%climate%artm_anomaly_timescale,  &   ! yr
                                     previous_time)                             ! yr
+    endif
 
-       if (verbose_glissade .and. this_rank==rtest) then
+    ! Similar calculations for snow and precip anomalies
+    ! Note: These variables are currently used only to compute glacier SMB.
+    !       There are assumed to have the same timescale as artm_anomaly.
+    ! TODO: Define a single anomaly timescale for all anomaly forcing?
+
+    model%climate%snow_corrected(:,:) = model%climate%snow(:,:)
+
+    if (model%options%enable_snow_anomaly) then
+
+       previous_time = model%numerics%time - model%numerics%dt * tim0/scyr
+
+       call glissade_add_2d_anomaly(model%climate%snow_corrected,          &   ! mm/yr w.e.
+                                    model%climate%snow_anomaly,            &   ! mm/yr w.e.
+                                    model%climate%artm_anomaly_tstart,     &   ! yr
+                                    model%climate%artm_anomaly_timescale,  &   ! yr
+                                    previous_time)                             ! yr
+    endif
+
+    model%climate%precip_corrected(:,:) = model%climate%precip(:,:)
+
+    if (model%options%enable_precip_anomaly) then
+
+       previous_time = model%numerics%time - model%numerics%dt * tim0/scyr
+
+       call glissade_add_2d_anomaly(model%climate%precip_corrected,        &   ! mm/yr w.e.
+                                    model%climate%precip_anomaly,          &   ! mm/yr w.e.
+                                    model%climate%artm_anomaly_tstart,     &   ! yr
+                                    model%climate%artm_anomaly_timescale,  &   ! yr
+                                    previous_time)                             ! yr
+    endif
+
+    if (verbose_glissade .and. this_rank==rtest) then
+       if (model%options%enable_artm_anomaly) then
           i = itest
           j = jtest
-          print*, 'i, j, previous_time, artm, artm anomaly, corrected artm (deg C):', &
-               i, j, previous_time, model%climate%artm(i,j), model%climate%artm_anomaly(i,j), &
-               model%climate%artm_corrected(i,j)
-       endif
-
-    endif
+          print*, 'rank, i, j, previous_time, current time, anomaly timescale (yr):', &
+               this_rank, i, j, previous_time, model%numerics%time, model%climate%artm_anomaly_timescale
+          print*, '   artm, artm anomaly, corrected artm (deg C):', model%climate%artm(i,j), &
+               model%climate%artm_anomaly(i,j), model%climate%artm_corrected(i,j)
+          if (model%options%enable_snow_anomaly) then
+             print*, '   snow, snow anomaly, corrected snow (mm/yr):', model%climate%snow(i,j), &
+                  model%climate%snow_anomaly(i,j), model%climate%snow_corrected(i,j)
+          endif
+          if (model%options%enable_precip_anomaly) then
+             print*, '   prcp, prcp anomaly, corrected prcp (mm/yr):', model%climate%precip(i,j), &
+                  model%climate%precip_anomaly(i,j), model%climate%precip_corrected(i,j)
+          endif
+       endif   ! enable_artm_anomaly
+    endif   ! verbose
 
     if (main_task .and. verbose_glissade) print*, 'Call glissade_therm_driver'
 
@@ -2851,6 +2891,7 @@ contains
 
           call glissade_add_2d_anomaly(model%climate%acab_corrected,          &   ! scaled model units
                                        model%climate%acab_anomaly,            &   ! scaled model units
+                                       model%climate%acab_anomaly_tstart,     &   ! yr
                                        model%climate%acab_anomaly_timescale,  &   ! yr
                                        previous_time)                             ! yr
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -2756,6 +2756,7 @@ contains
                model%glacier%cism_glacier_id,          &
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%artm,                     &  ! deg C
+               model%glacier%tmlt,                     &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
                model%climate%smb)                         ! mm/yr w.e.
 
@@ -3005,11 +3006,11 @@ contains
 
              ! TODO - Correct acab_applied for glacier mass removed?
              call glissade_glacier_advance_retreat(&
-                  model%numerics%dt * tim0/scyr,       &  ! s
                   ewn,             nsn,                &
                   itest,   jtest,  rtest,              &
                   thck_unscaled,                       &  ! m
                   model%geometry%usrf*thk0,            &  ! m
+                  model%glacier%minthck,               &  ! m
                   model%glacier%cism_glacier_id_init,  &
                   model%glacier%cism_glacier_id,  &
                   parallel)   !WHL - debug
@@ -4442,8 +4443,8 @@ contains
     ! If glaciers are enabled, invert for mu_star and powerlaw_c based on area and volume targets
 
     if (model%options%enable_glaciers .and. &
-         (model%options%glacier_mu_star == GLACIER_MU_STAR_INVERSION .or.  &
-          model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION)) then
+         (model%glacier%set_mu_star == GLACIER_MU_STAR_INVERSION .or.  &
+          model%glacier%set_powerlaw_c == GLACIER_POWERLAW_C_INVERSION)) then
 
        if (model%numerics%time == model%numerics%tstart) then
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -68,8 +68,8 @@ module glissade
   implicit none
 
   integer, private, parameter :: dummyunit=99
-!!  logical, parameter :: verbose_glissade = .false.
-  logical, parameter :: verbose_glissade = .true.
+  logical, parameter :: verbose_glissade = .false.
+!!  logical, parameter :: verbose_glissade = .true.
 
   ! Change any of the following logical parameters to true to carry out simple tests
   logical, parameter :: test_transport = .false.    ! if true, call test_transport subroutine
@@ -553,7 +553,7 @@ contains
     !  computes a few remaining variable.
 
     if (model%options%enable_glaciers) then
-       call glissade_glacier_init(model)
+       call glissade_glacier_init(model, model%glacier)
     endif
 
     ! open all output files
@@ -2132,10 +2132,10 @@ contains
     !       after horizontal transport and before applying the surface and basal mass balance.
     ! ------------------------------------------------------------------------ 
 
-    use cism_parallel, only: parallel_type, parallel_halo, parallel_halo_tracers, staggered_parallel_halo, &
-         parallel_reduce_max
+    use cism_parallel, only: parallel_type, parallel_halo, parallel_halo_tracers,  &
+         staggered_parallel_halo, parallel_reduce_max
 
-    use glimmer_paramets, only: eps11, tim0, thk0, vel0, len0
+    use glimmer_paramets, only: eps11, eps08, tim0, thk0, vel0, len0
     use glimmer_physcon, only: rhow, rhoi, scyr
     use glimmer_scales, only: scale_acab
     use glissade_therm, only: glissade_temp2enth, glissade_enth2temp
@@ -2152,7 +2152,8 @@ contains
     use glissade_bmlt_float, only: verbose_bmlt_float
     use glissade_calving, only: verbose_calving
     use glissade_grid_operators, only: glissade_vertical_interpolate
-    use glissade_glacier, only: glissade_glacier_smb, verbose_glacier
+    use glissade_glacier, only: verbose_glacier, glissade_glacier_smb, &
+                                glissade_glacier_advance_retreat
     use glide_stop, only: glide_finalise
 
     implicit none
@@ -2743,10 +2744,6 @@ contains
 
        if (model%options%enable_glaciers) then
 
-          if (verbose_glacier .and. main_task) then
-             print*, 'call glissade_glacier_smb, nglacier =', model%glacier%nglacier
-          endif
-
           ! Halo updates for snow and artm
           ! (Not sure the artm update is needed; there is one above)
           call parallel_halo(model%climate%artm, parallel)
@@ -2757,9 +2754,9 @@ contains
                itest,    jtest,    rtest,              &
                model%glacier%nglacier,                 &
                model%glacier%cism_glacier_id,          &
-               model%glacier%mu_star,                  &  ! mm/yr w.e./deg
                model%climate%snow,                     &  ! mm/yr w.e.
                model%climate%artm,                     &  ! deg C
+               model%glacier%mu_star,                  &  ! mm/yr w.e./deg
                model%climate%smb)                         ! mm/yr w.e.
 
           ! Convert SMB (mm/yr w.e.) to acab (CISM model units)
@@ -2977,8 +2974,8 @@ contains
        !       * acab, bmlt (m/s)
        ! ------------------------------------------------------------------------
 
-       call glissade_mass_balance_driver(model%numerics%dt * tim0,                             &
-                                         model%numerics%dew * len0, model%numerics%dns * len0, &
+       call glissade_mass_balance_driver(model%numerics%dt * tim0,                             &  ! s
+                                         model%numerics%dew * len0, model%numerics%dns * len0, &  ! m
                                          ewn,         nsn,          upn-1,                     &
                                          model%numerics%sigma,                                 &
                                          parallel,                                             &
@@ -2994,6 +2991,31 @@ contains
                                          model%geometry%tracers_usrf(:,:,:),                   &
                                          model%geometry%tracers_lsrf(:,:,:),                   &
                                          model%options%which_ho_vertical_remap)
+
+       !-------------------------------------------------------------------------
+       ! If running with glaciers, then adjust glacier indices based on advance and retreat,
+       ! Call once a year to avoid subannual variability.
+       !-------------------------------------------------------------------------
+
+       if (model%options%enable_glaciers) then
+
+          ! Determine whether a year has passed, asssuming an integer number of timesteps per year.
+          ! model%numerics%time is real(dp) with units of yr
+          if (abs(model%numerics%time - nint(model%numerics%time)) < eps08) then
+
+             ! TODO - Correct acab_applied for glacier mass removed?
+             call glissade_glacier_advance_retreat(&
+                  model%numerics%dt * tim0/scyr,       &  ! s
+                  ewn,             nsn,                &
+                  itest,   jtest,  rtest,              &
+                  thck_unscaled,                       &  ! m
+                  model%geometry%usrf*thk0,            &  ! m
+                  model%glacier%cism_glacier_id_init,  &
+                  model%glacier%cism_glacier_id,  &
+                  parallel)   !WHL - debug
+
+          endif   ! 1-year interval has passed
+       endif   ! enable_glaciers
 
        !WHL - debug
        call parallel_halo(thck_unscaled, parallel)
@@ -3947,7 +3969,7 @@ contains
          staggered_parallel_halo, staggered_parallel_halo_extrapolate, &
          parallel_reduce_max, parallel_reduce_min, parallel_globalindex
 
-    use glimmer_paramets, only: tim0, len0, vel0, thk0, vis0, tau0, evs0
+    use glimmer_paramets, only: eps08, tim0, len0, vel0, thk0, vis0, tau0, evs0
     use glimmer_physcon, only: rhow, rhoi, scyr
     use glimmer_scales, only: scale_acab
     use glide_thck, only: glide_calclsrf
@@ -3968,7 +3990,7 @@ contains
          glissade_inversion_bmlt_basin, glissade_inversion_deltaT_ocn, &
          glissade_inversion_flow_enhancement_factor, &
          usrf_to_thck
-    use glissade_glacier, only: glissade_glacier_inversion
+    use glissade_glacier, only: verbose_glacier, glissade_glacier_inversion
 
     implicit none
 
@@ -3996,6 +4018,9 @@ contains
          f_flotation_obs,    & ! f_flotation_obs as a function of thck_obs (instead of current thck)
          thck_calving_front,   & ! effective thickness of ice at the calving front
          powerlaw_c_icegrid      ! powerlaw_c on the unstaggered ice grid
+
+    real(dp), dimension(model%general%ewn, model%general%nsn) ::  &
+         flow_enhancement_factor_float    ! flow enhancement factor for floating ice
 
     real(dp) :: &
          dsigma,                   & ! layer thickness in sigma coordinates
@@ -4414,57 +4439,21 @@ contains
     endif   ! which_ho_flow_enhancement_factor
 
 
-    ! If glaciers are enabled, then invert for mu_star and powerlaw_c
-    !  based on glacier area and volume targets.  Do not invert on restart.
+    ! If glaciers are enabled, invert for mu_star and powerlaw_c based on area and volume targets
 
     if (model%options%enable_glaciers .and. &
          (model%options%glacier_mu_star == GLACIER_MU_STAR_INVERSION .or.  &
           model%options%glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION)) then
 
-       if ( (model%options%is_restart == RESTART_TRUE) .and. &
-            (model%numerics%time == model%numerics%tstart) ) then
-          ! first call after a restart; do not invert for glacier parameters
+       if (model%numerics%time == model%numerics%tstart) then
+
+           ! first call at start-up or after a restart; do not invert
 
        else
 
-          call glissade_glacier_inversion(&
-               model%options%glacier_mu_star,                         &
-               model%options%glacier_powerlaw_c,                      &
-               model%numerics%dt * tim0/scyr,                         &  ! yr
-               itest,       jtest,         rtest,                     &
-               ewn,                        nsn,                       &
-               model%numerics%dew * len0,  model%numerics%dns * len0, &  ! m
-               model%geometry%thck * thk0,                            &  ! m
-               model%geometry%dthck_dt * scyr,                        &  ! m/yr
-               model%basal_physics%powerlaw_c_min,                    &
-               model%basal_physics%powerlaw_c_max,                    &
-               model%glacier)
+          call glissade_glacier_inversion(model, model%glacier)
 
-          ! Copy glacier%powerlaw_c(ng) to the unstaggered ice grid.
-
-          powerlaw_c_icegrid(:,:) = 0.0d0
-          do j = 1, nsn
-             do i = 1, ewn
-                ng = model%glacier%cism_glacier_id(i,j)
-                if (ng >= 1) then
-                   powerlaw_c_icegrid(i,j) = model%glacier%powerlaw_c(ng)
-                endif
-             enddo
-          enddo
-
-          ! Interpolate powerlaw_c to the staggered velocity grid.
-          ! At glacier margins, ignoring powerlaw_c in adjacent ice-free cells
-          !  (by setting stagger_margin_in = 1).
-          ! Thus, powerlaw_c = 0 at vertices surrounded by ice-free cells.
-          ! Note: Here, 'ice-free' means thck < thklim.
-
-          call glissade_stagger(&
-               ewn,                 nsn,                             &
-               powerlaw_c_icegrid,  model%basal_physics%powerlaw_c,  &
-               ice_mask = ice_mask,                                  &
-               stagger_margin_in = 1)
-
-       endif   ! first call after restart
+       endif   ! time = tstart
 
     endif   ! enable_glaciers with inversion
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -4060,8 +4060,8 @@ contains
     use glissade_bmlt_float, only: glissade_bmlt_float_thermal_forcing
     use glissade_inversion, only: verbose_inversion, glissade_inversion_basal_friction,  &
          glissade_inversion_bmlt_basin, glissade_inversion_deltaT_ocn, &
-         glissade_inversion_flow_enhancement_factor, &
-         usrf_to_thck
+         glissade_inversion_flow_enhancement_factor
+    use glissade_utils, only: glissade_usrf_to_thck
     use glissade_glacier, only: glissade_glacier_inversion
 
     implicit none
@@ -4390,7 +4390,7 @@ contains
           ! Given the surface elevation target, compute the thickness target.
           ! This can change in time if the bed topography is dynamic.
 
-          call usrf_to_thck(&
+          call glissade_usrf_to_thck(&
                model%geometry%usrf_obs,  &
                model%geometry%topg,      &
                model%climate%eus,        &
@@ -4464,7 +4464,7 @@ contains
           ! Given the surface elevation target, compute the thickness target.
           ! This can change in time if the bed topography is dynamic.
 
-          call usrf_to_thck(&
+          call glissade_usrf_to_thck(&
                model%geometry%usrf_obs,  &
                model%geometry%topg,      &
                model%climate%eus,        &

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1984,11 +1984,11 @@ contains
             (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref(:,:)) * model%climate%t_lapse
        if (verbose_glacier .and. this_rank == rtest) then
           i = itest; j = jtest
-          print*, ' '
-          print*, 'rank, i, j, usrf_ref, usrf, dz:', this_rank, i, j, &
-               model%climate%usrf_ref(i,j), model%geometry%usrf(i,j)*thk0, &
-               model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref(i,j)
-          print*, '   artm_ref, artm:', model%climate%artm_ref(i,j), model%climate%artm(i,j)
+!          print*, ' '
+!          print*, 'rank, i, j, usrf_ref, usrf, dz:', this_rank, i, j, &
+!               model%climate%usrf_ref(i,j), model%geometry%usrf(i,j)*thk0, &
+!               model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref(i,j)
+!          print*, '   artm_ref, artm:', model%climate%artm_ref(i,j), model%climate%artm(i,j)
        endif
 
        ! optionally, do the same for an auxiliary field, artm_aux
@@ -1999,11 +1999,12 @@ contains
                (model%geometry%usrf(:,:)*thk0 - model%climate%usrf_ref_aux(:,:)) * model%climate%t_lapse
           if (verbose_glacier .and. this_rank == rtest) then
              i = itest; j = jtest
-             print*, ' '
-             print*, 'rank, i, j, usrf_ref_aux, usrf, dz:', this_rank, i, j, &
-                  model%climate%usrf_ref_aux(i,j), model%geometry%usrf(i,j)*thk0, &
-                  model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref_aux(i,j)
-             print*, '   artm_ref_aux, artm_aux:', model%climate%artm_ref_aux(i,j), model%climate%artm_aux(i,j)
+!             print*, ' '
+!             print*, 'rank, i, j, usrf_ref_aux, usrf, dz:', this_rank, i, j, &
+!                  model%climate%usrf_ref_aux(i,j), model%geometry%usrf(i,j)*thk0, &
+!                  model%geometry%usrf(i,j)*thk0 - model%climate%usrf_ref_aux(i,j)
+!             print*, '   artm_ref_aux, artm_aux:', model%climate%artm_ref_aux(i,j), &
+!                  model%climate%artm_aux(i,j)
           endif
        endif
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -307,7 +307,8 @@ contains
     ! An exception is dimension glacierid, whose length (nglacier) is computed internally by CISM.
     ! On restart, we can get the length from the restart file.
 
-    if (model%options%enable_glaciers .and. model%options%is_restart == RESTART_TRUE) then
+    if (model%options%enable_glaciers .and. &
+         model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) then
        infile => model%funits%in_first   ! assume glacierid is a dimension in the restart file
        call glimmer_nc_get_dimlength(infile, 'glacierid', model%glacier%nglacier)
     endif
@@ -446,7 +447,7 @@ contains
     !  (usrf - thck > topg), but the ice is above flotation thickness.
     ! In these grid cells, we set thck = usrf - topg, preserving the input usrf and removing the lakes.
 
-    if (model%options%adjust_input_thickness .and. model%options%is_restart == RESTART_FALSE) then
+    if (model%options%adjust_input_thickness .and. model%options%is_restart == NO_RESTART) then
        call glissade_adjust_thickness(model)
     endif
 
@@ -454,19 +455,19 @@ contains
     ! This subroutine does not change the topg, but returns thck consistent with the new usrf.
     ! If the initial usrf is rough, then multiple smoothing passes may be needed to stabilize the flow.
 
-    if (model%options%smooth_input_usrf .and. model%options%is_restart == RESTART_FALSE) then
+    if (model%options%smooth_input_usrf .and. model%options%is_restart == NO_RESTART) then
        call glissade_smooth_usrf(model, nsmooth = 5)
     endif   ! smooth_input_usrf
 
     ! Optionally, smooth the input topography with a Laplacian smoother.
 
-    if (model%options%smooth_input_topography .and. model%options%is_restart == RESTART_FALSE) then
+    if (model%options%smooth_input_topography .and. model%options%is_restart == NO_RESTART) then
        call glissade_smooth_topography(model)
     endif   ! smooth_input_topography
 
     ! Optionally, adjust the input topography in a specified region
 
-    if (model%options%adjust_input_topography .and. model%options%is_restart == RESTART_FALSE) then
+    if (model%options%adjust_input_topography .and. model%options%is_restart == NO_RESTART) then
        call glissade_adjust_topography(model)
     endif
 
@@ -680,7 +681,7 @@ contains
                'Setting artm_anomaly = constant value (degC):', model%climate%artm_anomaly_const
           call write_log(trim(message))
        else
-          if (model%options%is_restart == RESTART_FALSE) then
+          if (model%options%is_restart == NO_RESTART) then
              call write_log('Setting artm_anomaly from external file')
           endif
        endif
@@ -839,7 +840,7 @@ contains
     ! Note: This option is designed for standalone runs, and should be used only with caution for coupled runs.
     !       On restart, overwrite_acab_mask is read from the restart file.
 
-    if (model%climate%overwrite_acab_value /= 0 .and. model%options%is_restart == RESTART_FALSE) then
+    if (model%climate%overwrite_acab_value /= 0 .and. model%options%is_restart == NO_RESTART) then
 
        call glissade_overwrite_acab_mask(model%options%overwrite_acab,          &
                                          model%climate%acab,                    &
@@ -909,7 +910,7 @@ contains
     ! Note: Do initial calving only for a cold start with evolving ice, not for a restart
     if (l_evolve_ice .and. &
          model%options%calving_init == CALVING_INIT_ON .and. &
-         model%options%is_restart == RESTART_FALSE) then
+         model%options%is_restart == NO_RESTART) then
 
        ! ------------------------------------------------------------------------
        ! Note: The initial calving solve is treated differently from the runtime calving solve.
@@ -934,7 +935,7 @@ contains
 
     ! Initialize the effective pressure calculation
 
-    if (model%options%is_restart == RESTART_FALSE) then
+    if (model%options%is_restart == NO_RESTART) then
        call glissade_init_effective_pressure(model%options%which_ho_effecpress,  &
                                              model%basal_physics)
     endif
@@ -943,7 +944,7 @@ contains
     ! Note: This can set powerlaw_c and coulomb_c to nonzero values when they are never used,
     !       but is simpler than checking all possible basal friction options.
 
-    if (model%options%is_restart == RESTART_FALSE) then
+    if (model%options%is_restart == NO_RESTART) then
        if (model%options%which_ho_powerlaw_c == HO_POWERLAW_C_CONSTANT) then
           model%basal_physics%powerlaw_c = model%basal_physics%powerlaw_c_const
        endif
@@ -1071,7 +1072,7 @@ contains
     endif  ! thickness-based calving
 
     if ((model%options%whichcalving == CALVING_GRID_MASK .or. model%options%apply_calving_mask)  &
-         .and. model%options%is_restart == RESTART_FALSE) then
+         .and. model%options%is_restart == NO_RESTART) then
 
        ! Initialize the no-advance calving_mask
        ! Note: This is done after initial calving, which may include iceberg removal or calving-front culling.
@@ -1154,7 +1155,7 @@ contains
        !TODO: Is dthck_dt_obs needed in the restart file after dthck_dt_obs_basin is computed?
 
        if (model%options%enable_acab_dthck_dt_correction .and. &
-           model%options%is_restart == RESTART_FALSE) then
+           model%options%is_restart == NO_RESTART) then
 
           allocate(dthck_dt_basin(model%ocean_data%nbasin))
 
@@ -4326,8 +4327,8 @@ contains
 
     ! Compute the thickness tendency dH/dt from one step to the next (m/s)
     ! This tendency is used for coulomb_c and powerlaw_c inversion.
-    if ( (model%options%is_restart == RESTART_TRUE) .and. &
-         (model%numerics%time == model%numerics%tstart) ) then
+    if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+         .and. (model%numerics%time == model%numerics%tstart) ) then
        ! first call after a restart; do not compute dthck_dt
     else
        model%geometry%dthck_dt(:,:) = (model%geometry%thck(:,:) - model%geometry%thck_old(:,:)) * thk0 &
@@ -4348,8 +4349,8 @@ contains
          model%options%which_ho_coulomb_c  == HO_COULOMB_C_INVERSION  .or. &
          model%options%which_ho_coulomb_c  == HO_COULOMB_C_EXTERNAL ) then
 
-       if ( (model%options%is_restart == RESTART_TRUE) .and. &
-            (model%numerics%time == model%numerics%tstart) ) then
+       if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+            .and. (model%numerics%time == model%numerics%tstart) ) then
           ! first call after a restart; do not update powerlaw_c or coulomb_c
        else
           call glissade_inversion_basal_friction(model)
@@ -4361,8 +4362,9 @@ contains
 
     if ( model%options%which_ho_bmlt_basin == HO_BMLT_BASIN_INVERSION) then
 
-       if ( (model%options%is_restart == RESTART_TRUE) .and. &
-            (model%numerics%time == model%numerics%tstart) ) then
+       if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+            .and. (model%numerics%time == model%numerics%tstart) ) then
+
           ! first call after a restart; do not update basin-scale melting parameters
 
        else
@@ -4391,8 +4393,9 @@ contains
 
     if ( model%options%which_ho_deltaT_ocn == HO_DELTAT_OCN_INVERSION) then
 
-       if ( (model%options%is_restart == RESTART_TRUE) .and. &
-            (model%numerics%time == model%numerics%tstart) ) then
+       if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+            .and. (model%numerics%time == model%numerics%tstart) ) then
+
           ! first call after a restart; do not update deltaT_ocn
 
        else
@@ -4465,8 +4468,9 @@ contains
 
     if ( model%options%which_ho_flow_enhancement_factor == HO_FLOW_ENHANCEMENT_FACTOR_INVERSION) then
 
-       if ( (model%options%is_restart == RESTART_TRUE) .and. &
-            (model%numerics%time == model%numerics%tstart) ) then
+       if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+            .and. (model%numerics%time == model%numerics%tstart) ) then
+
           ! first call after a restart; do not update basin-scale parameters
 
        else
@@ -4664,8 +4668,8 @@ contains
     ! Do not solve velocity for initial time on a restart because that breaks an exact restart.
     ! Note: model%numerics%tstart is the time of restart, not necessarily the value of tstart in the config file.
 
-    if ( (model%options%is_restart == RESTART_TRUE) .and. &
-         (model%numerics%time == model%numerics%tstart) ) then
+    if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+         .and. (model%numerics%time == model%numerics%tstart) ) then
   
        ! Do not solve for velocity, because this would break exact restart
 
@@ -4869,8 +4873,8 @@ contains
     ! These are used for some calving schemes.
     !TODO - Put these calculations in a utility subroutine
 
-    if ( (model%options%is_restart == RESTART_TRUE) .and. &
-         (model%numerics%time == model%numerics%tstart) ) then
+    if ( (model%options%is_restart == STANDARD_RESTART .or. model%options%is_restart == HYBRID_RESTART) &
+         .and. (model%numerics%time == model%numerics%tstart) ) then
 
        ! do nothing, since the tau eigenvalues are read from the restart file
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -117,6 +117,7 @@ contains
     use glissade_basal_traction, only: glissade_init_effective_pressure
     use glissade_bmlt_float, only: glissade_bmlt_float_thermal_forcing_init, verbose_bmlt_float
     use glissade_grounding_line, only: glissade_grounded_fraction
+    use glissade_glacier, only: glissade_glacier_init
     use glissade_utils, only: glissade_adjust_thickness, glissade_smooth_usrf, &
          glissade_smooth_topography, glissade_adjust_topography
     use glissade_utils, only: glissade_stdev, glissade_basin_average
@@ -414,7 +415,7 @@ contains
     ! Write projection info to log
     call glimmap_printproj(model%projection)
 
-    ! Optionally, adjust the input ice thickness is grid cells where there are interior lakes
+    ! Optionally, adjust the input ice thickness in grid cells where there are interior lakes
     !  (usrf - thck > topg), but the ice is above flotation thickness.
     ! In these grid cells, we set thck = usrf - topg, preserving the input usrf and removing the lakes.
 
@@ -506,6 +507,11 @@ contains
 
     ! Compute the cell areas of the grid
     model%geometry%cell_area = model%numerics%dew*model%numerics%dns
+
+    ! If running with glaciers, then process the input glacier data
+    if (model%options%enable_glaciers .and. model%options%is_restart == RESTART_FALSE) then
+       call glissade_glacier_init(model)
+    endif
 
     ! If a 2D bheatflx field is present in the input file, it will have been written 
     !  to model%temper%bheatflx.  For the case model%options%gthf = 0, we want to use

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -646,6 +646,28 @@ contains
     model%climate%artm_corrected(:,:) = model%climate%artm(:,:)
 
     if (model%options%enable_artm_anomaly) then
+
+       ! Check whether artm_anomaly was read from an external file.
+       ! If so, then use this field as the anomaly.
+       ! If not, then set artm_anomaly = artm_anomaly_constant everywhere.
+       ! Note: The artm_anomaly field does not change during the run,
+       !       but it is possible to ramp in the anomaly using artm_anomaly_timescale.
+       ! TODO - Write a short utility function to compute global_maxval of any field.
+
+       local_maxval = maxval(abs(model%climate%artm_anomaly))
+       global_maxval = parallel_reduce_max(local_maxval)
+       if (global_maxval < eps11) then
+          model%climate%artm_anomaly = model%climate%artm_anomaly_const
+          write(message,*) &
+               'Setting artm_anomaly = constant value (degC):', model%climate%artm_anomaly_const
+          call write_log(trim(message))
+       else
+          print*, 'global_maxval(artm_anomaly) =', global_maxval  !WHL - debug
+          if (model%options%is_restart == RESTART_FALSE) then
+             call write_log('Setting artm_anomaly from external file')
+          endif
+       endif
+
        call glissade_add_2d_anomaly(model%climate%artm_corrected,          &   ! degC
                                     model%climate%artm_anomaly,            &   ! degC
                                     model%climate%artm_anomaly_timescale,  &   ! yr
@@ -1922,37 +1944,6 @@ contains
 
     call t_startf('glissade_thermal_solve')
 
-    ! Optionally, add an anomaly to the surface air temperature
-    ! Typically, artm_corrected = artm, but sometimes (e.g., for ISMIP6 forcing experiments),
-    !  it includes a time-dependent anomaly.
-    ! Note that artm itself does not change in time.
-
-    ! initialize
-    model%climate%artm_corrected(:,:) = model%climate%artm(:,:)
-
-    if (model%options%enable_artm_anomaly) then
-
-       ! Note: When being ramped up, the anomaly is not incremented until after the final time step of the year.
-       !       This is the reason for passing the previous time to the subroutine.
-       previous_time = model%numerics%time - model%numerics%dt * tim0/scyr
-
-       call glissade_add_2d_anomaly(model%climate%artm_corrected,          &   ! degC
-                                    model%climate%artm_anomaly,            &   ! degC
-                                    model%climate%artm_anomaly_timescale,  &   ! yr
-                                    previous_time)                             ! yr
-
-       if (verbose_glissade .and. this_rank==rtest) then
-          i = itest
-          j = jtest
-          print*, 'i, j, previous_time, artm, artm anomaly, corrected artm (deg C):', &
-               i, j, previous_time, model%climate%artm(i,j), model%climate%artm_anomaly(i,j), &
-               model%climate%artm_corrected(i,j)
-       endif
-
-    endif
-
-    if (main_task .and. verbose_glissade) print*, 'Call glissade_therm_driver'
-
     ! Downscale artm to the current surface elevation if needed.
     ! Depending on the value of artm_input_function, artm might be dependent on the upper surface elevation.
     ! The options are:
@@ -2003,6 +1994,37 @@ contains
     endif   ! artm_input_function
 
     call parallel_halo(model%climate%artm, parallel)
+
+    ! Optionally, add an anomaly to the surface air temperature
+    ! Typically, artm_corrected = artm, but sometimes (e.g., for ISMIP6 forcing experiments),
+    !  it includes a time-dependent anomaly.
+    ! Note that artm itself does not change in time, unless it is elevation-dependent..
+
+    ! initialize
+    model%climate%artm_corrected(:,:) = model%climate%artm(:,:)
+
+    if (model%options%enable_artm_anomaly) then
+
+       ! Note: When being ramped up, the anomaly is not incremented until after the final time step of the year.
+       !       This is the reason for passing the previous time to the subroutine.
+       previous_time = model%numerics%time - model%numerics%dt * tim0/scyr
+
+       call glissade_add_2d_anomaly(model%climate%artm_corrected,          &   ! degC
+                                    model%climate%artm_anomaly,            &   ! degC
+                                    model%climate%artm_anomaly_timescale,  &   ! yr
+                                    previous_time)                             ! yr
+
+       if (verbose_glissade .and. this_rank==rtest) then
+          i = itest
+          j = jtest
+          print*, 'i, j, previous_time, artm, artm anomaly, corrected artm (deg C):', &
+               i, j, previous_time, model%climate%artm(i,j), model%climate%artm_anomaly(i,j), &
+               model%climate%artm_corrected(i,j)
+       endif
+
+    endif
+
+    if (main_task .and. verbose_glissade) print*, 'Call glissade_therm_driver'
 
     ! Note: glissade_therm_driver uses SI units
     !       Output arguments are temp, waterfrac, bpmp and bmlt_ground
@@ -2804,7 +2826,7 @@ contains
                model%glacier%cism_glacier_id,          &
                model%glacier%t_mlt,                    &  ! deg C
                model%climate%snow,                     &  ! mm/yr w.e.
-               model%climate%artm,                     &  ! deg C
+               model%climate%artm_corrected,           &  ! deg C
                model%glacier%mu_star,                  &  ! mm/yr w.e./deg
                model%climate%smb)                         ! mm/yr w.e.
 

--- a/libglissade/glissade_basal_traction.F90
+++ b/libglissade/glissade_basal_traction.F90
@@ -145,6 +145,7 @@ contains
 
   ! variables for Coulomb friction law
   real(dp) :: coulomb_c   ! Coulomb law friction coefficient (unitless)
+  real(dp) :: powerlaw_c_const  ! power law friction coefficient (Pa m^{-1/3} yr^{1/3})
   real(dp) :: lambda_max        ! wavelength of bedrock bumps at subgrid scale (m)
   real(dp) :: m_max             ! maximum bed obstacle slope (unitless)
   real(dp) :: m                 ! exponent m in power law
@@ -210,6 +211,7 @@ contains
                                   basal_physics%coulomb_c_bedmin,  &
                                   basal_physics%coulomb_c_bedmax,  &
                                   basal_physics%coulomb_c)
+
   endif
 
   ! Compute beta based on whichbabc

--- a/libglissade/glissade_bmlt_float.F90
+++ b/libglissade/glissade_bmlt_float.F90
@@ -567,7 +567,7 @@ module glissade_bmlt_float
 
     endif  ! simple_init
 
-    if (model%options%is_restart == RESTART_FALSE) then
+    if (model%options%is_restart == NO_RESTART) then
 
        if (model%options%bmlt_float_thermal_forcing_param == BMLT_FLOAT_TF_ISMIP6_LOCAL .or.  &
            model%options%bmlt_float_thermal_forcing_param == BMLT_FLOAT_TF_ISMIP6_NONLOCAL .or. &

--- a/libglissade/glissade_glacier.F90
+++ b/libglissade/glissade_glacier.F90
@@ -24,12 +24,25 @@
 !
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+!TODO:
+! Set options for repeatedly reading the monthly climatological forcing
+! Put a glacier section in the config file.
+! Add restart logic in glissade_glacier_init.
+! Decide on the list of glacier restart fields:
+!    rgi_glacier_id, cism_glacier_id, glacier_area_target, glacier_volume_target,
+!    glacier_mu_star, glacier_powerlaw_c
+! What about nglacier?  Diagnose from size of restart arrays?
+! What about ngdiag? Recompute?
+! What about cism_to_rgi_glacier_id?  Recompute?
+! What about array allocation?
+
 module glissade_glacier
 
     ! Subroutines for glacier tuning and tracking
 
     use glimmer_global 
     use glimmer_paramets, only: thk0, len0
+    use glimmer_physcon, only: scyr
     use glide_types
     use glimmer_log
     use cism_parallel, only: main_task, this_rank, nhalo
@@ -37,7 +50,8 @@ module glissade_glacier
     implicit none
 
     private
-    public :: glissade_glacier_init
+    public :: verbose_glacier, glissade_glacier_init, &
+         glissade_glacier_smb, glissade_glacier_inversion
 
     logical, parameter :: verbose_glacier = .true.
 
@@ -58,33 +72,35 @@ contains
     ! If running on multiple disconnected glacier regions, this routine should be called once per region.
     !TODO: One set of logic for init, another for restart
 
-    ! One key task is to create one-to-one maps between the input glacier_id array (typically with RGI IDs)
-    !  and a local array called glacier_id_cism.  The local array assigns to each grid cell
-    !  a number between 1 and nglacier where nglacier is the total number of unique glacier IDs.
+    ! One key task is to create maps between input RGI glacier IDs (in the rgi_glacier_id array)
+    !  and an array called cism_glacier_id.
+    ! The cism_glacier_id array assigns to each grid cell (i,j) a number between 1 and nglacier,
+    !  where nglacier is the total number of unique glacier IDs.
     ! This allows us to loop over IDs in the range (1:nglacier), which is more efficient than
-    !  looping over input glacier IDs.  The input IDs typically have large gaps.
+    !  looping over the input glacier IDs, which often have large gaps.
 
     use cism_parallel, only: distributed_gather_var, distributed_scatter_var, &
-         parallel_reduce_sum, broadcast, parallel_halo 
+         parallel_reduce_sum, broadcast, parallel_halo
+
+    use cism_parallel, only: parallel_barrier  !WHL - debug
 
     type(glide_global_type),intent(inout) :: model
 
     ! local variables
-    integer :: ewn, nsn, global_ewn, global_nsn
-    integer :: itest, jtest, rtest   ! coordinates of diagnostic point
+    integer :: ewn, nsn               ! local grid dimensions
+    integer :: global_ewn, global_nsn ! global grid dimensions
+    integer :: itest, jtest, rtest    ! coordinates of diagnostic point
+    real(dp) :: dew, dns              ! grid cell length in each direction (m)
 
     ! temporary global arrays
     integer, dimension(:,:), allocatable :: &
-         glacier_id_global,         & ! global array of the input glacier ID; maps (i,j) to RGI ID
-         glacier_id_cism_global       ! global array of the CISM glacier ID; maps (i,j) to CISM glacier ID
+         rgi_glacier_id_global,     & ! global array of the input RGI glacier ID; maps (i,j) to RGI ID
+         cism_glacier_id_global       ! global array of the CISM glacier ID; maps (i,j) to CISM glacier ID
 
     type(glacier_info), dimension(:), allocatable :: & 
          glacier_list                 ! sorted list of glacier IDs with i and j indices
 
-    ! The next three arrays will have dimension (nglacier), once nglacier is computed
-!!    integer, dimension(:), allocatable :: &
-!!         cism_to_glacier_id           ! maps CISM ID (1:nglacier) to input glacier_id
-
+    ! The next two arrays will have dimension (nglacier), once nglacier is computed
     real(dp), dimension(:), allocatable :: &
          local_area,                & ! area per glacier (m^2)
          local_volume                 ! volume per glacier (m^3)
@@ -100,11 +116,11 @@ contains
     integer :: i, j, nc, ng, count
 
     !WHL - debug
-    integer, dimension(:), allocatable :: test_list
-    integer ::  nlist
-    real(sp) :: random
+!    integer, dimension(:), allocatable :: test_list
+!    integer ::  nlist
+!    real(sp) :: random
 
-    if (verbose_glacier .and. main_task) then
+    if (verbose_glacier .and. this_rank == rtest) then
        print*, ' '
        print*, 'In glissade_glacier_init'
     endif
@@ -112,66 +128,55 @@ contains
     parallel = model%parallel
     global_ewn = parallel%global_ewn
     global_nsn = parallel%global_nsn
-
     ewn = model%general%ewn
     nsn = model%general%nsn
+    dew = model%numerics%dew
+    dns = model%numerics%dns
 
     ! get coordinates of diagnostic point
-    rtest = -999
-    itest = 1
-    jtest = 1
-    if (this_rank == model%numerics%rdiag_local) then
-       rtest = model%numerics%rdiag_local
-       itest = model%numerics%idiag_local
-       jtest = model%numerics%jdiag_local
-    endif
-
-    ! debug - scatter test
-!    if (main_task) print*, 'Scatter glacier_id_cism'
-!    allocate(glacier_id_cism_global(global_ewn,global_nsn))
-!    glacier_id_cism_global = 0
-!    model%glacier%glacier_id_cism = 0
-!    call distributed_scatter_var(model%glacier%glacier_id_cism, glacier_id_cism_global, parallel)
-!    if (main_task) print*, 'Successful scatter'
-!    if (allocated(glacier_id_cism_global)) deallocate(glacier_id_cism_global)
-
-    ! Gather glacier IDs to the main task
-
-    allocate(glacier_id_global(global_ewn, global_nsn))
-    call distributed_gather_var(model%glacier%glacier_id, glacier_id_global, parallel)
-
-    if (verbose_glacier .and. main_task) then
-       print*, ' '
-       print*, 'Gathered glacier IDs to main task'
-       print*, 'size(glacier_id) =', size(model%glacier%glacier_id,1), size(model%glacier%glacier_id,2)
-       print*, 'size(glacier_id_global) =', size(glacier_id_global,1), size(glacier_id_global,2)
-    endif
+    rtest = model%numerics%rdiag_local
+    itest = model%numerics%idiag_local
+    jtest = model%numerics%jdiag_local
 
     if (verbose_glacier .and. this_rank == rtest) then
        i = itest
        j = jtest
        print*, ' '
-       print*, 'Glacier ID, rtest, itest, jtest:', rtest, itest, jtest
+       print*, 'RGI glacier ID, rtest, itest, jtest:', rtest, itest, jtest
        do j = jtest+3, jtest-3, -1
           write(6,'(i6)',advance='no') j
           do i = itest-3, itest+3
-             write(6,'(i10)',advance='no') model%glacier%glacier_id(i,j)
+             write(6,'(i10)',advance='no') model%glacier%rgi_glacier_id(i,j)
           enddo
           write(6,*) ' '
        enddo
     endif
 
+    ! Arrays in the glacier derived type may have been allocated with dimension(1).
+    ! If so, then deallocate here, and reallocate below with dimension (nglacier).
+    ! Typically, nglacier is not known until after initialization.
+
+    if (associated(model%glacier%glacierid)) deallocate(model%glacier%glacierid)
+    if (associated(model%glacier%cism_to_rgi_glacier_id)) &
+         deallocate(model%glacier%cism_to_rgi_glacier_id)
+    if (associated(model%glacier%area)) deallocate(model%glacier%area)
+    if (associated(model%glacier%volume)) deallocate(model%glacier%volume)
+    if (associated(model%glacier%area_target)) deallocate(model%glacier%area_target)
+    if (associated(model%glacier%volume_target)) deallocate(model%glacier%volume_target)
+    if (associated(model%glacier%dvolume_dt)) deallocate(model%glacier%dvolume_dt)
+    if (associated(model%glacier%mu_star)) deallocate(model%glacier%mu_star)
+    if (associated(model%glacier%powerlaw_c)) deallocate(model%glacier%powerlaw_c)
+
     ! Count the number of cells with glaciers
+    ! Loop over locally owned cells
 
     count = 0
-
-    ! Loop over locally owned cells
     do j = nhalo+1, nsn-nhalo
        do i = nhalo+1, ewn-nhalo
-          if (model%glacier%glacier_id(i,j) > 0) then
+          if (model%glacier%rgi_glacier_id(i,j) > 0) then
              count = count + 1
-          elseif (model%glacier%glacier_id(i,j) < 0) then  ! should not happen
-             print*, 'glacier_id < 0: i, j, value =', i, j, model%glacier%glacier_id(i,j)
+          elseif (model%glacier%rgi_glacier_id(i,j) < 0) then  ! should not happen
+             print*, 'glacier_id < 0: i, j, value =', i, j, model%glacier%rgi_glacier_id(i,j)
              stop   ! TODO - exit gracefully
           endif
        enddo
@@ -179,19 +184,33 @@ contains
 
     ncells_glacier = parallel_reduce_sum(count)
 
-    ! Allocate a global array on the main task only.
-    ! On other tasks, allocate a size 0 array, since distributed_scatter_var wants arrays allocated on all tasks.
+    ! Gather the RGI glacier IDs to the main task
+    if (main_task) allocate(rgi_glacier_id_global(global_ewn, global_nsn))
+    call distributed_gather_var(model%glacier%rgi_glacier_id, rgi_glacier_id_global, parallel)
+
+    ! Allocate a global array for the CISM glacier IDs on the main task..
+    ! Allocate a size 0 array on other tasks; distributed_scatter_var wants arrays allocated on all tasks.                   
+
     if (main_task) then
-       allocate(glacier_id_cism_global(global_ewn,global_nsn))
-       glacier_id_cism_global(:,:) = 0.0d0
+       allocate(cism_glacier_id_global(global_ewn,global_nsn))
     else
-       allocate(glacier_id_cism_global(0,0))
+       allocate(cism_glacier_id_global(0,0))
+    endif
+    cism_glacier_id_global(:,:) = 0.0d0
+
+    if (verbose_glacier .and. main_task) then
+       print*, ' '
+       print*, 'Gathered RGI glacier IDs to main task'
+       print*, 'size(rgi_glacier_id) =', &
+            size(model%glacier%rgi_glacier_id,1), size(model%glacier%rgi_glacier_id,2)
+       print*, 'size(rgi_glacier_id_global) =', &
+            size(rgi_glacier_id_global,1), size(rgi_glacier_id_global,2)
     endif
 
     if (main_task) then
 
-       gid_minval = minval(glacier_id_global)
-       gid_maxval = maxval(glacier_id_global)
+       gid_minval = minval(rgi_glacier_id_global)
+       gid_maxval = maxval(rgi_glacier_id_global)
 
        if (verbose_glacier) then
           print*, 'Total ncells   =', global_ewn * global_nsn
@@ -211,22 +230,23 @@ contains
 
        do j = 1, global_nsn
           do i = 1, global_ewn
-             if (glacier_id_global(i,j) > 0) then
+             if (rgi_glacier_id_global(i,j) > 0) then
                 count = count + 1
-                glacier_list(count)%id = glacier_id_global(i,j)
+                glacier_list(count)%id = rgi_glacier_id_global(i,j)
                 glacier_list(count)%indxi = i
                 glacier_list(count)%indxj = j
              endif
           enddo
        enddo
 
-       deallocate(glacier_id_global)  ! no longer needed after glacier_list is built
+       ! Deallocate the RGI global array (no longer needed after glacier_list is built)
+       deallocate(rgi_glacier_id_global)  
 
        ! Sort the list from low to high IDs.
        ! As the IDs are sorted, the i and j indices come along for the ride.
        ! When there are multiple cells with the same glacier ID, these cells are adjacent on the list.
        ! For example, suppose the initial list is (5, 9, 7, 6, 7, 10, 4, 1, 1, 3, 1).
-       ! The sorted list would be (1, 1, 1, 3, 5, 7, 7, 7, 9, 10).
+       ! The sorted list would be (1, 1, 1, 3, 4, 5, 6, 7, 7, 9, 10).
 
        call glacier_quicksort(glacier_list, 1, ncells_glacier)
 
@@ -255,8 +275,7 @@ contains
 !       call quicksort(test_list, 1, nlist)
 !       print*, 'Sorted list:', test_list(:)
 
-       ! Now that the glacier IDs are sorted from low to high,
-       ! it is easy to count the total number of glaciers
+       ! Now that the glacier IDs are sorted from low to high, count the glaciers
 
        nglacier = 0
        current_id = 0
@@ -269,21 +288,22 @@ contains
 
        model%glacier%nglacier = nglacier
 
-       ! Create two useful arrays:
-       ! (1) The cism_to_glacier_id array maps the CISM ID (between 1 and nglacier) to the input glacier_id.
-       ! (2) The glacier_id_cism array maps each glaciated grid cell (i,j) to a CISM ID.
-       ! The reason to carry around i and j in the sorted glacier_list is to efficienly fill glacier_id_cism.
-       ! Note: cism_to_glacier_id is part of the glacier derived type, but cannot be allocate until nglacier is known.
+       ! Fill two useful arrays:
+       ! (1) The cism_to_rgi_glacier_id array maps the CISM ID (between 1 and nglacier) to the RGI glacier_id.
+       ! (2) The cism_glacier_id array maps each glaciated grid cell (i,j) to a CISM ID.
+       ! By carrying i and j in the sorted glacier_list, we can efficiently fill cism_glacier_id.
+       ! Note: cism_to_rgi_glacier_id cannot be allocated until nglacier is known.
 
-       allocate(model%glacier%cism_to_glacier_id(nglacier))
-       model%glacier%cism_to_glacier_id(:) = 0
+       allocate(model%glacier%cism_to_rgi_glacier_id(nglacier))
+       model%glacier%cism_to_rgi_glacier_id(:) = 0
 
        if (verbose_glacier) then
           print*, ' '
           print*, 'Counted glaciers: nglacier =', nglacier
           print*, ' '
-          print*, 'Pick a glacier: ng =',  nglacier/2
-          print*, 'icell, i, j, glacier_id_cism_global(i,j), cism_to_glacier_id(ng)'
+          ng = nglacier/2
+          print*, 'Random cism_glacier_id:', ng
+          print*, 'icell, i, j, cism_glacier_id_global(i,j), cism_to_rgi_glacier_id(ng)'
        endif
 
        ng = 0
@@ -292,7 +312,7 @@ contains
           if (glacier_list(nc)%id > current_id) then
              ng = ng + 1
              current_id = glacier_list(nc)%id
-             model%glacier%cism_to_glacier_id(ng) = glacier_list(nc)%id
+             model%glacier%cism_to_rgi_glacier_id(ng) = glacier_list(nc)%id
           endif
           i = glacier_list(nc)%indxi
           j = glacier_list(nc)%indxj
@@ -300,9 +320,9 @@ contains
              print*, 'Warning: zeroes, ng, i, j, id =', ng, i, j, glacier_list(nc)%id
              stop   ! TODO - exit gracefully
           endif
-          glacier_id_cism_global(i,j) = ng
+          cism_glacier_id_global(i,j) = ng
           if (ng == nglacier/2) then   ! random glacier
-             print*, nc, i, j, glacier_id_cism_global(i,j), model%glacier%cism_to_glacier_id(ng)
+             print*, nc, i, j, cism_glacier_id_global(i,j), model%glacier%cism_to_rgi_glacier_id(ng)
           endif
           if (ng > nglacier) then
              print*, 'ng > nglacier, nc, i, j , ng =', nc, i, j, ng
@@ -314,88 +334,669 @@ contains
 
        if (verbose_glacier) then
           print*, ' '
-          print*, 'maxval(cism_to_glacier_id) =', maxval(model%glacier%cism_to_glacier_id) 
-          print*, 'maxval(glacier_id_cism_global) =', maxval(glacier_id_cism_global)
+          print*, 'maxval(cism_to_rgi_glacier_id) =', maxval(model%glacier%cism_to_rgi_glacier_id)
+          print*, 'maxval(cism_glacier_id_global) =', maxval(cism_glacier_id_global)
        endif
 
     endif   ! main_task
 
-    ! Communicate glacier info from the main task to all processors
+    ! Scatter cism_glacier_id_global to all processors
+    ! Note: This global array is deallocated in the distributed_scatter_var subroutine
 
-    if (verbose_glacier .and. main_task) print*, 'Broadcast nglacier and cism_to_glacier_id'
+    if (verbose_glacier .and. main_task) print*, 'Scatter cism_glacier_id'
+    call distributed_scatter_var(model%glacier%cism_glacier_id, cism_glacier_id_global, parallel)
+    call parallel_halo(model%glacier%cism_glacier_id, parallel)
+
+    ! Broadcast glacier info from the main task to all processors
+
+    if (verbose_glacier .and. main_task) print*, 'Broadcast nglacier and cism_to_rgi_glacier_id'
     call broadcast(model%glacier%nglacier)
     nglacier = model%glacier%nglacier
 
-    if (.not.associated(model%glacier%cism_to_glacier_id)) &
-         allocate(model%glacier%cism_to_glacier_id(nglacier))
-    call broadcast(model%glacier%cism_to_glacier_id)
+    if (.not.associated(model%glacier%cism_to_rgi_glacier_id)) &
+         allocate(model%glacier%cism_to_rgi_glacier_id(nglacier))
+    call broadcast(model%glacier%cism_to_rgi_glacier_id)
 
-    if (verbose_glacier .and. main_task) print*, 'Scatter glacier_id_cism'
-    ! Note: glacier_id_cism_global is deallocated in the subroutine
-    call distributed_scatter_var(model%glacier%glacier_id_cism, glacier_id_cism_global, parallel)
-    call parallel_halo(model%glacier%glacier_id_cism, parallel)
+    ! Set the index of the diagnostic glacier, using the CISM glacier ID for the diagnostic point
+    if (this_rank == rtest) then
+       model%glacier%ngdiag = model%glacier%cism_glacier_id(itest,jtest)
+    endif
+    call broadcast(model%glacier%ngdiag, rtest)
 
-    !TODO - Move area and volume computations to subroutines
+    ! Allocate and fill the glacierid dimension array
+    allocate(model%glacier%glacierid(nglacier))
+    do ng = 1, nglacier
+       model%glacier%glacierid(ng) = ng
+    enddo
 
-    ! Allocate and initialize glacier area and volume
-
+    ! Allocate other arrays with dimension(nglacier)
     allocate(model%glacier%area(nglacier))
     allocate(model%glacier%volume(nglacier))
-    model%glacier%area(:) = 0.0d0
-    model%glacier%volume(:) = 0.0d0
+    allocate(model%glacier%area_target(nglacier))
+    allocate(model%glacier%volume_target(nglacier))
+    allocate(model%glacier%dvolume_dt(nglacier))
+    allocate(model%glacier%mu_star(nglacier))
+    allocate(model%glacier%powerlaw_c(nglacier))
 
+    ! Compute the initial area and volume of each glacier.
+    ! These values will be targets for inversion.
+
+    call glacier_area_volume(&
+         ewn,           nsn,               &
+         nglacier,                         &
+         model%glacier%cism_glacier_id,    &
+         dew*dns*len0**2,                  &
+         model%geometry%thck*thk0,         &
+         model%glacier%area,               &
+         model%glacier%volume)
+
+    ! Initialize the other glacier arrays
+
+    model%glacier%area_target(:) = model%glacier%area(:)
+    model%glacier%volume_target(:) = model%glacier%volume(:)
+    model%glacier%dvolume_dt(:) = 0.0d0
+    model%glacier%mu_star(:) = model%glacier%mu_star_const
+    model%glacier%powerlaw_c(:) = model%basal_physics%powerlaw_c_const
+
+    ! Check for zero A or V target
+    if (main_task) then
+       print*, ' '
+       print*, 'Check for A = 0, V = 0'
+       do ng = 1, nglacier
+          if (model%glacier%area_target(ng) == 0.0d0 .or. &
+              model%glacier%volume_target(ng) == 0.0d0) then
+             print*, 'ng, A (km^2), V (km^3):', &
+                  ng, model%glacier%area_target(ng)/1.0d6, model%glacier%volume_target(ng)/1.0d9
+          endif
+       enddo
+    endif
+
+    if (verbose_glacier .and. main_task) then
+       print*, ' '
+       ng = model%glacier%ngdiag
+       print*, 'Glacier ID for diagnostic cell: r, i, j, ng =', rtest, itest, jtest, ng
+       print*, 'area target (km^2) =', model%glacier%area_target(ng) / 1.0d6
+       print*, 'volume target (km^3) =', model%glacier%volume_target(ng) / 1.0d9
+!!       print*, 'dvolume_dt (km^3/yr) =', model%glacier%dvolume_dt(ng) * scyr/1.0d9
+       print*, 'mu_star (mm/yr w.e./deg) =', model%glacier%mu_star(ng)
+       print*, 'powerlaw_c (Pa (m/yr)^(-1/3)) =', model%glacier%powerlaw_c(ng)
+       print*, 'Done in glissade_glacier_init'
+    endif
+
+  end subroutine glissade_glacier_init
+
+!****************************************************
+
+  subroutine glissade_glacier_smb(&
+       ewn,              nsn,               &
+       itest,   jtest,   rtest,             &
+       nglacier,                            &
+       cism_glacier_id,  mu_star,           &
+       snow,             artm,              &
+       glacier_smb)
+
+    ! Compute the SMB in each grid cell using an empirical relationship
+    !  based on Maussion et al. (2019):
+    !
+    !     SMB = snow - mu_star * max(artm - T_mlt, 0),
+    !
+    ! where snow = monthly mean snowfall rate,
+    !       mu_star is a glacier-specific tuning parameter,
+    !       atrm = monthly mean air temperature,
+    !       Tmlt = monthly mean air temp above which melting occurs
+    !
+    ! This subroutine should be called at least once a month
+    !
+    ! Note: In Maussion et al., SMB and prcp are monthly mass balances in mm w.e.
+    !       Not sure that mu_star should have the same units (though Fig. 3 shows
+    !       units of mm w.e./yr/deg).
+
+    use parallel, only: nhalo, main_task
+
+    ! input/output arguments
+
+    integer, intent(in) ::  &
+         ewn, nsn,                    & ! number of cells in each horizontal direction
+         nglacier,                    & ! total number of glaciers in the domain
+         itest, jtest, rtest            ! coordinates of diagnostic point
+
+    integer, dimension(ewn,nsn), intent(in) ::  &
+         cism_glacier_id                ! integer glacier ID in the range (1, nglacier)
+
+    real(dp), dimension(nglacier), intent(in) :: &
+         mu_star                        ! glacier-specific SMB tuning parameter (mm w.e./yr/deg)
+
+    real(dp), dimension(ewn,nsn), intent(in) :: &
+         snow,                        & ! monthly mean snowfall rate (mm w.e./yr)
+         artm                           ! monthly mean 2m air temperature (deg C)
+
+    real(dp), dimension(ewn,nsn), intent(out) :: &
+         glacier_smb                    ! SMB in each gridcell (mm w.e./yr)
+
+    ! local variables
+
+    integer :: i, j, ng
+
+    real(dp), parameter ::  &
+         glacier_tmlt = -1.0d0          ! artm (deg C) above which melt occurs
+                                        ! Maussion et al. suggest -1 C
+
+    if (verbose_glacier .and. this_rank == rtest) then
+       print*, 'In glissade_glacier_smb'
+    endif
+
+    ! initialize
+    glacier_smb(:,:) = 0.0d0
+
+    if (verbose_glacier .and. this_rank == rtest) then
+       print*, 'Loop'
+       print*, 'minval, maxval(snow) =', minval(snow), maxval(snow)
+       print*, 'minval, maxval(artm) =', minval(artm), maxval(artm)
+    endif
+
+    ! compute SMB
+    do j = 1, nsn
+       do i = 1, ewn
+
+          ng = cism_glacier_id(i,j)
+          glacier_smb(i,j) = &
+               snow(i,j) - mu_star(ng) * max(artm(i,j) - glacier_tmlt, 0.0d0)
+
+          if (verbose_glacier .and. this_rank == rtest .and. i == itest .and. j == jtest) then
+             print*, ' '
+             print*, 'Glacier SMB: rank i, j =', this_rank, i, j
+             print*, '   mu_star (mm/yr w.e./deg) =', mu_star(ng)
+             print*, '   snow (mm/yr w.e.), artm (C) =', snow(i,j), artm(i,j)
+             print*, '   SMB (mm/yr w.e.) =', glacier_smb(i,j)
+          endif
+
+       enddo
+    enddo
+
+    if (verbose_glacier .and. this_rank == rtest) then
+       print*, 'Done in glissade_glacier_smb'
+    endif
+
+  end subroutine glissade_glacier_smb
+
+!****************************************************
+
+  subroutine glissade_glacier_inversion(&
+       glacier_mu_star,                  &
+       glacier_powerlaw_c,               &
+       dt,                               &
+       itest,   jtest,  rtest,           &
+       ewn,             nsn,             &
+       dew,             dns,             &
+       thck,            dthck_dt,        &
+       powerlaw_c_min,  powerlaw_c_max,  &
+       glacier)
+
+    use glimmer_paramets, only: len0, thk0
+    use glimmer_physcon, only: scyr
+
+    real(dp), intent(in) :: &
+         dt,                          & ! time step (s)
+         dew, dns                       ! grid cell dimensions (m)
+
+    integer, intent(in) ::  &
+         glacier_mu_star,             & ! flag for mu_star inversion
+         glacier_powerlaw_c,          & ! flag for powerlaw_c inversion
+         itest, jtest, rtest,         & ! coordinates of diagnostic cell
+         ewn, nsn                       ! number of cells in each horizontal direction
+
+    real(dp), dimension(ewn,nsn), intent(in) ::  &
+         thck,                        & ! ice thickness (m)
+         dthck_dt                       ! rate of change of thickness (m/yr)
+
+    real(dp), intent(in) :: &
+         powerlaw_c_min, powerlaw_c_max ! min and max allowed values of C_p in power law (Pa (m/yr)^(-1/3))
+
+    ! Note: The glacier type includes the following:
+    ! integer ::  nglacier          ! number of glaciers in the global domain
+    ! integer ::  ngdiag            ! CISM index of diagnostic glacier
+    ! integer, dimension(:,:) :: cism_glacier_id  ! CISM glacier ID for each grid cell
+    ! real(dp), dimension(:) :: area          ! glacier area (m^2)
+    ! real(dp), dimension(:) :: volume        ! glacier volume (m^3)
+    ! real(dp), dimension(:) :: dvolume_dt    ! rate of change of glacier volume (m^3/yr)
+    ! real(dp), dimension(:) :: mu_star       ! SMB parameter for each glacier (mm/yr w.e./deg K)
+    ! real(dp) :: mu_star_min, mu_star_max    ! min and max values allowed for mu_star
+    ! real(dp), dimension(:) :: powerlaw_c    ! basal friction parameter for each glacier (Pa (m/yr)^(-1/3))
+
+    type(glide_glacier), intent(inout) :: &
+         glacier       ! glacier derived type
+
+    ! local variables
+
+    integer :: nglacier       ! number of glaciers
+    integer :: ngdiag         ! CISM index of diagnostic glacier
+    integer :: ng
+
+    nglacier = glacier%nglacier
+    ngdiag = glacier%ngdiag
+
+    if (verbose_glacier .and. main_task) then
+       print*, 'In glissade_glacier_inversion, dt (yr) =', dt
+       print*, 'Diag cell (r, i, j) =', rtest, itest, jtest
+       print*, '   thck (m), dthck(dt):', thck(itest, jtest), dthck_dt(itest, jtest)
+       print*, 'call glacier_area_volume'
+    endif
+
+    ! Compute the current area and volume of each glacier
+    ! Note: This requires global sums. For now, do the computation independently on each task.
+
+    call glacier_area_volume(&
+         ewn,           nsn,         &
+         nglacier,                   &
+         glacier%cism_glacier_id,    &
+         dew*dns,                    &  ! m^2
+         thck,                       &  ! m
+         glacier%area,               &  ! m^2
+         glacier%volume,             &  ! m^3
+         dthck_dt,                   &  ! m/yr
+         glacier%dvolume_dt)            ! m^3/yr
+
+    if (verbose_glacier .and. main_task) then
+       print*, ' '
+       print*, 'Update area (km^2) and volume (km^3) for glacier:', ngdiag
+       print*, 'Current area and volume:', glacier%area(ngdiag)/1.0d6, &
+            glacier%volume(ngdiag)/1.0d9
+       print*, '   Target area and volume:', glacier%area_target(ngdiag)/1.0d6, &
+            glacier%volume_target(ngdiag)/1.0d9
+       print*, '   dV_dt (m^3/yr):', glacier%dvolume_dt(ngdiag)/1.0d9
+    endif
+
+    ! Given the current and target glacier areas, invert for mu_star
+
+    if (glacier_mu_star == GLACIER_MU_STAR_INVERSION) then
+
+       if (verbose_glacier .and. main_task) then
+          print*, 'glacier_invert_mu_star'
+       endif
+
+       call glacier_invert_mu_star(&
+            dt,                                         &
+            ewn,                 nsn,                   &
+            nglacier,            ngdiag,                &
+            glacier%mu_star_min, glacier%mu_star_max,   &
+            glacier%area,        glacier%area_target,   &
+            glacier%mu_star)
+
+    endif
+
+    ! Given the current and target glacier volumes, invert for powerlaw_c
+
+    if (glacier_powerlaw_c == GLACIER_POWERLAW_C_INVERSION) then
+
+       if (verbose_glacier .and. main_task) then
+          print*, 'glacier_invert_powerlaw_c'
+       endif
+
+       call glacier_invert_powerlaw_c(&
+            dt,                                         &
+            ewn,                 nsn,                   &
+            nglacier,            ngdiag,                &
+            powerlaw_c_min,      powerlaw_c_max,        &
+            glacier%volume,      glacier%volume_target, &
+            glacier%dvolume_dt,                         &
+            glacier%powerlaw_c)
+
+    endif
+
+    if (verbose_glacier .and. main_task) then
+       print*, 'Done in glacier_glacier_inversion'
+    endif
+
+  end subroutine glissade_glacier_inversion
+
+!****************************************************
+
+  subroutine glacier_invert_mu_star(&
+       dt,                                  &
+       ewn,              nsn,               &
+       nglacier,         ngdiag,            &
+       mu_star_min,      mu_star_max,       &
+       area,             area_target,       &
+       mu_star)
+
+    ! Given the current glacier areas and area targets,
+    ! invert for the parameter mu_star in the glacier SMB formula
+
+    ! Note: This subroutine should be called from main_task only, since it uses
+    !       glacier areas summed over all processors.
+
+    ! input/output arguments
+
+    real(dp), intent(in) :: &
+         dt                             ! timestep (yr)
+
+    integer, intent(in) ::  &
+         ewn, nsn,                    & ! number of cells in each horizontal direction
+         nglacier,                    & ! total number of glaciers in the domain
+         ngdiag                         ! CISM ID of diagnostic glacier
+
+    !TODO - Decide on max and min values.
+    !       Min should be zero; don't want negative values
+
+    real(dp), intent(in) :: &
+         mu_star_min, mu_star_max       ! min and max allowed values of mu_star (mm w.e/yr/deg)
+
+    real(dp), dimension(nglacier), intent(in) :: &
+         area,                        & ! current glacier area (m^2)
+         area_target                    ! area target (m^2)
+
+    ! Note: Here, mu_star_glacier(nglacier) is the value shared by all cells in a given glacier
+    ! The calling subroutine will need to map these values onto each grid cell.
+    real(dp), dimension(nglacier), intent(inout) :: &
+         mu_star                        ! glacier-specific SMB tuning parameter (mm/yr w.e./deg)
+
+    ! local variables
+
+    integer :: ng
+
+    real(dp), parameter :: &
+         glacier_area_timescale = 100.d0  ! timescale (yr)
+
+    real(dp) :: &
+         err_area,                    & ! relative area error, (A - A_target)/A_target
+         term1, term2,                & ! terms in prognostic equation for mu_star
+         dmu_star                       ! change in mu_star
+
+    character(len=100) :: message
+
+    !TODO - Rewrite the comments below.
+    ! I am going to try the inversion without a dA/dt term.
+    ! This is because glacier area is going to change discontinuously
+    !  as a glacier advances into or retreats from a given cell.
+
+    ! The inversion works as follows:
+    ! The change in mu_star is proportional to the current mu_star and to the relative error,
+    !  err_area = (A - A_target)/A_target.
+    ! If err_area > 0, we increase mu_star to make the glacier melt more and retreat.
+    ! If err_area < 0, we reduce mu_star to make the glacier melt less and advance.
+    ! This is done with a characteristic timescale tau.
+    ! We also include a term proportional to dA/dt so that ideally, mu_star smoothly approaches
+    !  the value needed to attain a steady-state A, without oscillating about the desired value.
+    ! See the comments in module glissade_inversion, subroutine invert_basal_friction.
+    ! We should always have mu_star >= 0.
+    ! Maussion et al. (2019) suggest values of roughly 100 to 300 mm w.e./yr/deg,
+    !  but with a wide range.
+    ! (Wondering if values should be higher; seems like we should be able to get ~1000 mm melt
+    !  in 0.1 year with (T - Tmlt) = 10 C.  This would imply mu_star = 1000 mm w.e./yr/deg.
+    ! Here is the prognostic equation:
+    ! dmu/dt = -mu_star * (1/tau) * (A - A_target)/A_target + (2*tau/A_target) * dA/dt
+
+    do ng = 1, nglacier
+
+       if (area_target(ng) > 0.0d0) then  ! this should be the case
+          err_area = (area(ng) - area_target(ng)) / area_target(ng)
+          term1 = -err_area / glacier_area_timescale
+          dmu_star = mu_star(ng) * term1 * dt
+!!          term2 = -2.0d0 * darea_dt(ng) / area_target(ng)
+!!          dmu_star = mu_star(ng) * (term1 + term2) * dt
+
+          ! Limit to prevent a large relative change in one step
+          if (abs(dmu_star) > 0.05d0 * mu_star(ng)) then
+             if (dmu_star > 0.0d0) then
+                dmu_star =  0.05d0 * mu_star(ng)
+             else
+                dmu_star = -0.05d0 * mu_star(ng)
+             endif
+          endif
+
+          ! Update mu_star
+          mu_star(ng) = mu_star(ng) + dmu_star
+
+          ! Limit to a physically reasonable range
+          mu_star(ng) = min(mu_star(ng), mu_star_max)
+          mu_star(ng) = max(mu_star(ng), mu_star_min)
+
+          if (verbose_glacier .and. main_task .and. ng == ngdiag) then
+             print*, ' '
+             print*, 'Invert for mu_star: ngdiag =', ngdiag
+             print*, 'A, A_target (km^2), err_area:', &
+                  area(ng)/1.0d6, area_target(ng)/1.0d6, err_area
+             print*, 'term1*dt:', term1*dt
+             print*, 'dmu_star, new mu_star:', dmu_star, mu_star(ng)
+          endif
+
+       else   ! area_target(ng) = 0
+
+          write(message,*) 'Error: area_target = 0 for glacier', ng
+          call write_log(message, GM_FATAL)
+
+       endif
+
+    enddo   ! ng
+
+  end subroutine glacier_invert_mu_star
+
+!****************************************************
+
+  subroutine glacier_invert_powerlaw_c(&
+       dt,                                  &
+       ewn,              nsn,               &
+       nglacier,         ngdiag,            &
+       powerlaw_c_min,   powerlaw_c_max,    &
+       volume,           volume_target,     &
+       dvolume_dt,       powerlaw_c)
+
+    use glimmer_physcon, only: scyr
+
+    ! Given the current glacier volumes and volume targets,
+    ! invert for the parameter powerlaw_c in the relationship for basal sliding.
+
+    ! Note: This subroutine should be called from main_task only, since it uses
+    !       glacier volumes summed over all processors.
+
+    ! input/output arguments
+
+    real(dp), intent(in) :: &
+         dt                             ! timestep (yr)
+
+    integer, intent(in) ::  &
+         ewn, nsn,                    & ! number of cells in each horizontal direction
+         nglacier,                    & ! total number of glaciers in the domain
+         ngdiag                         ! ID of diagnostic glacier
+
+    real(dp), intent(in) :: &
+         powerlaw_c_min, powerlaw_c_max ! min and max allowed values of powerlaw_c (Pa (m/yr)^(-1/3))
+
+    real(dp), dimension(nglacier), intent(in) :: &
+         volume,                      & ! current glacier volume (m^3)
+         volume_target,               & ! volume target (m^3)
+         dvolume_dt                     ! rate of change of volume (m^3/yr)
+
+    ! Note: Here, powerlaw_c_glacier(nglacier) is the value shared by all cells in a given glacier
+    ! The calling subroutine will need to map these values onto each grid cell.
+    real(dp), dimension(nglacier), intent(inout) :: &
+         powerlaw_c                     ! glacier-specific basal friction parameter (Pa (m/yr)^(-1/3))
+
+    ! local variables
+
+    integer :: ng
+
+    real(dp), parameter :: &
+         glacier_volume_timescale = 100.d0   ! timescale (yr)
+
+    real(dp) :: &
+         err_vol,                     & ! relative volume error, (V - V_target)/V_target
+         term1, term2,                & ! terms in prognostic equation for powerlaw_c
+         dpowerlaw_c                    ! change in powerlaw_c
+
+    character(len=100) :: message
+
+    ! The inversion works as follows:
+    ! The change in C_p is proportional to the current value of C_p and to the relative error,
+    !  err_vol = (V - V_target)/V_target.
+    ! If err_vol > 0, we reduce C_p to make the glacier flow faster and thin.
+    ! If err_vol < 0, we increase C_p to make the glacier flow slower and thicken.
+    ! This is done with a characteristic timescale tau.
+    ! We also include a term proportional to dV/dt so that ideally, C_p smoothly approaches
+    !  the value needed to attain a steady-state V, without oscillating about the desired value.
+    ! See the comments in module glissade_inversion, subroutine invert_basal_friction.
+    ! Here is the prognostic equation:
+    ! dC/dt = -C * (1/tau) * (V - V_target)/V_target + (2*tau/V_target) * dV/dt
+
+    do ng = 1, nglacier
+
+       if (volume_target(ng) > 0.0d0) then  ! this should be the case for most glaciers
+          err_vol = (volume(ng) - volume_target(ng)) / volume_target(ng)
+          term1 = -err_vol / glacier_volume_timescale
+          term2 = -2.0d0 * dvolume_dt(ng) / volume_target(ng)
+          dpowerlaw_c = powerlaw_c(ng) * (term1 + term2) * dt
+
+          ! Limit to prevent a large relative change in one step
+          if (abs(dpowerlaw_c) > 0.05d0 * powerlaw_c(ng)) then
+             if (dpowerlaw_c > 0.0d0) then
+                dpowerlaw_c =  0.05d0 * powerlaw_c(ng)
+             else
+                dpowerlaw_c = -0.05d0 * powerlaw_c(ng)
+             endif
+          endif
+
+          ! Update powerlaw_c
+          powerlaw_c(ng) = powerlaw_c(ng) + dpowerlaw_c
+
+          ! Limit to a physically reasonable range
+          powerlaw_c(ng) = min(powerlaw_c(ng), powerlaw_c_max)
+          powerlaw_c(ng) = max(powerlaw_c(ng), powerlaw_c_min)
+
+          if (verbose_glacier .and. main_task .and. ng == ngdiag) then
+             print*, ' '
+             print*, 'Invert for powerlaw_c: ngdiag =', ngdiag
+             print*, 'V, V_target (km^3)', volume(ng)/1.0d9, volume_target(ng)/1.0d9
+             print*, 'dV_dt (km^3/yr), relative err_vol:', dvolume_dt(ng)/1.0d9, err_vol
+             print*, 'dt (yr), term1*dt, term2*dt:', dt, term1*dt, term2*dt
+             print*, 'dpowerlaw_c, new powerlaw_c:', dpowerlaw_c, powerlaw_c(ng)
+          endif
+
+       else   ! volume_target(ng) = 0
+
+          !TODO: Remove these glaciers from the inversion?
+          ! For now, set C_p to the min value to minimize the thickness
+          powerlaw_c(ng) = powerlaw_c_min
+
+       endif
+
+    enddo   ! ng
+
+  end subroutine glacier_invert_powerlaw_c
+
+!****************************************************
+
+  subroutine glacier_area_volume(&
+       ewn,           nsn,               &
+       nglacier,      cism_glacier_id,   &
+       cell_area,     thck,              &
+       area,          volume,            &
+       dthck_dt,      dvolume_dt)
+
+    use cism_parallel, only: parallel_reduce_sum
+
+    ! input/output arguments
+
+    integer, intent(in) ::  &
+         ewn, nsn,                    & ! number of cells in each horizontal direction
+         nglacier                       ! total number of glaciers in the domain
+
+    integer, dimension(ewn,nsn), intent(in) ::  &
+         cism_glacier_id                ! integer glacier ID in the range (1, nglacier)
+
+    real(dp), intent(in) :: &
+         cell_area                      ! grid cell area (m^2), assumed equal for all cells
+
+    real(dp), dimension(ewn,nsn), intent(in) ::  &
+         thck                           ! ice thickness (m)
+
+    real(dp), dimension(nglacier), intent(out) ::  &
+         area,                & ! area of each glacier (m^2)
+         volume                 ! volume of each glacier (m^3)
+
+    real(dp), dimension(ewn,nsn), intent(in), optional ::  &
+         dthck_dt               ! rate of change of ice thickness (m/yr)
+
+    real(dp), dimension(nglacier), intent(out), optional ::  &
+         dvolume_dt             ! rate of change of glacier volume (m^3/yr)
+
+    ! local variables
+
+    real(dp), dimension(:), allocatable :: &
+         local_area, local_volume       ! area and volume on each processor, before global sum
+
+    integer :: i, j, ng
+
+    ! Initialize the output arrays
+    area(:) = 0.0d0
+    volume(:) = 0.0d0
+
+    ! Allocate and initialize local arrays
     allocate(local_area(nglacier))
     allocate(local_volume(nglacier))
     local_area(:) = 0.0d0
     local_volume(:) = 0.0d0
 
     ! Compute the initial area and volume of each glacier.
-    ! We need parallel sums, since a glacier can lie on 2 or more processors.
+    ! We need parallel sums, since a glacier can lie on two or more processors.
 
     if (verbose_glacier .and. main_task) then
-       print*, 'Compute glacier area and volume'
-       print*, '   cell_area (m^3) =', model%geometry%cell_area(3,3) * len0**2
+       print*, ' '
+       print*, 'Compute glacier area and volume; cell_area (m^3) =', cell_area
     endif
 
     do j = nhalo+1, nsn-nhalo
        do i = nhalo+1, ewn-nhalo
-          ng = model%glacier%glacier_id_cism(i,j)
+          ng = cism_glacier_id(i,j)
           if (ng >= 1) then
-             local_area(ng) = local_area(ng) &
-                  + model%geometry%cell_area(i,j)*len0**2
-             local_volume(ng) = local_volume(ng) &
-                  + model%geometry%cell_area(i,j)*len0**2 * model%geometry%thck(i,j)*thk0
+             local_area(ng) = local_area(ng) + cell_area
+             local_volume(ng) = local_volume(ng) + cell_area * thck(i,j)
           endif
        enddo
     enddo
 
-    model%glacier%area   = parallel_reduce_sum(local_area)
-    model%glacier%volume = parallel_reduce_sum(local_volume)
+    area   = parallel_reduce_sum(local_area)
+    volume = parallel_reduce_sum(local_volume)
 
     if (verbose_glacier .and. main_task) then
-       print*, 'Max area (km^2)   =', maxval(model%glacier%area) * 1.0d-6    ! m^2 to km^2
-       print*, 'Max volume (km^3) =', maxval(model%glacier%volume) * 1.0d-9  ! m^3 to km^3
+       print*, 'Max area (km^2)   =', maxval(area) * 1.0d-6    ! m^2 to km^2
+       print*, 'Max volume (km^3) =', maxval(volume) * 1.0d-9  ! m^3 to km^3
        print*, ' '
-       print*, 'Selected A (km^2) and V (km^3) of large glaciers:'
+       print*, 'Selected A (km^2) and  V(km^3) of large glaciers (> 3 km^3):'
        do ng = 1, nglacier
-          if (model%glacier%area(ng) * 1.0d-6 > 10.0d0) then  ! 10 km^2 or more
-             write(6,'(i8,2f10.3)') ng, model%glacier%area(ng)*1.0d-6, model%glacier%volume(ng)*1.0d-9
+          if (volume(ng) * 1.0d-9 > 3.0d0) then  ! 3 km^3 or more
+             write(6,'(i8,2f10.3)') ng, area(ng)*1.0d-6, volume(ng)*1.0d-9
           endif
        enddo
+    endif
+
+    ! Optionally, compute the rate of change of glacier volume
+    if (present(dthck_dt) .and. present(dvolume_dt)) then
+       ! use local_volume as a work array for dvolume_dt
+       dvolume_dt(:) = 0.0d0
+       local_volume(:) = 0.0d0
+       do j = nhalo+1, nsn-nhalo
+          do i = nhalo+1, ewn-nhalo
+             ng = cism_glacier_id(i,j)
+             if (ng >= 1) then
+                local_volume(ng) = local_volume(ng) + cell_area * dthck_dt(i,j)
+             endif
+          enddo
+       enddo
+       dvolume_dt = parallel_reduce_sum(local_volume)
     endif
 
     deallocate(local_area)
     deallocate(local_volume)
 
-    if (main_task) print*, 'Done in glissade_glacier_init'
+  end subroutine glacier_area_volume
 
-  end subroutine glissade_glacier_init
-
-!****************************************************      
+!****************************************************
 
   recursive subroutine quicksort(A, first, last)
  
     ! Given an unsorted integer array, return an array with elements sorted from low to high.
+    ! Note: This is a template for a quicksort subroutine, but the subroutine actually called
+    !       is glacier_quicksort below.
 
     implicit none
 
@@ -435,7 +1036,7 @@ contains
 
   end subroutine quicksort
 
-!****************************************************      
+!****************************************************
 
   recursive subroutine glacier_quicksort(A, first, last)
  
@@ -477,8 +1078,6 @@ contains
 
     if (first < i-1) call glacier_quicksort(A, first, i-1)
     if (last  > j+1) call glacier_quicksort(A, j+1, last)
-
-!    print*, 'Done in quicksort'
 
   end subroutine glacier_quicksort
 

--- a/libglissade/glissade_glacier.F90
+++ b/libglissade/glissade_glacier.F90
@@ -1,0 +1,489 @@
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!                                                             
+!   glissade_glacier.F90 - part of the Community Ice Sheet Model (CISM)  
+!                                                              
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!
+!   Copyright (C) 2005-2018
+!   CISM contributors - see AUTHORS file for list of contributors
+!
+!   This file is part of CISM.
+!
+!   CISM is free software: you can redistribute it and/or modify it
+!   under the terms of the Lesser GNU General Public License as published
+!   by the Free Software Foundation, either version 3 of the License, or
+!   (at your option) any later version.
+!
+!   CISM is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!   Lesser GNU General Public License for more details.
+!
+!   You should have received a copy of the Lesser GNU General Public License
+!   along with CISM. If not, see <http://www.gnu.org/licenses/>.
+!
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+module glissade_glacier
+
+    ! Subroutines for glacier tuning and tracking
+
+    use glimmer_global 
+    use glimmer_paramets, only: thk0, len0
+    use glide_types
+    use glimmer_log
+    use cism_parallel, only: main_task, this_rank, nhalo
+
+    implicit none
+
+    private
+    public :: glissade_glacier_init
+
+    logical, parameter :: verbose_glacier = .true.
+
+    ! derived type that holds info for each glaciated grid cell
+    type glacier_info
+       integer :: id           ! input glacier ID, usually RGI
+       integer :: indxi        ! i index of cell
+       integer :: indxj        ! j index of cell
+    end type glacier_info
+
+contains
+
+!****************************************************      
+
+  subroutine glissade_glacier_init(model)
+
+    ! Initialize glaciers for a region
+    ! If running on multiple disconnected glacier regions, this routine should be called once per region.
+    !TODO: One set of logic for init, another for restart
+
+    ! One key task is to create one-to-one maps between the input glacier_id array (typically with RGI IDs)
+    !  and a local array called glacier_id_cism.  The local array assigns to each grid cell
+    !  a number between 1 and nglacier where nglacier is the total number of unique glacier IDs.
+    ! This allows us to loop over IDs in the range (1:nglacier), which is more efficient than
+    !  looping over input glacier IDs.  The input IDs typically have large gaps.
+
+    use cism_parallel, only: distributed_gather_var, distributed_scatter_var, &
+         parallel_reduce_sum, broadcast, parallel_halo 
+
+    type(glide_global_type),intent(inout) :: model
+
+    ! local variables
+    integer :: ewn, nsn, global_ewn, global_nsn
+    integer :: itest, jtest, rtest   ! coordinates of diagnostic point
+
+    ! temporary global arrays
+    integer, dimension(:,:), allocatable :: &
+         glacier_id_global,         & ! global array of the input glacier ID; maps (i,j) to RGI ID
+         glacier_id_cism_global       ! global array of the CISM glacier ID; maps (i,j) to CISM glacier ID
+
+    type(glacier_info), dimension(:), allocatable :: & 
+         glacier_list                 ! sorted list of glacier IDs with i and j indices
+
+    ! The next three arrays will have dimension (nglacier), once nglacier is computed
+!!    integer, dimension(:), allocatable :: &
+!!         cism_to_glacier_id           ! maps CISM ID (1:nglacier) to input glacier_id
+
+    real(dp), dimension(:), allocatable :: &
+         local_area,                & ! area per glacier (m^2)
+         local_volume                 ! volume per glacier (m^3)
+
+    integer :: &
+         nglacier,                  & ! number of glaciers in global domain
+         ncells_glacier,            & ! number of global grid cells occupied by glaciers at initialization
+         current_id,                & ! current glacier_id from list
+         gid_minval, gid_maxval       ! min and max values of glacier_id
+
+    type(parallel_type) :: parallel   ! info for parallel communication
+
+    integer :: i, j, nc, ng, count
+
+    !WHL - debug
+    integer, dimension(:), allocatable :: test_list
+    integer ::  nlist
+    real(sp) :: random
+
+    if (verbose_glacier .and. main_task) then
+       print*, ' '
+       print*, 'In glissade_glacier_init'
+    endif
+
+    parallel = model%parallel
+    global_ewn = parallel%global_ewn
+    global_nsn = parallel%global_nsn
+
+    ewn = model%general%ewn
+    nsn = model%general%nsn
+
+    ! get coordinates of diagnostic point
+    rtest = -999
+    itest = 1
+    jtest = 1
+    if (this_rank == model%numerics%rdiag_local) then
+       rtest = model%numerics%rdiag_local
+       itest = model%numerics%idiag_local
+       jtest = model%numerics%jdiag_local
+    endif
+
+    ! debug - scatter test
+!    if (main_task) print*, 'Scatter glacier_id_cism'
+!    allocate(glacier_id_cism_global(global_ewn,global_nsn))
+!    glacier_id_cism_global = 0
+!    model%glacier%glacier_id_cism = 0
+!    call distributed_scatter_var(model%glacier%glacier_id_cism, glacier_id_cism_global, parallel)
+!    if (main_task) print*, 'Successful scatter'
+!    if (allocated(glacier_id_cism_global)) deallocate(glacier_id_cism_global)
+
+    ! Gather glacier IDs to the main task
+
+    allocate(glacier_id_global(global_ewn, global_nsn))
+    call distributed_gather_var(model%glacier%glacier_id, glacier_id_global, parallel)
+
+    if (verbose_glacier .and. main_task) then
+       print*, ' '
+       print*, 'Gathered glacier IDs to main task'
+       print*, 'size(glacier_id) =', size(model%glacier%glacier_id,1), size(model%glacier%glacier_id,2)
+       print*, 'size(glacier_id_global) =', size(glacier_id_global,1), size(glacier_id_global,2)
+    endif
+
+    if (verbose_glacier .and. this_rank == rtest) then
+       i = itest
+       j = jtest
+       print*, ' '
+       print*, 'Glacier ID, rtest, itest, jtest:', rtest, itest, jtest
+       do j = jtest+3, jtest-3, -1
+          write(6,'(i6)',advance='no') j
+          do i = itest-3, itest+3
+             write(6,'(i10)',advance='no') model%glacier%glacier_id(i,j)
+          enddo
+          write(6,*) ' '
+       enddo
+    endif
+
+    ! Count the number of cells with glaciers
+
+    count = 0
+
+    ! Loop over locally owned cells
+    do j = nhalo+1, nsn-nhalo
+       do i = nhalo+1, ewn-nhalo
+          if (model%glacier%glacier_id(i,j) > 0) then
+             count = count + 1
+          elseif (model%glacier%glacier_id(i,j) < 0) then  ! should not happen
+             print*, 'glacier_id < 0: i, j, value =', i, j, model%glacier%glacier_id(i,j)
+             stop   ! TODO - exit gracefully
+          endif
+       enddo
+    enddo
+
+    ncells_glacier = parallel_reduce_sum(count)
+
+    ! Allocate a global array on the main task only.
+    ! On other tasks, allocate a size 0 array, since distributed_scatter_var wants arrays allocated on all tasks.
+    if (main_task) then
+       allocate(glacier_id_cism_global(global_ewn,global_nsn))
+       glacier_id_cism_global(:,:) = 0.0d0
+    else
+       allocate(glacier_id_cism_global(0,0))
+    endif
+
+    if (main_task) then
+
+       gid_minval = minval(glacier_id_global)
+       gid_maxval = maxval(glacier_id_global)
+
+       if (verbose_glacier) then
+          print*, 'Total ncells   =', global_ewn * global_nsn
+          print*, 'ncells_glacier =', ncells_glacier
+          print*, 'glacier_id minval, maxval =', gid_minval, gid_maxval
+       endif
+
+       ! Create an unsorted list of glacier IDs, with associated i and j indices.
+       ! There is one entry per glacier-covered cell.
+
+       allocate(glacier_list(ncells_glacier))
+       glacier_list(:)%id = 0
+       glacier_list(:)%indxi = 0
+       glacier_list(:)%indxj = 0
+
+       count = 0
+
+       do j = 1, global_nsn
+          do i = 1, global_ewn
+             if (glacier_id_global(i,j) > 0) then
+                count = count + 1
+                glacier_list(count)%id = glacier_id_global(i,j)
+                glacier_list(count)%indxi = i
+                glacier_list(count)%indxj = j
+             endif
+          enddo
+       enddo
+
+       deallocate(glacier_id_global)  ! no longer needed after glacier_list is built
+
+       ! Sort the list from low to high IDs.
+       ! As the IDs are sorted, the i and j indices come along for the ride.
+       ! When there are multiple cells with the same glacier ID, these cells are adjacent on the list.
+       ! For example, suppose the initial list is (5, 9, 7, 6, 7, 10, 4, 1, 1, 3, 1).
+       ! The sorted list would be (1, 1, 1, 3, 5, 7, 7, 7, 9, 10).
+
+       call glacier_quicksort(glacier_list, 1, ncells_glacier)
+
+       if (verbose_glacier) then
+          print*, 'Sorted glacier IDs in ascending order'
+          print*, ' '
+          print*, 'icell, i, j, ID for a few cells:'
+          do i = 1, 10
+             print*, i, glacier_list(i)%indxi, glacier_list(i)%indxj, glacier_list(i)%id
+          enddo
+          do i = ncells_glacier-9, ncells_glacier
+             print*, i, glacier_list(i)%indxi, glacier_list(i)%indxj, glacier_list(i)%id
+          enddo
+       endif
+
+!       WHL - Short list to test quicksort for integer arrays
+!       print*, ' '
+!       print*, 'Unsorted list:'
+!       nlist = 20
+!       allocate(test_list(nlist))
+!       do i = 1, nlist
+!          call random_number(random)
+!          test_list(i) = int(random*nlist) + 1
+!          print*, i, random, test_list(i)
+!       enddo
+!       call quicksort(test_list, 1, nlist)
+!       print*, 'Sorted list:', test_list(:)
+
+       ! Now that the glacier IDs are sorted from low to high,
+       ! it is easy to count the total number of glaciers
+
+       nglacier = 0
+       current_id = 0
+       do nc = 1, ncells_glacier
+          if (glacier_list(nc)%id > current_id) then
+             nglacier = nglacier + 1
+             current_id = glacier_list(nc)%id
+          endif
+       enddo
+
+       model%glacier%nglacier = nglacier
+
+       ! Create two useful arrays:
+       ! (1) The cism_to_glacier_id array maps the CISM ID (between 1 and nglacier) to the input glacier_id.
+       ! (2) The glacier_id_cism array maps each glaciated grid cell (i,j) to a CISM ID.
+       ! The reason to carry around i and j in the sorted glacier_list is to efficienly fill glacier_id_cism.
+       ! Note: cism_to_glacier_id is part of the glacier derived type, but cannot be allocate until nglacier is known.
+
+       allocate(model%glacier%cism_to_glacier_id(nglacier))
+       model%glacier%cism_to_glacier_id(:) = 0
+
+       if (verbose_glacier) then
+          print*, ' '
+          print*, 'Counted glaciers: nglacier =', nglacier
+          print*, ' '
+          print*, 'Pick a glacier: ng =',  nglacier/2
+          print*, 'icell, i, j, glacier_id_cism_global(i,j), cism_to_glacier_id(ng)'
+       endif
+
+       ng = 0
+       current_id = 0
+       do nc = 1, ncells_glacier
+          if (glacier_list(nc)%id > current_id) then
+             ng = ng + 1
+             current_id = glacier_list(nc)%id
+             model%glacier%cism_to_glacier_id(ng) = glacier_list(nc)%id
+          endif
+          i = glacier_list(nc)%indxi
+          j = glacier_list(nc)%indxj
+          if (i == 0 .or. j == 0) then
+             print*, 'Warning: zeroes, ng, i, j, id =', ng, i, j, glacier_list(nc)%id
+             stop   ! TODO - exit gracefully
+          endif
+          glacier_id_cism_global(i,j) = ng
+          if (ng == nglacier/2) then   ! random glacier
+             print*, nc, i, j, glacier_id_cism_global(i,j), model%glacier%cism_to_glacier_id(ng)
+          endif
+          if (ng > nglacier) then
+             print*, 'ng > nglacier, nc, i, j , ng =', nc, i, j, ng
+             stop  !TODO - exit gracefully
+          endif
+       enddo
+
+       deallocate(glacier_list)
+
+       if (verbose_glacier) then
+          print*, ' '
+          print*, 'maxval(cism_to_glacier_id) =', maxval(model%glacier%cism_to_glacier_id) 
+          print*, 'maxval(glacier_id_cism_global) =', maxval(glacier_id_cism_global)
+       endif
+
+    endif   ! main_task
+
+    ! Communicate glacier info from the main task to all processors
+
+    if (verbose_glacier .and. main_task) print*, 'Broadcast nglacier and cism_to_glacier_id'
+    call broadcast(model%glacier%nglacier)
+    nglacier = model%glacier%nglacier
+
+    if (.not.associated(model%glacier%cism_to_glacier_id)) &
+         allocate(model%glacier%cism_to_glacier_id(nglacier))
+    call broadcast(model%glacier%cism_to_glacier_id)
+
+    if (verbose_glacier .and. main_task) print*, 'Scatter glacier_id_cism'
+    ! Note: glacier_id_cism_global is deallocated in the subroutine
+    call distributed_scatter_var(model%glacier%glacier_id_cism, glacier_id_cism_global, parallel)
+    call parallel_halo(model%glacier%glacier_id_cism, parallel)
+
+    !TODO - Move area and volume computations to subroutines
+
+    ! Allocate and initialize glacier area and volume
+
+    allocate(model%glacier%area(nglacier))
+    allocate(model%glacier%volume(nglacier))
+    model%glacier%area(:) = 0.0d0
+    model%glacier%volume(:) = 0.0d0
+
+    allocate(local_area(nglacier))
+    allocate(local_volume(nglacier))
+    local_area(:) = 0.0d0
+    local_volume(:) = 0.0d0
+
+    ! Compute the initial area and volume of each glacier.
+    ! We need parallel sums, since a glacier can lie on 2 or more processors.
+
+    if (verbose_glacier .and. main_task) then
+       print*, 'Compute glacier area and volume'
+       print*, '   cell_area (m^3) =', model%geometry%cell_area(3,3) * len0**2
+    endif
+
+    do j = nhalo+1, nsn-nhalo
+       do i = nhalo+1, ewn-nhalo
+          ng = model%glacier%glacier_id_cism(i,j)
+          if (ng >= 1) then
+             local_area(ng) = local_area(ng) &
+                  + model%geometry%cell_area(i,j)*len0**2
+             local_volume(ng) = local_volume(ng) &
+                  + model%geometry%cell_area(i,j)*len0**2 * model%geometry%thck(i,j)*thk0
+          endif
+       enddo
+    enddo
+
+    model%glacier%area   = parallel_reduce_sum(local_area)
+    model%glacier%volume = parallel_reduce_sum(local_volume)
+
+    if (verbose_glacier .and. main_task) then
+       print*, 'Max area (km^2)   =', maxval(model%glacier%area) * 1.0d-6    ! m^2 to km^2
+       print*, 'Max volume (km^3) =', maxval(model%glacier%volume) * 1.0d-9  ! m^3 to km^3
+       print*, ' '
+       print*, 'Selected A (km^2) and V (km^3) of large glaciers:'
+       do ng = 1, nglacier
+          if (model%glacier%area(ng) * 1.0d-6 > 10.0d0) then  ! 10 km^2 or more
+             write(6,'(i8,2f10.3)') ng, model%glacier%area(ng)*1.0d-6, model%glacier%volume(ng)*1.0d-9
+          endif
+       enddo
+    endif
+
+    deallocate(local_area)
+    deallocate(local_volume)
+
+    if (main_task) print*, 'Done in glissade_glacier_init'
+
+  end subroutine glissade_glacier_init
+
+!****************************************************      
+
+  recursive subroutine quicksort(A, first, last)
+ 
+    ! Given an unsorted integer array, return an array with elements sorted from low to high.
+
+    implicit none
+
+    ! input/output arguments
+    integer, dimension(:), intent(inout) :: A
+    integer, intent(in) :: first, last
+ 
+    ! local arguments
+    integer :: temp
+    integer :: pivot
+    integer :: i, j
+
+    pivot = A( (first+last)/2 )
+    i = first
+    j = last
+
+    ! Partition loop
+    do
+       do while (A(i) < pivot)
+          i = i + 1
+       enddo
+       do while (A(j) > pivot)
+          j = j - 1
+       enddo
+       if (i >= j) exit
+       temp = A(i)
+       A(i) = A(j)
+       A(j) = temp
+       i = i + 1
+       j = j - 1
+    enddo
+
+    if (first < i-1) call quicksort(A, first, i-1)
+    if (last  > j+1) call quicksort(A, j+1, last)
+
+!    print*, 'Done in quicksort'
+
+  end subroutine quicksort
+
+!****************************************************      
+
+  recursive subroutine glacier_quicksort(A, first, last)
+ 
+    ! Given an unsorted array of type glacier_info, return an array with
+    ! glacier IDs (A%id) sorted from low to high.
+    ! The logic is just like quicksort above, but tailored for the derived type.
+
+    implicit none
+
+    ! input/output arguments
+    type(glacier_info), dimension(:), intent(inout) :: A
+    integer, intent(in) :: first, last
+ 
+    ! local arguments
+    type(glacier_info) :: temp
+    integer :: pivot
+    integer :: i, j
+
+    pivot = A( (first+last)/2 )%id
+    i = first
+    j = last
+
+    ! Partition loop
+    do
+       do while (A(i)%id < pivot)
+          i = i + 1
+       enddo
+       do while (A(j)%id > pivot)
+          j = j - 1
+       enddo
+       if (i >= j) exit
+       ! Swap A(i) with A(j). Note that A%indxi and A%indxj are swapped along with A%id.
+       temp = A(i)
+       A(i) = A(j)
+       A(j) = temp
+       i = i + 1
+       j = j - 1
+    enddo
+
+    if (first < i-1) call glacier_quicksort(A, first, i-1)
+    if (last  > j+1) call glacier_quicksort(A, j+1, last)
+
+!    print*, 'Done in quicksort'
+
+  end subroutine glacier_quicksort
+
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+end module glissade_glacier
+
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/libglissade/glissade_glacier.F90
+++ b/libglissade/glissade_glacier.F90
@@ -193,7 +193,7 @@ contains
 
     endif   ! scale_area
 
-    if (model%options%is_restart == RESTART_FALSE) then
+    if (model%options%is_restart == NO_RESTART) then
 
        ! not a restart; initialize everything from the input file
 
@@ -553,7 +553,7 @@ contains
             nglacier,              glacier%cism_glacier_id_init,  &
             model%climate%smb_obs, glacier%smb_obs)
 
-    else  ! restart
+    else  ! restart (either standard or hybrid)
 
        ! In this case, most required glacier info has already been read from the restart file.
        ! Here, do some error checks and diagnostics.

--- a/libglissade/glissade_inversion.F90
+++ b/libglissade/glissade_inversion.F90
@@ -40,7 +40,7 @@ module glissade_inversion
   private
   public :: verbose_inversion, glissade_init_inversion, glissade_inversion_basal_friction, &
             glissade_inversion_bmlt_basin, glissade_inversion_deltaT_ocn, &
-            glissade_inversion_flow_enhancement_factor, usrf_to_thck
+            glissade_inversion_flow_enhancement_factor
   public :: deltaT_ocn_maxval
 
   !-----------------------------------------------------------------------------

--- a/libglissade/glissade_inversion.F90
+++ b/libglissade/glissade_inversion.F90
@@ -978,7 +978,7 @@ contains
              ! For a thickness target H_obs, the rate is given by
              !     dC/dt = -C * [(H - H_obs)/(H0*tau) + dH/dt * 2/H0 - r * ln(C/C_r) / tau]
              ! where tau = babc_timescale, H0 = babc_thck_scale, r = babc_relax_factor, and
-             !  C_r is a relaxation target..
+             !  C_r is a relaxation target.
              ! Apart from the relaxation term, this equation is similar to that of a damped harmonic oscillator:
              !     m * d2x/dt2 = -k*x - c*dx/dt
              ! where m is the mass, k is a spring constant, and c is a damping term.

--- a/libglissade/glissade_inversion.F90
+++ b/libglissade/glissade_inversion.F90
@@ -68,6 +68,7 @@ contains
     use glissade_masks, only: glissade_get_masks
     use glissade_grid_operators, only: glissade_stagger
     use glissade_basal_traction, only: set_coulomb_c_elevation
+    use glissade_utils, only: glissade_usrf_to_thck, glissade_thck_to_usrf
 
     type(glide_global_type), intent(inout) :: model   ! model instance
 
@@ -143,7 +144,8 @@ contains
        endif
 
        ! Given usrf_obs and topg, compute thck_obs.
-       call usrf_to_thck(&
+
+       call glissade_usrf_to_thck(&
             model%geometry%usrf_obs,  &
             model%geometry%topg,      &
             model%climate%eus,        &
@@ -207,10 +209,11 @@ contains
 
           ! Reset usrf_obs to be consistent with thck_obs.
           ! (usrf itself will be recomputed later in glissade_initialise)
-          call thck_to_usrf(thck_obs,  &
-                            model%geometry%topg,      &
-                            model%climate%eus,        &
-                            model%geometry%usrf_obs)
+          call glissade_thck_to_usrf(&
+               thck_obs,  &
+               model%geometry%topg,      &
+               model%climate%eus,        &
+               model%geometry%usrf_obs)
 
        endif   ! not a restart
 
@@ -462,6 +465,7 @@ contains
     use glimmer_physcon, only: scyr, grav
     use glissade_grid_operators, only: glissade_stagger, glissade_stagger_real_mask
     use glissade_basal_traction, only: set_coulomb_c_elevation
+    use glissade_utils, only: glissade_usrf_to_thck
 
     implicit none
 
@@ -529,7 +533,8 @@ contains
 
        ! Given the surface elevation target, compute the thickness target.
        ! (This can change in time if the bed topography is dynamic.)
-       call usrf_to_thck(&
+
+       call glissade_usrf_to_thck(&
             model%geometry%usrf_obs,  &
             model%geometry%topg,      &
             model%climate%eus,        &
@@ -1267,7 +1272,8 @@ contains
           print*, 'basin, term_thck, term_dHdt*dt, dTbasin, new deltaT_basin:'
           do nb = 1, nbasin
              write(6,'(i6,4f12.6)') nb, &
-                  dt/dbmlt_dtemp_scale * (floating_thck_basin(nb) - floating_thck_target_basin(nb)) / (bmlt_basin_timescale**2), &
+                  dt/dbmlt_dtemp_scale * (floating_thck_basin(nb) - floating_thck_target_basin(nb)) / &
+                  (bmlt_basin_timescale**2), &
                   dt/dbmlt_dtemp_scale * 2.0d0 * floating_dthck_dt_basin(nb) / bmlt_basin_timescale, &
                   dt*dTbasin_dt(nb), deltaT_basin(nb)
           enddo
@@ -1900,79 +1906,6 @@ contains
     endif
 
   end subroutine get_basin_targets
-
-!***********************************************************************
-
-  !TODO - Move the two following subroutines to a utility module?
-
-  subroutine usrf_to_thck(usrf, topg, eus, thck)
-
-    ! Given the bed topography and upper ice surface elevation, compute the ice thickness.
-    ! The ice is assumed to satisfy a flotation condition.
-    ! That is, if topg - eus < 0 (marine-based ice), and if the upper surface is too close
-    !  to sea level to ground the ice, then the ice thickness is chosen to satisfy
-    !  rhoi*H = -rhoo*(topg-eus).
-    ! Note: usrf, topg, eus and thck must all have the same units (often but not necessarily meters).
-
-    use glimmer_physcon, only : rhoo, rhoi
-
-    real(dp), dimension(:,:), intent(in) :: &
-         usrf,           & ! ice upper surface elevation
-         topg              ! elevation of bedrock topography
-
-    real(dp), intent(in) :: &
-         eus               ! eustatic sea level
-
-    real(dp), dimension(:,:), intent(out) :: &
-         thck              ! ice thickness
-
-    ! initialize
-    thck(:,:) = 0.0d0
-
-    where (usrf > (topg - eus))   ! ice is present, thck > 0
-       where (topg - eus < 0.0d0)   ! marine-based ice
-          where ((topg - eus) * (1.0d0 - rhoo/rhoi) > usrf)  ! ice is floating
-             thck = usrf / (1.0d0 - rhoi/rhoo)
-          elsewhere   ! ice is grounded
-             thck = usrf - (topg - eus)
-          endwhere
-       elsewhere   ! land-based ice
-          thck = usrf - (topg - eus)
-       endwhere
-    endwhere
-
-  end subroutine usrf_to_thck
-
-!***********************************************************************
-
-  subroutine thck_to_usrf(thck, topg, eus, usrf)
-
-    ! Given the bed topography and ice thickness, compute the upper surface elevation.
-    ! The ice is assumed to satisfy a flotation condition.
-    ! That is, if topg - eus < 0 (marine-based ice), and if the ice is too thin to be grounded,
-    !  then the upper surface is chosen to satisfy rhoi*H = rhoo*(H - usrf),
-    !  or equivalently usrf = (1 - rhoi/rhoo)*H.
-    ! Note: usrf, topg, eus and thck must all have the same units (often but not necessarily meters).
-
-    use glimmer_physcon, only : rhoo, rhoi
-
-    real(dp), dimension(:,:), intent(in) :: &
-         thck,           & ! ice thickness
-         topg              ! elevation of bedrock topography
-
-    real(dp), intent(in) :: &
-         eus               ! eustatic sea level
-
-    real(dp), dimension(:,:), intent(out) :: &
-         usrf              ! ice upper surface elevation
-
-    where ((topg - eus) < -(rhoi/rhoo)*thck)
-       usrf = (1.0d0 - rhoi/rhoo)*thck   ! ice is floating
-    elsewhere   ! ice is grounded
-       usrf = (topg - eus) + thck
-    endwhere
-
-  end subroutine thck_to_usrf
 
 !=======================================================================
 

--- a/libglissade/glissade_inversion.F90
+++ b/libglissade/glissade_inversion.F90
@@ -151,7 +151,7 @@ contains
             model%climate%eus,        &
             thck_obs)
 
-       if (model%options%is_restart == RESTART_FALSE) then
+       if (model%options%is_restart == NO_RESTART) then
 
           ! At the start of the run, adjust thck_obs so that the observational target is not too close to thck_flotation.
           ! The reason for this is that if we restore H to values very close to thck_flotation,
@@ -221,7 +221,7 @@ contains
        call parallel_halo(thck_obs, parallel)
 
        ! Set the surface speed target, velo_sfc_obs
-       if (model%options%is_restart == RESTART_FALSE) then
+       if (model%options%is_restart == NO_RESTART) then
           model%velocity%velo_sfc_obs(:,:) = &
                sqrt(model%velocity%usfc_obs(:,:)**2 + model%velocity%vsfc_obs(:,:)**2)
        endif
@@ -376,7 +376,7 @@ contains
 
     if (model%options%which_ho_bmlt_basin == HO_BMLT_BASIN_INVERSION) then
 
-       if (model%options%is_restart == RESTART_FALSE) then
+       if (model%options%is_restart == NO_RESTART) then
 
           ! Set floating_thck_target for floating ice and lightly grounded ice.
           ! Here, "lightly grounded" means that the magnitude of f_flotation = (-topg - eus) - (rhoi/rhoo)*thck

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -181,7 +181,7 @@ module glissade_therm
     ! Method (3) may be optimal for reducing spinup time in the interior of large ice sheets.
     ! Option (4) requires that temperature is present in the input file.
 
-    if (is_restart == RESTART_TRUE) then
+    if (is_restart == STANDARD_RESTART .or. is_restart == HYBRID_RESTART) then
 
        ! Temperature has already been initialized from a restart file.
        ! (Temperature is always a restart variable.)

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -1122,7 +1122,7 @@ module glissade_therm
              if (abs((efinal-einit-delta_e)/dttem) > 1.0d-7) then
              ! WHL: For stability tests with a very short time step (e.g., < 1.d-6 year),
              !      the energy-conservation error can be triggered by machine roundoff.
-             !      For the tests in Robinson et al. (2021), I replaced the line above
+             !      For the slab tests in Robinson et al. (2021), I replaced the line above
              !      with the line below, which compares the error to the total energy.
              !      The latter criterion is less likely to give false positives,
              !       but might be more likely to give false negatives.

--- a/libglissade/glissade_therm.F90
+++ b/libglissade/glissade_therm.F90
@@ -1267,6 +1267,14 @@ module glissade_therm
     !       if so, it is combined with bmlt_ground
     ! TODO: Treat melt_internal as a separate field in glissade_tstep?
 
+    ! WHL - debug
+    if (verbose_therm .and. this_rank == rtest) then
+       ew = itest
+       ns = jtest
+       print*, 'bmlt_ground (m/yr) w/out internal melt:', bmlt_ground(ew,ns)*scyr
+       print*, 'Internal melt (m/yr):', melt_internal(ew,ns)*scyr
+    endif
+
     bmlt_ground(:,:) = bmlt_ground(:,:) + melt_internal(:,:)
 
     ! Check for temperatures that are physically unrealistic.

--- a/libglissade/glissade_transport.F90
+++ b/libglissade/glissade_transport.F90
@@ -1789,6 +1789,7 @@
 
   subroutine glissade_add_2d_anomaly(var2d,                    &
                                      var2d_anomaly,            &
+                                     anomaly_tstart,           &
                                      anomaly_timescale,        &
                                      time)
 
@@ -1802,6 +1803,7 @@
          var2d_anomaly       !> anomalous field to be added to the var2d input value
 
     real(dp), intent(in) ::  &
+         anomaly_tstart,   & !> time to begin applying the anomaly (yr)
          anomaly_timescale   !> number of years over which the anomaly is phased in linearly
 
     real(dp), intent(in) :: &
@@ -1816,30 +1818,27 @@
     nsn = size(var2d,2)
 
     ! Given the model time, compute the fraction of the anomaly to be applied now.
-    ! Note: The anomaly is applied in annual step functions starting at the end of the first year.
-    !       Add a small value to the time to avoid rounding errors when time is close to an integer value.
+    ! Add a small value to the time to avoid rounding errors when time is close to an integer value.
 
-    ! GL 06-26-19: note: Do we need the restriction of annual anomaly application?
-    ! WHL: The anomaly can now be applied as a smooth linear ramp (instead of yearly step changes)
-    !      by uncommenting one line below, when computing anomaly_fraction..
-
-    if (time + eps08 > anomaly_timescale .or. anomaly_timescale == 0.0d0) then
+    if (time + eps08 > anomaly_tstart + anomaly_timescale .or. anomaly_timescale == 0.0d0) then
 
        ! apply the full anomaly
        anomaly_fraction = 1.0d0
 
-    else
+    elseif (time + eps08 > anomaly_tstart) then
 
-       ! truncate the number of years and divide by the timescale
-       anomaly_fraction = floor((time + eps08), dp) / anomaly_timescale
+       ! apply an increasing fraction of the anomaly
+       anomaly_fraction = (time - anomaly_tstart) / anomaly_timescale
 
        ! Note: For initMIP, the anomaly is applied in annual step functions
        !        starting at the end of the first year.
        !       Comment out the line above and uncomment the following line
-       !        to apply a linear ramp throughout the anomaly run.
-!!       anomaly_fraction = real(time,dp) / anomaly_timescale
-!!       print*, 'time, anomaly_timescale, fraction:', time, anomaly_timescale, anomaly_fraction
+       !        to increase the anomaly once a year.
+!       anomaly_fraction = floor(time + eps08 - anomaly_tstart, dp) / anomaly_timescale
 
+    else
+       ! no anomaly to apply
+       anomaly_fraction = 0.0d0
     endif
 
     ! apply the anomaly
@@ -1855,6 +1854,7 @@
 
   subroutine glissade_add_3d_anomaly(var3d,                 &
                                      var3d_anomaly,         &
+                                     anomaly_tstart,        &
                                      anomaly_timescale,     &
                                      time)
 
@@ -1868,6 +1868,7 @@
          var3d_anomaly       !> anomaly to be added to the input value
 
     real(dp), intent(in) ::  &
+         anomaly_tstart,   & !> time to begin applying the anomaly (yr)
          anomaly_timescale   !> number of years over which the anomaly is phased in linearly
 
     real(dp), intent(in) :: &
@@ -1882,26 +1883,27 @@
     nsn = size(var3d,3)
 
     ! Given the model time, compute the fraction of the anomaly to be applied now.
-    ! Note: The anomaly is applied in annual step functions starting at the end of the first year.
-    !       Add a small value to the time to avoid rounding errors when time is close to an integer value.
+    ! Add a small value to the time to avoid rounding errors when time is close to an integer value.
 
-    if (time + eps08 > anomaly_timescale .or. anomaly_timescale == 0.0d0) then
+    if (time + eps08 > anomaly_tstart + anomaly_timescale .or. anomaly_timescale == 0.0d0) then
 
        ! apply the full anomaly
        anomaly_fraction = 1.0d0
 
-    else
+    elseif (time + eps08 > anomaly_tstart) then
 
-       ! truncate the number of years and divide by the timescale
-       anomaly_fraction = floor((time + eps08), dp) / anomaly_timescale
+       ! apply an increasing fraction of the anomaly
+       anomaly_fraction = (time - anomaly_tstart) / anomaly_timescale
 
        ! Note: For initMIP, the anomaly is applied in annual step functions
        !        starting at the end of the first year.
        !       Comment out the line above and uncomment the following line
-       !        to apply a linear ramp throughout the anomaly run.
-!!       anomaly_fraction = real(time,dp) / anomaly_timescale
-!!       print*, 'time, anomaly_timescale, fraction:', time, anomaly_timescale, anomaly_fraction
-
+       !        to increase the anomaly once a year.
+!       anomaly_fraction = floor(time + eps08 - anomaly_tstart, dp) / anomaly_timescale
+!
+    else
+       ! no anomaly to apply
+       anomaly_fraction = 0.0d0
     endif
 
     ! apply the anomaly

--- a/libglissade/glissade_transport.F90
+++ b/libglissade/glissade_transport.F90
@@ -1094,7 +1094,7 @@
       endif
       indices_adv(2:3) = indices_adv(2:3) + staggered_lhalo  ! want the i,j coordinates WITH the halo present -
                                                              ! we got indices into the slice of owned cells
-      ! Finally, determine maximum allowable time step based on advectice CFL condition.
+      ! Finally, determine maximum allowable time step based on advective CFL condition.
       my_allowable_dt_adv = dew / (maxvel + 1.0d-20)
 
       ! ------------------------------------------------------------------------
@@ -1174,6 +1174,11 @@
              if (deltat > 10.d0 * allowable_dt_adv) then
                 print*, 'deltat, allowable_dt_adv, ratio =', deltat, allowable_dt_adv, deltat/allowable_dt_adv
                 call write_log('Aborting with CFL violation', GM_FATAL)
+             endif
+             !WHL - debug
+             if (deltat > allowable_dt_adv) then
+                print*, 'deltat, allowable_dt_adv, ratio =', deltat, allowable_dt_adv, deltat/allowable_dt_adv
+                print*, '  Limited by position', indices_adv_global(2), indices_adv_global(3)
              endif
           endif
 

--- a/libglissade/glissade_utils.F90
+++ b/libglissade/glissade_utils.F90
@@ -41,6 +41,7 @@ module glissade_utils
   public :: glissade_adjust_thickness, glissade_smooth_usrf, &
        glissade_smooth_topography, glissade_adjust_topography, &
        glissade_basin_sum, glissade_basin_average, &
+       glissade_usrf_to_thck, glissade_thck_to_usrf, &
        glissade_stdev, verbose_stdev
 
   logical, parameter :: verbose_stdev = .true.
@@ -1030,6 +1031,76 @@ contains
 
   end subroutine glissade_stdev
 
+!***********************************************************************
+
+  subroutine glissade_usrf_to_thck(usrf, topg, eus, thck)
+
+    ! Given the bed topography and upper ice surface elevation, compute the ice thickness.
+    ! The ice is assumed to satisfy a flotation condition.
+    ! That is, if topg - eus < 0 (marine-based ice), and if the upper surface is too close
+    !  to sea level to ground the ice, then the ice thickness is chosen to satisfy
+    !  rhoi*H = -rhoo*(topg-eus).
+    ! Note: usrf, topg, eus and thck must all have the same units (often but not necessarily meters).
+
+    use glimmer_physcon, only : rhoo, rhoi
+
+    real(dp), dimension(:,:), intent(in) :: &
+         usrf,           & ! ice upper surface elevation
+         topg              ! elevation of bedrock topography
+
+    real(dp), intent(in) :: &
+         eus               ! eustatic sea level
+
+    real(dp), dimension(:,:), intent(out) :: &
+         thck              ! ice thickness
+
+    ! initialize
+    thck(:,:) = 0.0d0
+
+    where (usrf > (topg - eus))   ! ice is present, thck > 0
+       where (topg - eus < 0.0d0)   ! marine-based ice
+          where ((topg - eus) * (1.0d0 - rhoo/rhoi) > usrf)  ! ice is floating
+             thck = usrf / (1.0d0 - rhoi/rhoo)
+          elsewhere   ! ice is grounded
+             thck = usrf - (topg - eus)
+          endwhere
+       elsewhere   ! land-based ice
+          thck = usrf - (topg - eus)
+       endwhere
+    endwhere
+
+  end subroutine glissade_usrf_to_thck
+
+!***********************************************************************
+
+  subroutine glissade_thck_to_usrf(thck, topg, eus, usrf)
+
+    ! Given the bed topography and ice thickness, compute the upper surface elevation.
+    ! The ice is assumed to satisfy a flotation condition.
+    ! That is, if topg - eus < 0 (marine-based ice), and if the ice is too thin to be grounded,
+    !  then the upper surface is chosen to satisfy rhoi*H = rhoo*(H - usrf),
+    !  or equivalently usrf = (1 - rhoi/rhoo)*H.
+    ! Note: usrf, topg, eus and thck must all have the same units (often but not necessarily meters).
+
+    use glimmer_physcon, only : rhoo, rhoi
+
+    real(dp), dimension(:,:), intent(in) :: &
+         thck,           & ! ice thickness
+         topg              ! elevation of bedrock topography
+
+    real(dp), intent(in) :: &
+         eus               ! eustatic sea level
+
+    real(dp), dimension(:,:), intent(out) :: &
+         usrf              ! ice upper surface elevation
+
+    where ((topg - eus) < -(rhoi/rhoo)*thck)
+       usrf = (1.0d0 - rhoi/rhoo)*thck   ! ice is floating
+    elsewhere   ! ice is grounded
+       usrf = (topg - eus) + thck
+    endwhere
+
+  end subroutine glissade_thck_to_usrf
 
 !TODO - Other utility subroutines to add here?
 !       E.g., tridiag; calclsrf; subroutines to zero out tracers

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -2038,7 +2038,7 @@
     flwafact(:,:,:) = 0.d0
 
     ! Note: flwa is available in all cells, so flwafact can be computed in all cells.
-    !       This includes cells with thck < thklim, in case a value of flwa is needed
+    !       This includes cells with thck <= thklim, in case a value of flwa is needed
     !        (e.g., inactive land-margin cells adjacent to active cells).
 
     ! Loop over all cells that border locally owned vertices.

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -764,7 +764,6 @@
     integer ::   &
        whichbabc, &             ! option for basal boundary condition
        whichbeta_limit, &       ! option to limit beta for grounded ice
-       which_powerlaw_c, &      ! option for powerlaw friction parameter Cp
        which_coulomb_c, &       ! option for coulomb friction parameter Cc
        whichefvs, &             ! option for effective viscosity calculation 
                                 ! (calculate it or make it uniform)
@@ -1139,7 +1138,6 @@
 
      whichbabc            = model%options%which_ho_babc
      whichbeta_limit      = model%options%which_ho_beta_limit
-     which_powerlaw_c     = model%options%which_ho_powerlaw_c
      which_coulomb_c      = model%options%which_ho_coulomb_c
      whichefvs            = model%options%which_ho_efvs
      whichresid           = model%options%which_ho_resid
@@ -2754,7 +2752,8 @@
                 write(6,'(i6)',advance='no') j
                 do i = itest-3, itest+3
                    if (thck(i,j) > 0.0d0) then
-                      write(6,'(f10.5)',advance='no') model%basal_physics%effecpress(i,j) / (rhoi*grav*thck(i,j))
+                      write(6,'(f10.5)',advance='no') &
+                           model%basal_physics%effecpress(i,j) / (rhoi*grav*thck(i,j))
                    else
                       write(6,'(f10.5)',advance='no') 0.0d0
                    endif
@@ -2791,7 +2790,6 @@
                          beta*tau0/(vel0*scyr),            &  ! external beta (intent in)
                          beta_internal,                    &  ! beta weighted by f_ground (intent inout)
                          whichbeta_limit,                  &
-                         which_ho_powerlaw_c = which_powerlaw_c,  &
                          which_ho_coulomb_c  = which_coulomb_c,   &
                          itest = itest, jtest = jtest, rtest = rtest)
 

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -764,6 +764,7 @@
     integer ::   &
        whichbabc, &             ! option for basal boundary condition
        whichbeta_limit, &       ! option to limit beta for grounded ice
+       which_powerlaw_c, &      ! option for powerlaw friction parameter Cp
        which_coulomb_c, &       ! option for coulomb friction parameter Cc
        whichefvs, &             ! option for effective viscosity calculation 
                                 ! (calculate it or make it uniform)

--- a/tests/slab/README.md
+++ b/tests/slab/README.md
@@ -85,6 +85,14 @@ with a Gaussian perturbation of amplitude 0.1 m and run for 100 timesteps.
 The maximum stable timestep will be determined at 12 resolutions ranging from 10m to 40 km.
 This test takes several minutes to complete on a Macbook Pro with 4 cores.
 
+Note: This test can fail with an energy conservation error, due to energy conservation diagnostics
+that are not appropriate for the problem. If so, the user can edit .../libglissade/glissade_therm.F90.
+Comment out this line:
+     if (abs((efinal-einit-delta_e)/dttem) > 1.0d-7) then
+Uncomment this line:
+     if (abs((efinal-einit-delta_e)/(efinal)) > 1.0d-8) then
+And try the test again.
+
 To see the full set of commmand line options, type 'python stabilitySlab.py -h'.
 
 For questions, please contact William Lipscomb (lipscomb@ucar.edu) or Gunter Leguy (gunterl@ucar.edu).

--- a/utils/build/generate_ncvars.py
+++ b/utils/build/generate_ncvars.py
@@ -427,7 +427,7 @@ class PrintNC_template(PrintVars):
                     dimstring = dimstring + 'up'
                 else:
                     dimstring = dimstring + '1'
-                
+
             if  'level' in dims:
                 # handle 3D fields
                 spaces = ' '*3
@@ -455,8 +455,9 @@ class PrintNC_template(PrintVars):
             if 'avg_factor' in var:
                 data = '(%s)*(%s)'%(var['avg_factor'],data)
 
-            #WHL: Call parallel_put_var to write scalars; else call distributed_put_var
-            if dimstring == 'outfile%timecounter':   # scalar variable; no dimensions except time
+            #WHL: Call parallel_put_var to write scalars and 1D arrays without horizontal dimensions
+            #     Otherwise, call distributed_put_var
+            if dimstring == 'outfile%timecounter' or dimstring == '1,outfile%timecounter':
                 self.stream.write("%s       status = parallel_put_var(NCO%%id, varid, &\n%s            %s, (/%s/))\n"%(spaces,
                                                                                                                spaces,data,dimstring))
             else:
@@ -542,8 +543,9 @@ class PrintNC_template(PrintVars):
                     spaces = ' '*3
                     self.stream.write("       do up=1,NCI%nzocn\n")
 
-                #WHL: Call parallel_get_var to get scalars; else call distributed_get_var
-                if dimstring == 'infile%current_time':   # scalar variable; no dimensions except time
+                #WHL: Call parallel_get_var to read scalars and 1D arrays without horizontal dimensions
+                #     Otherwise, call distributed_get_var
+                if dimstring == 'infile%current_time' or dimstring == '1,infile%current_time':
                     self.stream.write("%s       status = parallel_get_var(NCI%%id, varid, &\n%s            %s)\n"%(spaces,
                                                                                                                    spaces,var['data']))
                 else:

--- a/utils/build/generate_ncvars.py
+++ b/utils/build/generate_ncvars.py
@@ -249,7 +249,7 @@ class PrintNC_template(PrintVars):
         self.handletoken['!GENVAR_RESETAVG!'] = self.print_var_avg_reset
         #WHL - Added for read_once forcing capability
         self.handletoken['!GENVAR_READ_ONCE_ALLOCATE!'] = self.print_var_read_once_allocate
-        self.handletoken['!GENVAR_READ_ONCE_FILL!'] = self.print_var_read_once_fill
+        self.handletoken['!GENVAR_READ_ONCE_COPY!'] = self.print_var_read_once_copy
         self.handletoken['!GENVAR_READ_ONCE_RETRIEVE!'] = self.print_var_read_once_retrieve
 
     def write(self,vars):
@@ -704,21 +704,30 @@ class PrintNC_template(PrintVars):
             self.stream.write("             nx = size(%s,1)\n"%var['data'])
             self.stream.write("             ny = size(%s,2)\n"%var['data'])
             self.stream.write("             allocate(%s(nx,ny,nt))\n"%read_once_data)
+            self.stream.write("             %s = 0.0d0\n"%read_once_data)
             self.stream.write("          end if\n\n")
 
-    def print_var_read_once_fill(self,var):
-        """Fill read_once arrays"""
+    def print_var_read_once_copy(self,var):
+        """Copy data to read_once arrays"""
 
         if var['read_once']:
             read_once_data = '%s_%s'%(var['data'],READ_ONCE_SUFFIX)
-            self.stream.write("             %s(:,:,t) = %s(:,:)\n"%(read_once_data,var['data']))
+            self.stream.write("             global_sum = parallel_reduce_sum(sum(%s))\n"%var['data'])
+            self.stream.write("             if (global_sum /= 0.0d0) then\n")
+            self.stream.write("                %s(:,:,t) = %s(:,:)\n"%(read_once_data,var['data']))
+            self.stream.write("                %s = 0.0d0\n"%var['data'])
+            self.stream.write("                if (t==1) ic%%nc%%vars = trim(ic%%nc%%vars)//' %s '\n"%var['name'])
+            self.stream.write("             endif\n\n")
 
     def print_var_read_once_retrieve(self,var):
         """Retrieve data from read_once arrays"""
 
         if var['read_once']:
             read_once_data = '%s_%s'%(var['data'],READ_ONCE_SUFFIX)
-            self.stream.write("             %s(:,:) = %s(:,:,t)\n"%(var['data'],read_once_data))
+            self.stream.write("             if (index(ic%%nc%%vars,' %s ') /= 0) then\n"%var['name'])
+            self.stream.write("                %s(:,:) = %s(:,:,t)\n"%(var['data'],read_once_data))
+            self.stream.write("                if (main_task .and. verbose_read_forcing) print*, 'Retrieve %s'\n"%var['name'])
+            self.stream.write("             endif\n\n")
 
 def usage():
     """Short help message."""


### PR DESCRIPTION
Moved commits from #63 to a branch with a less complicated merge history to get rid of duplicate commits. Original branch with appropriate dates and commit history found here: [lipscomb/hma_glaciers4
](https://github.com/ESCOMP/CISM/tree/lipscomb/hma_glaciers4)
This is the branch used to develop a glacier modeling scheme. This code was used for the runs we submitted to GlacierMIP3 for the European Alps. The glacier scheme will be described in full in a paper in prep by Minallah, Lipscomb, and Leguy. Briefly:

- CISM reads in glacier information for an RGI region or sub-region. Each glacier-covered cell is assigned an RGI integer ID, ice thickness, and basal topography. CISM converts the RGI IDs to local IDs, with glaciers numbered consecutively from 1 to N.
- CISM also reads in climate fields: typically, monthly means of surface air temperature and precipitation at a reference elevation. For the Alps, we had two input climates: a baseline climate from the 1980s with glaciers assumed to be in balance, and a warmer, more recent climate when glaciers are out of balance. The fields for the warmer climate are specified as anomalies relative to the baseline climate. Temperature is downscaled to the current glacier elevation based on a fixed lapse rate. Precip can be applied as either rain or snow based on the downscaled temperature.
- In addition, CISM reads in an observationally based SMB dataset; we have used the dataset from Hugonnet et al. (2021).
- The goal is to spin up the glaciers such that the ice thickness and extent are in good agreement with observationally-based targets for the baseline climate. The targets are typically the RGI glacier extents, along with the thickness that would be expected at a date (perhaps earlier than the RGI date) when the glaciers are in balance with the climate.
- During the spin-up, we adjust two parameters, alpha and mu, for each glacier to satisfy two equations: (1) SMB = 0 = alphaP - muTp over the target glacier extent for the baseline climate, and (2) SMB' = SMB_obs = alphaP' - muTp' over the target glacier extent for the recent warm climate. Here, P is the precip and Tp is proportional to the difference between the downscaled temperature and the freezing temperature.
- During the spin-up, the ice flow dynamics is the same as it would be for ice sheets, but at higher resolution (100–200 m for the Alps). For glaciers we've been using the DIVA velocity solver with power-law basal sliding. The parameter C_p (powerlaw_c) is adjusted to optimize the match with the thickness target. The spin-up typically takes several thousand years. Toward the end of the spin-up, we may turn off the C_p inversion.
- Various logic is applied during the spin-up to assign appropriate integer IDs as glaciers advance and retreat, and to discourage excessive advance and retreat.
- Once the glaciers are spun up, we can run forward with a new climate.

Much of the new code is in the new module glissade_glaciers.F90. There are some new glacier fields (some 1D, others 2D) in glide_vars.def, and there is a new 'glaciers' section of the config file.

There is a new restart option 2: "hybrid restart". For this kind of restart, CISM initializes itself using the restart file from a previous run, but with a new start and end date specified in the config file.

There are some new I/O capabilities. For example, it is possible to read in all the input climate data (e.g., monthly data for 20 different years, a total of 240 time slices) once at initialization and store the data for repeated application during the run (rather than read in the same monthly data multiple times).

Glacier-related diagnostics (e.g., total glacier area and volume in the region) are written to the log file along with the standard diagnostics.