### PR TITLE
A few updates to fix sourcing module files

### DIFF
--- a/builds/derecho-intel/derecho-intel-cmake
+++ b/builds/derecho-intel/derecho-intel-cmake
@@ -6,7 +6,7 @@
 
 source /etc/profile.d/z00_modules.csh
 
-source derecho-intel-modules
+./derecho-intel-modules
 
 # remove old build data:
 rm -f ./CMakeCache.txt

--- a/builds/derecho-intel/derecho-intel-cmake.sh
+++ b/builds/derecho-intel/derecho-intel-cmake.sh
@@ -17,7 +17,7 @@ fi
 
 source /etc/profile.d/z00_modules.sh
 
-source derecho-intel-modules
+./derecho-intel-modules
 
 echo CISM: "${cism_top}"
 

--- a/builds/derecho-intel/derecho-intel-modules
+++ b/builds/derecho-intel/derecho-intel-modules
@@ -5,4 +5,4 @@ module load ncarcompilers/1.0.0
 module load cray-mpich/8.1.27
 module load mkl/2023.2.0
 module load netcdf/4.9.2
-module load cmake/3.26.3
+module load cmake


### PR DESCRIPTION
The "source" command wasn't working in the ".sh" file due to a mismatch between "sh" and full "bash". Making the module file executable solves this problem in a simple method.