### PR TITLE
Lipscomb/antarctic calving

### DIFF
--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -194,9 +194,6 @@ contains
     model%calving%marine_limit = model%calving%marine_limit / thk0
     model%calving%timescale = model%calving%timescale * scyr                ! convert from yr to s
     model%calving%cliff_timescale = model%calving%cliff_timescale * scyr    ! convert from yr to s
-    !TODO - No conversion for strain-based calving
-!!!    model%calving%damage_constant1 = model%calving%damage_constant1 / scyr  ! convert from yr^{-1} to s^{-1}
-!!!    model%calving%damage_constant2 = model%calving%damage_constant2 / scyr  ! convert from yr^{-1} to s^{-1}
 
     ! scale periodic offsets for ISMIP-HOM
     model%numerics%periodic_offset_ew = model%numerics%periodic_offset_ew / thk0
@@ -976,7 +973,7 @@ contains
          'compute isostasy with model     ' /)
 
     !TODO - Change 'marine_margin' to 'calving'?  Would have to modify many config files
-    character(len=*), dimension(0:11), parameter :: marine_margin = (/ &
+    character(len=*), dimension(0:12), parameter :: marine_margin = (/ &
          'no calving law                   ', &
          'remove all floating ice          ', &
          'remove fraction of floating ice  ', &
@@ -987,6 +984,7 @@ contains
          'ice thickness threshold          ', &
          'stress threshold                 ', &
          'strain-rate (eigencalving)       ', &
+         'stochastic stress-based calving  ', &
          'damage-based calving scheme      ', &
          'Huybrechts calving               '/)
 
@@ -1452,24 +1450,16 @@ contains
 
     else   ! not Glissade
 
-       if (model%options%whichcalving == CALVING_THCK_THRESHOLD) then
-          call write_log('Error, calving thickness threshold option is supported for Glissade dycore only', GM_FATAL)
+       if (model%options%whichcalving == CALVING_GRID_MASK .or. &
+           model%options%whichcalving == CALVING_THCK_THRESHOLD .or. &
+           model%options%whichcalving == CF_ADVANCE_RETREAT_RATE .or. &
+           model%options%whichcalving == CALVING_STRESS .or. &
+           model%options%whichcalving == EIGEN_CALVING .or. &
+           model%options%whichcalving == CALVING_STRESS_STOCHASTIC .or. &
+           model%options%whichcalving == CALVING_DAMAGE) then
+          call write_log('Error, this calving option is supported for Glissade dycore only', GM_FATAL)
        endif
-       if (model%options%whichcalving == EIGEN_CALVING) then
-          call write_log('Error, eigencalving option is supported for Glissade dycore only', GM_FATAL)
-       endif
-       if (model%options%whichcalving == CALVING_STRESS) then
-          call write_log('Error, stress-based calving option is supported for Glissade dycore only', GM_FATAL)
-       endif
-       if (model%options%whichcalving == CALVING_GRID_MASK) then
-          call write_log('Error, calving grid mask option is supported for Glissade dycore only', GM_FATAL)
-       endif
-       if (model%options%whichcalving == CALVING_DAMAGE) then
-          call write_log('Error, calving damage option is supported for Glissade dycore only', GM_FATAL)
-       endif
-       if (model%options%whichcalving == CF_ADVANCE_RETREAT_RATE) then
-          call write_log('Error, calving front advance/retreat option is supported for Glissade dycore only', GM_FATAL)
-       endif
+
        if (model%options%calving_domain /= CALVING_DOMAIN_OCEAN_EDGE) then
           write(message,*) 'WARNING: calving domain can be selected for Glissade dycore only; user selection ignored'
           call write_log(message, GM_WARNING)
@@ -2449,10 +2439,11 @@ contains
        call write_log(message)
     endif
 
-    if (model%options%whichcalving == CF_ADVANCE_RETREAT_RATE.or.  &
-        model%options%whichcalving == CALVING_THCK_THRESHOLD .or.  &
-        model%options%whichcalving == CALVING_STRESS         .or.  &
-        model%options%whichcalving == EIGEN_CALVING          .or.  &
+    if (model%options%whichcalving == CF_ADVANCE_RETREAT_RATE    .or.  &
+        model%options%whichcalving == CALVING_THCK_THRESHOLD     .or.  &
+        model%options%whichcalving == CALVING_STRESS             .or.  &
+        model%options%whichcalving == EIGEN_CALVING              .or.  &
+        model%options%whichcalving == CALVING_STRESS_STOCHASTIC  .or.  &
         model%options%whichcalving == CALVING_DAMAGE) then
 
        if (model%options%which_ho_calving_front == HO_CALVING_FRONT_NO_SUBGRID) then
@@ -2478,6 +2469,13 @@ contains
           call write_log(message)
           write(message,*) 'stress_threshold (Pa)         : ', model%calving%stress_threshold
           call write_log(message)
+       elseif (model%options%whichcalving == CALVING_STRESS_STOCHASTIC) then
+          write(message,*) 'tau_eigenconstant 1           : ', model%calving%tau_eigenconstant1
+          call write_log(message)
+          write(message,*) 'tau_eigenconstant 2           : ', model%calving%tau_eigenconstant2
+          call write_log(message)
+          write(message,*) 'stress_threshold (Pa)         : ', model%calving%stress_threshold
+          call write_log(message)
        elseif (model%options%whichcalving == CALVING_DAMAGE) then
           write(message,*) 'damage constant1 (1/yr)       : ', model%calving%damage_constant1
           call write_log(message)
@@ -2494,14 +2492,13 @@ contains
           call write_log(message)
        endif
 
-    endif   ! calving options: thck_threshold, eigencalving, damage
+    endif   ! calving options: thck_threshold, eigencalving, stress-based, etc.
 
     if (model%options%which_ho_calving_front == HO_CALVING_FRONT_SUBGRID) then
        write(message,*) 'subgrid dthck_dx_cf           : ', model%calving%dthck_dx_cf
        call write_log(message)
        write(message,*) 'thck_effective_min (m)        : ', model%calving%thck_effective_min
        call write_log(message)
-       !TODO - Is the following needed with the new SUBGRID option?
        if (.not.model%options%remove_icebergs) then
           model%options%remove_icebergs = .true.
           write(message,*) 'Setting remove_icebergs = T for stability when using subgrid calving_front scheme'

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -974,19 +974,19 @@ contains
 
     !TODO - Change 'marine_margin' to 'calving'?  Would have to modify many config files
     character(len=*), dimension(0:12), parameter :: marine_margin = (/ &
-         'no calving law                   ', &
-         'remove all floating ice          ', &
-         'remove fraction of floating ice  ', &
-         'relaxed bedrock threshold        ', &
-         'present bedrock threshold        ', &
-         'calving based on grid location   ', &
-         'prescribe CF advance/retreat rate', &
-         'ice thickness threshold          ', &
-         'stress threshold                 ', &
-         'strain-rate (eigencalving)       ', &
-         'stochastic stress-based calving  ', &
-         'damage-based calving scheme      ', &
-         'Huybrechts calving               '/)
+         'no calving law                     ', &
+         'remove all floating ice           ', &
+         'remove fraction of floating ice   ', &
+         'relaxed bedrock threshold         ', &
+         'present bedrock threshold         ', &
+         'calving based on grid location    ', &
+         'prescribe CF advance/retreat rate ', &
+         'ice thickness threshold           ', &
+         'deterministic stress-based calving', &
+         'stochastic stress-based calving   ', &
+         'damage-based calving scheme       ', &
+         'strain-rate (eigencalving)        ', &
+         'Huybrechts calving                '/)
 
     character(len=*), dimension(0:1), parameter :: init_calving = (/ &
          'no calving at initialization    ', &
@@ -2205,9 +2205,11 @@ contains
     call GetValue(section,'tau_eigenconstant1', model%calving%tau_eigenconstant1)
     call GetValue(section,'tau_eigenconstant2', model%calving%tau_eigenconstant2)
     call GetValue(section,'stress_threshold',   model%calving%stress_threshold)
+    call GetValue(section,'lateral_rate_min',   model%calving%lateral_rate_min)
+    call GetValue(section,'effec_stress_min',   model%calving%effec_stress_min)
+    call GetValue(section,'length_scale',       model%calving%length_scale)
     call GetValue(section,'damage_threshold',   model%calving%damage_threshold)
-    call GetValue(section,'damage_constant1',   model%calving%damage_constant1)
-    call GetValue(section,'damage_constant2',   model%calving%damage_constant2)
+    call GetValue(section,'damage_constant',    model%calving%damage_constant)
     call GetValue(section,'taumax_cliff',       model%calving%taumax_cliff)
     call GetValue(section,'cliff_timescale',    model%calving%cliff_timescale)
     call GetValue(section,'calving_front_x',    model%calving%calving_front_x)
@@ -2442,8 +2444,8 @@ contains
     if (model%options%whichcalving == CF_ADVANCE_RETREAT_RATE    .or.  &
         model%options%whichcalving == CALVING_THCK_THRESHOLD     .or.  &
         model%options%whichcalving == CALVING_STRESS             .or.  &
-        model%options%whichcalving == EIGEN_CALVING              .or.  &
         model%options%whichcalving == CALVING_STRESS_STOCHASTIC  .or.  &
+        model%options%whichcalving == EIGEN_CALVING              .or.  &
         model%options%whichcalving == CALVING_DAMAGE) then
 
        if (model%options%which_ho_calving_front == HO_CALVING_FRONT_NO_SUBGRID) then
@@ -2469,6 +2471,8 @@ contains
           call write_log(message)
           write(message,*) 'stress_threshold (Pa)         : ', model%calving%stress_threshold
           call write_log(message)
+          write(message,*) 'lateral_rate_min (m/yr)       : ', model%calving%lateral_rate_min
+          call write_log(message)
        elseif (model%options%whichcalving == CALVING_STRESS_STOCHASTIC) then
           write(message,*) 'tau_eigenconstant 1           : ', model%calving%tau_eigenconstant1
           call write_log(message)
@@ -2476,10 +2480,14 @@ contains
           call write_log(message)
           write(message,*) 'stress_threshold (Pa)         : ', model%calving%stress_threshold
           call write_log(message)
-       elseif (model%options%whichcalving == CALVING_DAMAGE) then
-          write(message,*) 'damage constant1 (1/yr)       : ', model%calving%damage_constant1
+          write(message,*) 'effec_stress_min (m/yr)       : ', model%calving%effec_stress_min
           call write_log(message)
-          write(message,*) 'damage constant2 (1/yr)       : ', model%calving%damage_constant2
+          write(message,*) 'calving_length_scale (m)      : ', model%calving%length_scale
+          call write_log(message)
+       elseif (model%options%whichcalving == CALVING_DAMAGE) then
+          write(message,*) 'tau_eigenconstant 1           : ', model%calving%tau_eigenconstant1
+          call write_log(message)
+          write(message,*) 'tau_eigenconstant 2           : ', model%calving%tau_eigenconstant2
           call write_log(message)
           write(message,*) 'damage threshold              : ', model%calving%damage_threshold
           call write_log(message)
@@ -3728,13 +3736,15 @@ contains
            call glide_add_to_restart_variable_list('calving_mask', model_id)
         endif
 
-           ! The eigencalving calculation requires the product of eigenvalues of the horizontal strain rate tensor,
+        ! The eigencalving calculation requires the product of eigenvalues of the horizontal strain rate tensor,
         !  which depends on the stress tensor, which is computed by the HO solver.
         ! On restart, the correct stress and strain rate tensors are not available, so we read in the eigenproduct.
-        if (options%whichcalving == EIGEN_CALVING .or. options%whichcalving == CALVING_DAMAGE) then
+        if (options%whichcalving == EIGEN_CALVING) then
            call glide_add_to_restart_variable_list('eps_eigen1', model_id)
            call glide_add_to_restart_variable_list('eps_eigen2', model_id)
-        elseif (options%whichcalving == CALVING_STRESS) then
+        elseif (options%whichcalving == CALVING_STRESS .or. &
+                options%whichcalving == CALVING_STRESS_STOCHASTIC .or. &
+                options%whichcalving == CALVING_DAMAGE) then
            call glide_add_to_restart_variable_list('tau_eigen1', model_id)
            call glide_add_to_restart_variable_list('tau_eigen2', model_id)
         endif

--- a/libglide/glide_setup.F90
+++ b/libglide/glide_setup.F90
@@ -749,7 +749,6 @@ contains
     call GetValue(section,'remove_isthmuses', model%options%remove_isthmuses)
     call GetValue(section,'expand_calving_mask', model%options%expand_calving_mask)
     call GetValue(section,'limit_marine_cliffs', model%options%limit_marine_cliffs)
-    call GetValue(section,'cull_calving_front', model%options%cull_calving_front)
     call GetValue(section,'damage_flwa_feedback', model%options%damage_flwa_feedback)
     call GetValue(section,'adjust_input_thickness', model%options%adjust_input_thickness)
     call GetValue(section,'smooth_input_topography', model%options%smooth_input_topography)
@@ -1424,13 +1423,6 @@ contains
           call write_log(' The thickness of marine ice cliffs will be limited')
        else
           call write_log(' The thickness of marine ice cliffs will not be limited')
-       endif
-
-       if (model%options%cull_calving_front) then
-          write(message,*) ' Calving-front cells will be culled', model%calving%ncull_calving_front, 'times at initialization'
-          call write_log(message)
-       else
-          call write_log(' Calving-front cells will not be culled at initialization')
        endif
 
        if (model%options%whichcalving == CALVING_FLOAT_FRACTION) then
@@ -2228,7 +2220,6 @@ contains
     call GetValue(section,'damage_constant2',   model%calving%damage_constant2)
     call GetValue(section,'taumax_cliff',       model%calving%taumax_cliff)
     call GetValue(section,'cliff_timescale',    model%calving%cliff_timescale)
-    call GetValue(section,'ncull_calving_front',model%calving%ncull_calving_front)
     call GetValue(section,'calving_front_x',    model%calving%calving_front_x)
     call GetValue(section,'calving_front_y',    model%calving%calving_front_y)
     call GetValue(section,'f_ground_threshold', model%calving%f_ground_threshold)

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -184,9 +184,9 @@ module glide_types
   integer, parameter :: CF_ADVANCE_RETREAT_RATE = 6
   integer, parameter :: CALVING_THCK_THRESHOLD = 7
   integer, parameter :: CALVING_STRESS = 8
-  integer, parameter :: EIGEN_CALVING = 9
-  integer, parameter :: CALVING_STRESS_STOCHASTIC = 10
-  integer, parameter :: CALVING_DAMAGE = 11
+  integer, parameter :: CALVING_STRESS_STOCHASTIC = 9
+  integer, parameter :: CALVING_DAMAGE = 10
+  integer, parameter :: EIGEN_CALVING = 11
   integer, parameter :: CALVING_HUYBRECHTS = 12
 
   integer, parameter :: CALVING_INIT_OFF = 0
@@ -667,10 +667,10 @@ module glide_types
     !> \item[5] Set thickness to zero based on grid location (field 'calving_mask')
     !> \item[6] Prescribe the rate of calving front advance or retreat
     !> \item[7] Calve ice whose thickness is below a given threshold
-    !> \item[8] Calving rate based on stress threshold criterion (von Mises)
-    !> \item[9] Calving rate based on strain-rate criterion (eigencalving)
-    !> \item[10] Stochastic stress-based calving
-    !> \item[11] Calve ice that is sufficiently damaged
+    !> \item[8] Deterministic calving based on eigenvalues of the horizontal stress tensor
+    !> \item[9] Stochastic calving based on eigenvalues of the horizontal stress tensor
+    !> \item[10] Calving based on stochastic internal damage
+    !> \item[11] Eigencalving following Levermann et al. (2012)
     !> \item[12] Huybrechts calving
     !TODO - Revise the numbering?
     !> \end{description}
@@ -868,16 +868,16 @@ module glide_types
     !> Flag for basal powerlaw_c options
     !> \begin{description}
     !> \item[0] powerlaw_c = spatially uniform constant
-    !> \item[1] powerlaw_c = invert for 2D coulomb_c
-    !> \item[2] powerlaw_c = read 2D coulomb_c from external file
+    !> \item[1] invert for 2D powerlaw_c
+    !> \item[2] read 2D powerlaw_c from external file
     !> \end{description}
 
     integer :: which_ho_coulomb_c = 0
     !> Flag for basal coulomb_c options
     !> \begin{description}
     !> \item[0] coulomb_c = spatially uniform constant
-    !> \item[1] coulomb_c = invert for 2D coulomb_c
-    !> \item[2] coulomb_c = read 2D coulomb_c from external file
+    !> \item[1] invert for 2D coulomb_c
+    !> \item[2] read 2D coulomb_c from external file
     !> \item[3] coulomb_c = function of bed elevation
     !> \end{description}
 
@@ -921,7 +921,7 @@ module glide_types
     !> Basal water depth:
     !> \begin{description}
     !> \item[0] Set to zero everywhere
-    !> \item[1] Set to constant everywhere, to force T = Tpmp.
+    !> \item[1] Set to constant everywhere, to force T = Tpmp
     !> \item[2] Local basal till model with constant drainage
     !> \item[3] Steady-state water routing with flux calculation
     !> \end{description}
@@ -1555,7 +1555,6 @@ module glide_types
      real(dp),dimension(:,:),  pointer :: thck_effective => null() !> effective thickness for calving (m)
      real(dp),dimension(:,:),  pointer :: effective_areafrac => null() !> effective fractional area, < 1 for partial CF cells (m)
      real(dp),dimension(:,:),  pointer :: lateral_rate => null()   !> lateral calving rate (m/yr, not scaled)
-                                                                   !> (whichcalving = EIGEN_CALVING, CALVING_DAMAGE) 
      real(dp),dimension(:,:),  pointer :: tau_eigen1 => null()     !> first eigenvalue of 2D horizontal stress tensor (Pa)
      real(dp),dimension(:,:),  pointer :: tau_eigen2 => null()     !> second eigenvalue of 2D horizontal stress tensor (Pa)
      real(dp),dimension(:,:),  pointer :: eps_eigen1 => null()     !> first eigenvalue of 2D horizontal strain rate tensor (s^-1)
@@ -1575,13 +1574,17 @@ module glide_types
      real(dp) :: dthck_dx_cf = 0.0d0             !> assumed max value of |dH/dx| at the calving front for full (not partial) cells (m/m)
      real(dp) :: thck_effective_min = 50.0d0     !> minimum value of thck_effective (m) for calving-front cells
      real(dp) :: eigenconstant = 0.0d0           !> constant that multiplies the eigen-based strain rate to determine the calving rate (m)
-     real(dp) :: tau_eigenconstant1 = 1.0d0      !> constant that multiplies the tau_eigen1 term in stress-based calving (unitless)
+     real(dp) :: tau_eigenconstant1 = 0.25d0     !> constant that multiplies the tau_eigen1 term in stress-based calving (unitless)
      real(dp) :: tau_eigenconstant2 = 1.0d0      !> constant that multiplies the tau_eigen2 term in stress-based calving (unitless)
-     real(dp) :: stress_threshold = 1.0e5        !> stress threshold for CF retreat with stress-based calving (Pa)
+     real(dp) :: stress_threshold = 6.0e4        !> stress threshold for CF retreat with stress-based calving (Pa)
+     real(dp) :: lateral_rate_min = 0.0d0        !> minimum lateral retreat rate at CF (m/yr)
+     real(dp) :: effec_stress_min = 0.0d0        !> minimum effective stress for calving at CF (m/yr)
+     real(dp) :: length_scale = 4000.d0          !> length scale (m) for calving events (CALVING_STRESS_STOCHASTIC)
      real(dp) :: damage_threshold = 0.0d0        !> threshold at which ice column is sufficiently damaged to calve
                                                  !> 0 = no damage, 1 = total damage (whichcalving = CALVING_DAMAGE)
-     real(dp) :: damage_constant1 = 0.0d0        !> damage constant that multiplies tau_eigen1 (yr^-1)
-     real(dp) :: damage_constant2 = 0.0d0        !> damage constant that multiplies tau_eigen2 (yr^-1)
+     real(dp) :: damage_constant = 1.e5          !> damage scaling term with units of Pa * yr
+!     real(dp) :: damage_constant1 = 0.0d0        !> damage constant that multiplies tau_eigen1 (yr^-1)
+!     real(dp) :: damage_constant2 = 0.0d0        !> damage constant that multiplies tau_eigen2 (yr^-1)
      real(dp) :: taumax_cliff = 1.0d6            !> yield stress (Pa) for marine-based ice cliffs
      real(dp) :: cliff_timescale = 10.0d0        !> time scale (yr) for limiting marine cliffs (yr)
      real(dp) :: calving_front_x = 0.0d0         !> for CALVING_GRID_MASK option, calve ice wherever abs(x) > calving_front_x (m)
@@ -1911,8 +1914,8 @@ module glide_types
      integer :: set_powerlaw_c = 0
      !> \begin{description}
      !> \item[0] apply spatially uniform powerlaw_c
-     !> \item[1] invert for glacier-specific powerlaw_c
-     !> \item[2] read glacier-specific powerlaw_c from external file
+     !> \item[1] invert for 2D powerlaw_c
+     !> \item[2] read 2D powerlaw_c from external file
      !> \end{description}
 
      ! other options
@@ -1958,6 +1961,7 @@ module glide_types
           alpha_snow_max = 3.0d0              ! max value of alpha_snow
 
      real(dp) ::  &
+          !TODO - Change beta_artm_max to 5.0 as in Alps runs?
           beta_artm_max = 3.0,              & ! max magnitude of beta_artm (deg C)
           beta_artm_increment = 0.05d0        ! fixed increment in beta_artm (deg C)
 
@@ -1968,6 +1972,7 @@ module glide_types
           snow_threshold_max = 2.0d0          !> air temperature (deg C) above which all precip falls as rain
 
      real(dp) :: &
+          !TODO - Change baseline date to 1984 as in Alps runs?
           baseline_date = 1980.d0,          & !> baseline date, when glaciers are assumed to be in balance
           rgi_date = 2003.d0,               & !> date of RGI observations
           recent_date = 2010.d0               !> recent date associated with SMB observations for glaciers out of balance

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -185,8 +185,9 @@ module glide_types
   integer, parameter :: CALVING_THCK_THRESHOLD = 7
   integer, parameter :: CALVING_STRESS = 8
   integer, parameter :: EIGEN_CALVING = 9
-  integer, parameter :: CALVING_DAMAGE = 10
-  integer, parameter :: CALVING_HUYBRECHTS = 11
+  integer, parameter :: CALVING_STRESS_STOCHASTIC = 10
+  integer, parameter :: CALVING_DAMAGE = 11
+  integer, parameter :: CALVING_HUYBRECHTS = 12
 
   integer, parameter :: CALVING_INIT_OFF = 0
   integer, parameter :: CALVING_INIT_ON = 1
@@ -668,8 +669,10 @@ module glide_types
     !> \item[7] Calve ice whose thickness is below a given threshold
     !> \item[8] Calving rate based on stress threshold criterion (von Mises)
     !> \item[9] Calving rate based on strain-rate criterion (eigencalving)
-    !> \item[10] Calve ice that is sufficiently damaged
-    !> \item[11] Huybrechts calving
+    !> \item[10] Stochastic stress-based calving
+    !> \item[11] Calve ice that is sufficiently damaged
+    !> \item[12] Huybrechts calving
+    !TODO - Revise the numbering?
     !> \end{description}
 
     integer :: calving_init = 0

--- a/libglide/glide_types.F90
+++ b/libglide/glide_types.F90
@@ -664,11 +664,10 @@ module glide_types
     !> \item[4] Set thickness to zero if present bedrock topography lies below
     !>          a certain water depth (variable "marine_limit" in glide_types)  
     !> \item[5] Set thickness to zero based on grid location (field 'calving_mask')
-    !> \item[6] Set thickness to zero if ice at marine margin is thinner than
-    !>          a certain value (variable 'calving_minthck' in glide_types)
-    !> \item[7] Calving rate based on strain-rate criterion (eigencalving)
+    !> \item[6] Prescribe the rate of calving front advance or retreat
+    !> \item[7] Calve ice whose thickness is below a given threshold
     !> \item[8] Calving rate based on stress threshold criterion (von Mises)
-    !> \item[9] Prescribe the rate of calving front advance or retreat
+    !> \item[9] Calving rate based on strain-rate criterion (eigencalving)
     !> \item[10] Calve ice that is sufficiently damaged
     !> \item[11] Huybrechts calving
     !> \end{description}
@@ -704,10 +703,6 @@ module glide_types
 
     logical :: limit_marine_cliffs = .false.
     !> if true, then thin marine-based cliffs based on a thickness threshold
-
-    logical :: cull_calving_front = .false.
-    !> if true, then cull calving_front cells at initialization
-    !> This can make the run more stable by removing long, thin peninsulas
 
     logical :: damage_flwa_feedback = .false.
     !> if true, then flwa increases as damage increases
@@ -1584,8 +1579,6 @@ module glide_types
                                                  !> 0 = no damage, 1 = total damage (whichcalving = CALVING_DAMAGE)
      real(dp) :: damage_constant1 = 0.0d0        !> damage constant that multiplies tau_eigen1 (yr^-1)
      real(dp) :: damage_constant2 = 0.0d0        !> damage constant that multiplies tau_eigen2 (yr^-1)
-     integer  :: ncull_calving_front = 0         !> number of times to cull calving_front cells at initialization, if cull_calving_front = T
-                                                 !> Set to a larger value to remove wider peninsulas
      real(dp) :: taumax_cliff = 1.0d6            !> yield stress (Pa) for marine-based ice cliffs
      real(dp) :: cliff_timescale = 10.0d0        !> time scale (yr) for limiting marine cliffs (yr)
      real(dp) :: calving_front_x = 0.0d0         !> for CALVING_GRID_MASK option, calve ice wherever abs(x) > calving_front_x (m)

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -1056,10 +1056,11 @@ contains
 
     endif   ! force_retreat
 
-    !WHL - debug - Compute calving_mask for all the subgrid CF options
-!!    if ((model%options%whichcalving == CALVING_GRID_MASK .or. model%options%apply_calving_mask)  &
+    !Note: Compute calving_mask not only for the CALVING_GRID_MASK option, but also for the
+    !      subgrid CF options. With the subgrid CF options, we can use calving_mask to disable
+    !      inversion procedures that might inhibit CF advance/retreat (since this would be cheating).
     if ( (model%options%whichcalving == CALVING_GRID_MASK .or. model%options%apply_calving_mask .or.  &
-         model%options%which_ho_calving_front == HO_CALVING_FRONT_SUBGRID)  &
+          model%options%which_ho_calving_front == HO_CALVING_FRONT_SUBGRID)  &
          .and. model%options%is_restart == NO_RESTART) then
 
        ! Initialize the no-advance calving_mask
@@ -3227,7 +3228,8 @@ contains
     use glimmer_physcon, only: scyr
     use glissade_calving, only: glissade_calve_ice, verbose_calving, &
          glissade_remove_icebergs, glissade_remove_isthmuses, glissade_limit_cliffs
-    use glissade_masks, only: glissade_get_masks, glissade_ocean_connection_mask
+    use glissade_masks, only: glissade_get_masks, glissade_ocean_connection_mask, &
+         glissade_calving_front_mask
     use glissade_grounding_line, only: glissade_grounded_fraction
     implicit none
 
@@ -3276,6 +3278,11 @@ contains
     type(parallel_type) :: parallel   ! info for parallel communication
 
     logical, parameter :: verbose_retreat = .true.
+
+    integer, dimension(model%general%ewn, model%general%nsn) :: &
+         calving_front_mask,      & !
+         partial_cf_mask,         & ! = 1 for partially filled CF cells (thck < thck_effective), else = 0
+         full_mask                  ! = 1 for ice-filled cells that are not partial_cf cells, else = 0
 
     nx = model%general%ewn
     ny = model%general%nsn
@@ -3702,7 +3709,7 @@ contains
             land_mask = land_mask,  ocean_mask = ocean_mask)
 
        ! Compute the grounded ice fraction in each grid cell
-
+       !TODO - See if we can spread the fill with a grounded_mask (i.e., without f_ground_cell)
        call glissade_grounded_fraction(&
             nx,          ny,               &
             parallel,                      &
@@ -3720,6 +3727,33 @@ contains
             model%geometry%f_ground,       &
             model%geometry%f_ground_cell,  &
             model%geometry%topg_stdev*thk0)
+
+       if (model%options%which_ho_calving_front == HO_CALVING_FRONT_SUBGRID) then
+
+          ! Compute partial_cf_mask and full-mask.
+          ! This is to prevent partial CF cells from spreading the fill.
+          call glissade_calving_front_mask(&
+               nx,          ny,     &
+               model%options%which_ho_calving_front,       &
+               parallel,                                   &
+               model%geometry%thck*thk0,                   &
+               model%geometry%topg*thk0,                   &
+               model%climate%eus*thk0,                     &
+               ice_mask,            floating_mask,         &
+               ocean_mask,          land_mask,             &
+               calving_front_mask,                         &
+               dx = model%numerics%dew*len0,               &
+               dy = model%numerics%dns*len0,               &
+               dthck_dx_cf = model%calving%dthck_dx_cf,    &
+               thck_effective = model%calving%thck_effective,  &
+               thck_effective_min = model%calving%thck_effective_min,  &
+               partial_cf_mask = partial_cf_mask,          &
+               full_mask = full_mask,                      &
+               effective_areafrac = model%calving%effective_areafrac)
+
+          ice_mask = full_mask
+
+       endif   ! which_ho_calving_front
 
        ! Remove icebergs.
        ! Icebergs are defined as floating cells that do not have a path through active cells

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -3733,6 +3733,7 @@ contains
             thck_unscaled,                        &  ! m
             model%geometry%f_ground_cell,         &
             ice_mask,                             &
+            floating_mask,                        &
             land_mask,                            &
             model%calving%calving_thck)              ! m
 

--- a/libglissade/glissade.F90
+++ b/libglissade/glissade.F90
@@ -3225,9 +3225,8 @@ contains
 
     use glimmer_paramets, only: thk0, tim0, len0, vel0
     use glimmer_physcon, only: scyr
-    use glissade_calving, only: glissade_calve_ice, glissade_cull_calving_front, &
-         glissade_remove_icebergs, glissade_remove_isthmuses, glissade_limit_cliffs, &
-         verbose_calving
+    use glissade_calving, only: glissade_calve_ice, verbose_calving, &
+         glissade_remove_icebergs, glissade_remove_isthmuses, glissade_limit_cliffs
     use glissade_masks, only: glissade_get_masks, glissade_ocean_connection_mask
     use glissade_grounding_line, only: glissade_grounded_fraction
     implicit none
@@ -3255,8 +3254,6 @@ contains
     real(dp) :: &
          maxthck,                 & ! max thickness of retreating ice
          dthck                      ! thickness loss for retreating ice
-
-    logical :: cull_calving_front   ! true iff init_calving = T and options%cull_calving_front = T
 
     integer :: i, j
 
@@ -3546,22 +3543,6 @@ contains
             model%isostasy%relx*thk0,          &        ! m
             model%geometry%topg*thk0,          &        ! m
             model%climate%eus*thk0)                     ! m
-
-    endif
-
-    if (init_calving .and. model%options%cull_calving_front) then
-
-       call glissade_cull_calving_front(&
-            nx,           ny,              &
-            parallel,                      &
-            itest, jtest, rtest,           &
-            thck_unscaled,                 &  ! m
-            model%geometry%topg*thk0,      &  ! m
-            model%climate%eus*thk0,        &  ! m
-            model%numerics%thklim*thk0,    &  ! m
-            model%options%which_ho_calving_front, &
-            model%calving%ncull_calving_front,    &
-            model%calving%calving_thck)       ! m
 
     endif
 
@@ -4978,7 +4959,8 @@ contains
 
     !WHL - inversion debug
     ! The goal is to spin up in a way that minimizes flipping between grounded and floating.
-    if (verbose_inversion .and. model%numerics%time > model%numerics%tstart .and. &
+!!    if (verbose_inversion .and. model%numerics%time > model%numerics%tstart .and. &
+    if (0 == 1 .and. model%numerics%time > model%numerics%tstart .and. &
         (model%options%which_ho_powerlaw_c == HO_POWERLAW_C_INVERSION .or.  &
          model%options%which_ho_coulomb_c  == HO_COULOMB_C_INVERSION) ) then
        do j = nhalo+1, nsn-nhalo

--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -665,6 +665,40 @@ contains
                calving%stress_threshold,          &  ! Pa
                calving_dthck)                        ! m
 
+       elseif (which_calving == CALVING_STRESS_STOCHASTIC) then
+
+          call extrapolate_to_calving_front(&
+               nx,                 ny,     &
+               partial_cf_mask,            &
+               full_mask,                  &
+               calving%effective_areafrac, &
+               speed)
+
+          call extrapolate_to_calving_front(&
+               nx,                 ny,     &
+               partial_cf_mask,            &
+               full_mask,                  &
+               calving%effective_areafrac, &
+               calving%tau_eigen1,         &
+               calving%tau_eigen2)
+
+          call stochastic_stress_based_calving(&
+               nx,                 ny,            &
+               dx,                 dy,            &  ! m
+               dt,                                &  ! s
+               itest,   jtest,     rtest,         &
+               parallel,                          &
+               calving_front_mask,                &
+               floating_mask,                     &
+               speed,                             &  ! m/s
+               thck,                              &  ! m
+               calving%tau_eigen1,                &  ! Pa
+               calving%tau_eigen2,                &  ! Pa
+               calving%tau_eigenconstant1,        &
+               calving%tau_eigenconstant2,        &
+               calving%stress_threshold,          &  ! Pa
+               calving_dthck)                        ! m
+
        elseif (which_calving == EIGEN_CALVING) then
 
           call extrapolate_to_calving_front(&
@@ -1566,6 +1600,250 @@ contains
 
 !---------------------------------------------------------------------------
 
+  subroutine stochastic_stress_based_calving(&
+       nx,                 ny,            &
+       dx,                 dy,            &  ! m
+       dt,                                &  ! s
+       itest,   jtest,     rtest,         &
+       parallel,                          &
+       calving_front_mask,                &
+       floating_mask,                     &
+       speed,                             &  ! m/s
+       thck,                              &  ! m
+       tau_eigen1,    tau_eigen2,         &  ! Pa
+       tau_eigenconstant1,                &
+       tau_eigenconstant2,                &
+       stress_threshold,                  &  ! Pa
+       calving_dthck)                        ! m
+
+    ! Calve ice based on the eigenvalues of the 2D horizontal stress tensor near the calving front.
+    ! Instead of computing a deterministic calving rate (as in the subroutine above),
+    ! let the calving be stochastic.
+    !
+    ! The general idea is that each cell is assigned a damage probability based on the effective stress.
+    ! With high effective stress, it becomes asymptotically more likely to fail.
+    ! In each cell with nonzero damage, generate a random number to decide whether it fails.
+    ! After identifying failed cells, remove all the failed cells at the CF.
+    ! Also remove failed interior cells that have a path through failed cells to the CF.
+    !
+    ! This idea is based roughly on the percolation model of Bahr (1995).
+    ! Still under construction.
+
+    use glissade_masks, only: glissade_fill, initial_color, fill_color, boundary_color
+    use glide_diagnostics, only: point_diag
+
+    ! input/output arguments
+
+    integer, intent(in) :: &
+         nx, ny,                 & ! grid dimensions
+         itest, jtest, rtest       ! coordinates of diagnostic point
+
+    type(parallel_type), intent(in) :: &
+         parallel                  ! info for parallel communication
+
+    real(dp), intent(in) :: &
+         dx, dy,                 & ! grid cell size (m)
+         dt                        ! time step (s)
+
+    integer, dimension(nx,ny), intent(in) ::  &
+         calving_front_mask,     & ! = 1 where ice is floating and borders at least one ocean cell, else = 0
+         floating_mask             ! = 1 where ice is present and floating, else = 0
+
+    real(dp), dimension(nx,ny), intent(in) :: &
+         speed,                  & ! mean ice speed averaged to cell centers (m/s)
+         thck,                   & ! ice thickness (m)
+         tau_eigen1, tau_eigen2    ! eigenvalues of the horizontal stress tensor (Pa)
+
+    real(dp), intent(in) :: &
+         tau_eigenconstant1,     & ! multiplier for tau_eigen1 (unitless)
+         tau_eigenconstant2,     & ! multiplier for tau_eigen2 (unitless)
+         stress_threshold          ! stress threshold for calving front retreat
+
+    real(dp), dimension(nx,ny), intent(inout) :: &
+         calving_dthck             ! thickness lost due to calving (m)
+
+    ! local variables
+
+    integer :: i, j, count, count_save, iter, max_iter
+
+    real(dp) :: rnd                ! random number between 0 and 1
+
+    real(dp), dimension(nx,ny) :: &
+         effec_stress,           & ! effective stress (Pa)
+         failure_probability       ! probability that the cell fails at this time
+
+    ! This mask identifies cells that will calve if there is a path
+    ! through other failed cells to the CF.
+    integer, dimension(nx,ny) :: &
+         failed_mask               ! mask = 1 for failed calls, else = 0
+
+    integer,  dimension(nx,ny) ::  &
+         color                     ! integer 'color' for identifying cells that will calve
+
+    ! Compute an effective stress in each cell
+    ! Based on a stress threshold, compute a probability of cell failure.
+    !  (When effec_stress = stress_threshold, we have p = 1 - 1/e, or about 63%.)
+    ! Then determine whether the cell fails.
+
+    failed_mask = 0
+    effec_stress = 0.0d0
+
+    !TODO - Incorporate the ice speed and timestep somehow?
+    do j = nhalo+1, ny-nhalo
+       do i = nhalo+1, nx-nhalo
+          if (floating_mask(i,j) == 1) then
+
+             effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
+                               + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
+             failure_probability(i,j) = 1.0d0 - exp(-effec_stress(i,j)/stress_threshold)
+             call random_number(rnd)
+             if (rnd < failure_probability(i,j)) failed_mask(i,j) = 1
+
+          endif   ! floating
+       enddo   ! i
+    enddo   ! j
+
+    call parallel_halo(failed_mask, parallel)
+
+    ! Mark all floating cells with the initial color.
+    ! Mark other cells with the boundary color.
+
+    do j = nhalo+1, ny-nhalo
+       do i = nhalo+1, nx-nhalo
+          if (floating_mask(i,j) == 1) then
+             color(i,j) = initial_color
+          else
+             color(i,j) = boundary_color
+          endif
+       enddo
+    enddo
+
+    call parallel_halo(color, parallel)
+
+    ! Seed the fill with failed CF cells, and then ecursively fill all cells that are to be calved.
+    ! Repeat the recursion as necessary to spread the fill to adjacent processors.
+
+    max_iter = max(parallel%ewtasks, parallel%nstasks)
+    count_save = 0
+
+    do iter = 1, max_iter
+
+       if (iter == 1) then
+
+          do j = 1, ny
+             do i = 1, nx
+                if (calving_front_mask(i,j) == 1 .and. failed_mask(i,j) == 1) then  ! cell that can seed the fill
+                   if (color(i,j) /= fill_color) then
+                      ! assign the fill color to this cell, and recursively fill neighbor cells
+                      call glissade_fill(&
+                           nx,    ny,    &
+                           i,     j,     &
+                           color, failed_mask)
+                   endif
+                endif
+             enddo
+          enddo
+
+       else   ! iter > 1
+
+          call parallel_halo(color, parallel)
+
+          ! Loop through halo cells that were just filled on neighbor processors
+
+          ! west halo layer
+          i = nhalo
+          do j = 1, ny
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i+1,   j,     &
+                     color, failed_mask)
+             endif
+          enddo
+
+          ! east halo layer
+          i = nx - nhalo + 1
+          do j = 1, ny
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i-1,   j,     &
+                     color, failed_mask)
+             endif
+          enddo
+
+          ! south halo layer
+          j = nhalo
+          do i = nhalo+1, nx-nhalo  ! already checked halo corners above
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i,     j+1,   &
+                     color, failed_mask)
+             endif
+          enddo
+
+          ! north halo layer
+          j = ny-nhalo+1
+          do i = nhalo+1, nx-nhalo  ! already checked halo corners above
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i,     j-1,   &
+                     color, failed_mask)
+             endif
+          enddo
+
+       endif   ! iter
+
+       ! Count the calving cells
+       count = 0
+       do j = nhalo+1, ny-nhalo
+          do i = nhalo+1, nx-nhalo
+             if (color(i,j) == fill_color) count = count + 1
+          enddo
+       enddo
+       !WHL - If running a large problem, may want to reduce the frequency of this global sum
+       count = parallel_reduce_sum(count)
+
+       if (count == count_save) then
+!!          if (verbose_calving .and. main_task) &
+!!               write(6,*) 'Fill converged: iter, global_count =', iter, global_count
+          exit
+       else
+!!          if (verbose_calving .and. main_task) &
+!!               write(6,*) 'Convergence check: iter, global_count =', iter, global_count
+          count_save = count
+       endif
+
+    enddo   ! max_iter
+
+    call parallel_halo(color, parallel)
+
+    ! Once the fill is done, any cells with the fill color are to be calved.
+    ! The actual calving is done in another subroutine.
+
+    where (color == fill_color)
+       calving_dthck = thck
+    elsewhere
+       calving_dthck = 0.0d0
+    endwhere
+
+    if (verbose_calving) then
+       call point_diag(speed*scyr, 'Stochastic calving, ice speed (m/yr)', itest, jtest, rtest, 7, 7)
+       call point_diag(tau_eigen1, 'tau_eigen1 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
+       call point_diag(tau_eigen2, 'tau_eigen2 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
+       call point_diag(effec_stress, 'eff_stress (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
+       call point_diag(failure_probability, 'failure probability', itest, jtest, rtest, 7, 7, '(f10.3)')
+       call point_diag(failed_mask, 'failed mask', itest, jtest, rtest, 7, 7)
+       call point_diag(color, 'color', itest, jtest, rtest, 7, 7)
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7)
+    endif
+
+  end subroutine stochastic_stress_based_calving
+
+!---------------------------------------------------------------------------
+
   subroutine eigencalving(&
        nx,                 ny,            &
        dx,                 dy,            &  ! m
@@ -2200,13 +2478,14 @@ contains
        thck,                        &
        f_ground_cell,               &
        ice_mask,                    &
+       floating_mask,               &
        land_mask,                   &
        calving_thck)
 
-    ! Remove any icebergs. 
+    ! Remove any icebergs
         
     ! The algorithm is as follows:
-    ! (1) Mark all cells with ice  with the initial color.
+    ! (1) Mark all cells with ice with the initial color.
     !     Mark other cells with the boundary color.
     ! (2) Seed the fill by giving grounded ice cells the fill color.
     ! (3) Recursively fill all cells that are connected to filled cells by a path
@@ -2233,6 +2512,7 @@ contains
     real(dp), dimension(nx,ny), intent(inout) :: thck            !> ice thickness
     real(dp), dimension(nx,ny), intent(in)    :: f_ground_cell   !> grounded fraction in each grid cell
     integer,  dimension(nx,ny), intent(in)    :: ice_mask        !> = 1 where ice is present (thck > thklim), else = 0
+    integer,  dimension(nx,ny), intent(in)    :: floating_mask   !> = 1 where ice is present and floating, else = 0
     integer,  dimension(nx,ny), intent(in)    :: land_mask       !> = 1 where topg - eus >= 0, else = 0
     real(dp), dimension(nx,ny), intent(inout) :: calving_thck    !> thickness lost due to calving in each grid cell;
                                                                  !> on output, includes ice in icebergs
@@ -2244,7 +2524,7 @@ contains
          max_iter,             & ! max(ewtasks, nstasks)
          local_count,          & ! local counter for filled values
          global_count,         & ! global counter for filled values
-         global_count_save       ! globalcounter for filled values from previous iteration
+         global_count_save       ! global counter for filled values from previous iteration
 
     integer,  dimension(nx,ny) ::  &
          color                 ! integer 'color' for identifying icebergs
@@ -2291,7 +2571,8 @@ contains
                 !  that f_ground_cell exceeds a threshold value defined above.
                 ! Note: If running without a GLP, then f_ground_cell is binary, either 0 or 1.
 
-                if (ice_mask(i,j) == 1 .and. f_ground_cell(i,j) >= f_ground_threshold) then  ! grounded ice
+                if (ice_mask(i,j) == 1 .and. floating_mask(i,j) == 0 .and. &
+                    f_ground_cell(i,j) >= f_ground_threshold) then  ! grounded ice
 
                    if (color(i,j) /= boundary_color .and. color(i,j) /= fill_color) then
 
@@ -2308,7 +2589,7 @@ contains
              enddo
           enddo
 
-       else  ! count > 1
+       else  ! iter > 1
 
           ! Check for halo cells that were just filled on neighbor processors
           ! TODO - Is the 'ice_mask = 1' logic redundant? (Here and below?)  Use glissade_fill without buffer?
@@ -2325,7 +2606,7 @@ contains
              endif
           enddo
 
-          ! east halo layers
+          ! east halo layer
           i = nx - nhalo + 1
           do j = 1, ny
              if (color(i,j) == fill_color .and. ice_mask(i,j) == 1) then
@@ -2358,7 +2639,7 @@ contains
              endif
           enddo
 
-       endif  ! count = 1
+       endif  ! iter
 
        local_count = 0
        do j = nhalo+1, ny-nhalo
@@ -2380,36 +2661,17 @@ contains
           global_count_save = global_count
        endif
 
-    enddo  ! count
+    enddo  ! max_iter
 
-    !TODO - Remove the exception?
     ! Icebergs are cells that still have the initial color and are not on land.
     ! Remove ice in these cells, adding it to the calving field.
-    ! Note: There is an exception for cells that are
-    !       (1) adjacent to at least one ice-covered cell (sharing an edge), and
-    !       (2) connected diagonally to an ice-covered cell with the fill color.
-    !       Such cells are considered part of the inactive calving front and are
-    !        allowed to continue filling instead of calving.
-    ! Allow land-based cells to be removed if f_ground < f_ground_threshold
 
     do j = 2, ny-1
        do i = 2, nx-1
-
           if (color(i,j) == initial_color .and. land_mask(i,j) == 0) then
-             if (  ( color(i-1,j+1)==fill_color .and. ice_mask(i-1,j+1)==1 .and. &
-                       (ice_mask(i-1,j)==1 .or. ice_mask(i,j+1)==1) ) &
-              .or. ( color(i+1,j+1)==fill_color .and. ice_mask(i+1,j+1)==1 .and. &
-                       (ice_mask(i+1,j)==1 .or. ice_mask(i,j+1)==1) ) &
-              .or. ( color(i-1,j-1)==fill_color .and. ice_mask(i-1,j-1)==1 .and. &
-                       (ice_mask(i-1,j)==1 .or. ice_mask(i,j-1)==1) ) &
-              .or. ( color(i+1,j-1)==fill_color .and. ice_mask(i+1,j-1)==1 .and. &
-                       (ice_mask(i+1,j)==1 .or. ice_mask(i,j-1)==1) ) ) then
-                ! do nothing; this cell is part of the inactive calving front
-             else  ! not part of the inactive calving front; calve as an iceberg
-                calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
-                thck(i,j) = 0.0d0
-                !TODO - Also handle tracers?  E.g., set damage(:,i,j) = 0.d0?
-             endif  ! diagonally connected or not
+             calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
+             thck(i,j) = 0.0d0
+             !TODO - Also handle tracers?  E.g., set damage(:,i,j) = 0.d0?
           endif
        enddo
     enddo
@@ -2456,14 +2718,16 @@ contains
 
     integer :: i, j
 
-    integer, dimension(nx,ny) :: &
-         ocean_plus_thin_ice_mask         ! = 1 for ocean cells and cells with thin floating ice
+    real(dp) :: mask_e, mask_w, mask_n, mask_s
+    real(dp) :: thin_threshold
 
     ! Both floating and weakly grounded cells can be identified as isthmuses and removed;
     !  f_ground_threshold is used to identify weakly grounded cells.
 
     ! An isthmus cell has ice-free ocean or thin floating ice on each side:
-    !  isthmus_thck_threshold is used to identify thin floating ice.
+    !  ice is considered thin and floating if thinner than isthmus_thck_threshold
+    !  and also thinner than the ice in the central cell.
+
     real(dp), parameter :: &   ! threshold (m) for counting floating ice as thin
          isthmus_thck_threshold = 10.0d0
 
@@ -2471,16 +2735,29 @@ contains
        call point_diag(thck, 'Remove isthmuses, thck', itest, jtest, rtest, 7, 7)
     endif
 
-    ocean_plus_thin_ice_mask = ocean_mask
-    where (floating_mask == 1 .and. thck < isthmus_thck_threshold)
-       ocean_plus_thin_ice_mask = 1
-    endwhere
-
     do j = 2, ny-1
        do i = 2, nx-1
           if (floating_mask(i,j) == 1 .or. f_ground_cell(i,j) < f_ground_threshold) then
-             if ( (ocean_plus_thin_ice_mask(i-1,j) == 1 .and. ocean_plus_thin_ice_mask(i+1,j) == 1) .or. &
-                  (ocean_plus_thin_ice_mask(i,j-1) == 1 .and. ocean_plus_thin_ice_mask(i,j+1) == 1) ) then
+             mask_e = 0; mask_w = 0; mask_n = 0; mask_s = 0
+             thin_threshold = min(isthmus_thck_threshold, thck(i,j))
+             if (ocean_mask(i+1,j) == 1 .or. &
+                  (floating_mask (i+1,j) == 1 .and. thck(i+1,j) < thin_threshold) ) then
+                mask_e = 1
+             endif
+             if (ocean_mask(i-1,j) == 1 .or. &
+                  (floating_mask (i-1,j) == 1 .and. thck(i-1,j) < thin_threshold) ) then
+                mask_w = 1
+             endif
+             if (ocean_mask(i,j+1) == 1 .or. &
+                  (floating_mask (i,j+1) == 1 .and. thck(i,j+1) < thin_threshold) ) then
+                mask_n = 1
+             endif
+             if (ocean_mask(i,j-1) == 1 .or. &
+                  (floating_mask (i,j-1) == 1 .and. thck(i,j-1) < thin_threshold) ) then
+                mask_s = 1
+             endif
+             if ( (mask_e == 1 .and. mask_w == 1) .or. &
+                  (mask_n == 1 .and. mask_s == 1) ) then
                 calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
                 thck(i,j) = 0.0d0
              endif

--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -298,6 +298,9 @@ contains
 !    real(dp), intent(in)                     :: damage_constant     !> rate of change of damage (1/s) per unit stress (Pa)
 !    real(dp), intent(in)            :: cf_advance_retreat_amplitude !> amplitude (m/yr) of CF advance/retreat rate
 !    real(dp), intent(in)            :: cf_advance_retreat_period    !> period (yr) of CF advance/retreat rate
+!    integer,  dimension(:,:), intent(in)     :: protected_mask      !> integer mask: = 1 for cells that are able to fill,
+!                                                                    !>  = 0 for cells that are not allowed to fill
+!    integer,  dimension(:,:), intent(in)     :: damage_mask         !> integer mask: = 1 for damaged cells, else = 0
 !    integer,  dimension(:,:), intent(in)     :: calving_mask        !> integer mask: calve ice where calving_mask = 1
 !    real(dp), dimension(:,:), intent(out)    :: calving_thck        !> thickness lost due to calving in each grid cell (m)
 
@@ -663,6 +666,7 @@ contains
                calving%tau_eigenconstant1,        &
                calving%tau_eigenconstant2,        &
                calving%stress_threshold,          &  ! Pa
+               calving%lateral_rate_min/scyr,     &  ! m/s
                calving_dthck)                        ! m
 
        elseif (which_calving == CALVING_STRESS_STOCHASTIC) then
@@ -689,14 +693,18 @@ contains
                itest,   jtest,     rtest,         &
                parallel,                          &
                calving_front_mask,                &
-               floating_mask,                     &
-               speed,                             &  ! m/s
                thck,                              &  ! m
+               calving%thck_effective,            &  ! m
+               calving%effective_areafrac,        &
+               speed,                             &  ! m/s
+               cf_length,                         &  ! m
                calving%tau_eigen1,                &  ! Pa
                calving%tau_eigen2,                &  ! Pa
                calving%tau_eigenconstant1,        &
                calving%tau_eigenconstant2,        &
                calving%stress_threshold,          &  ! Pa
+               calving%effec_stress_min,          &  ! Pa
+               calving%length_scale,              &  ! m
                calving_dthck)                        ! m
 
        elseif (which_calving == EIGEN_CALVING) then
@@ -742,40 +750,55 @@ contains
                calving%tau_eigen1,         &
                calving%tau_eigen2)
 
-          call damage_based_calving(&
+          call stochastic_damage_based_calving(&
                nx,       ny,       nz,                 &
                dx,                 dy,                 &  ! m
                sigma,              dt,                 &
                itest,   jtest,     rtest,              &
+               parallel,                               &
                floating_mask,                          &
                calving_front_mask,                     &
-               speed,                                  &  ! m/s
-               cf_length,                              &  ! m
-               calving%thck_effective,                 &  ! m
+               thck,                                   &  ! m
+               topg,                                   &  ! m
                calving%tau_eigen1, calving%tau_eigen2, &  ! Pa
                calving%tau_eigenconstant1,             &
                calving%tau_eigenconstant2,             &
-               calving%damage_threshold,               &
+               calving%stress_threshold,               &
+               calving%effec_stress_min,               &  ! Pa
+               calving%damage_constant*scyr,           &  ! Pa s
                calving%damage,                         &
-               calving_dthck)                             ! m
+               calving_dthck,                          &  ! m
+               calving%eps_eigen1, calving%eps_eigen2)    ! 1/s
 
-       endif
+       endif   ! which_calving
 
        call parallel_halo(calving_dthck, parallel)
 
        ! Apply calving_dthck as computed above.
 
-       call apply_calving_dthck(&
-            nx,           ny,        &
-            itest, jtest, rtest,     &
-            parallel,                &
-            calving_front_mask,      &
-            floating_mask,           &
-            full_mask,               &
-            flux_in,                 &
-            calving_dthck,           &
-            thck,                    &
-            calving%calving_thck)
+       if (which_calving == CALVING_DAMAGE) then
+
+          ! different treatment because we can calve cells not on the CF
+          where (calving_dthck == thck)
+             calving%calving_thck = calving_dthck
+             thck = 0.0d0
+          endwhere
+
+       else
+
+          call apply_calving_dthck(&
+               nx,           ny,        &
+               itest, jtest, rtest,     &
+               parallel,                &
+               calving_front_mask,      &
+               floating_mask,           &
+               full_mask,               &
+               flux_in,                 &
+               calving_dthck,           &
+               thck,                    &
+               calving%calving_thck)
+
+       endif
 
        !TODO - Add a bug check for negative thicknesses?
        thck = max(thck, 0.0d0)
@@ -1186,8 +1209,9 @@ contains
                    cf_length(i,j) = count_ns*dx + count_ew*dy
                 endif
              elseif (count == 3) then
-                ! This is a bit arbitrary; assume the same length as a CF bordering two edges
-                cf_length(i,j) = sqrt(dx*dx + dy*dy)
+                ! This is a bit arbitrary; assume the same length as a CF bordering two edges.
+                ! The goal is to speed up calving for 'teeth' but not remove them instantly.
+                cf_length(i,j) = dx + dy
              endif
 
           endif   ! calving_mask
@@ -1505,6 +1529,7 @@ contains
        tau_eigenconstant1,                &
        tau_eigenconstant2,                &
        stress_threshold,                  &  ! Pa
+       lateral_rate_min,                  &  ! m/s
        calving_dthck)                        ! m
 
     ! Calve ice based on the eigenvalues of the 2D horizontal stress tensor near the calving front.
@@ -1535,7 +1560,8 @@ contains
     real(dp), intent(in) :: &
          tau_eigenconstant1,     & ! multiplier for tau_eigen1 (unitless)
          tau_eigenconstant2,     & ! multiplier for tau_eigen2 (unitless)
-         stress_threshold          ! stress threshold for calving front retreat
+         stress_threshold,       & ! stress threshold for calving front retreat
+         lateral_rate_min          ! min lateral rate at CF (m/s)
 
     real(dp), dimension(nx,ny), intent(inout) :: &
          calving_dthck             ! thickness lost due to calving (m)
@@ -1573,14 +1599,20 @@ contains
     calving_dthck = 0.0d0
     effec_stress = 0.0d0
 
+    !TODO - Compute nonzero values for floating cells only?
+    do j = nhalo+1, ny-nhalo
+       do i = nhalo+1, nx-nhalo
+          effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
+                            + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
+       enddo
+    enddo
+
     do j = nhalo+1, ny-nhalo
        do i = nhalo+1, nx-nhalo
 
-          effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
-                            + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
-
           if (calving_front_mask(i,j) == 1) then
-             lateral_rate(i,j) =  speed(i,j) * effec_stress(i,j) / stress_threshold
+             lateral_rate(i,j)  = speed(i,j) * effec_stress(i,j) / stress_threshold
+             lateral_rate(i,j) = max(lateral_rate(i,j), lateral_rate_min)
              calving_dthck(i,j) = lateral_rate(i,j) * dt * thck_effective(i,j) * cf_length(i,j) / (dx*dy)
           endif   ! CF mask
 
@@ -1607,13 +1639,17 @@ contains
        itest,   jtest,     rtest,         &
        parallel,                          &
        calving_front_mask,                &
-       floating_mask,                     &
-       speed,                             &  ! m/s
        thck,                              &  ! m
+       thck_effective,                    &  ! m
+       effective_areafrac,                &
+       speed,                             &  ! m/s
+       cf_length,                         &  ! m
        tau_eigen1,    tau_eigen2,         &  ! Pa
        tau_eigenconstant1,                &
        tau_eigenconstant2,                &
        stress_threshold,                  &  ! Pa
+       effec_stress_min,                  &  ! Pa
+       length_scale,                      &  ! m
        calving_dthck)                        ! m
 
     ! Calve ice based on the eigenvalues of the 2D horizontal stress tensor near the calving front.
@@ -1646,198 +1682,110 @@ contains
          dt                        ! time step (s)
 
     integer, dimension(nx,ny), intent(in) ::  &
-         calving_front_mask,     & ! = 1 where ice is floating and borders at least one ocean cell, else = 0
-         floating_mask             ! = 1 where ice is present and floating, else = 0
+         calving_front_mask        ! = 1 where ice is floating and borders at least one ocean cell, else = 0
 
     real(dp), dimension(nx,ny), intent(in) :: &
-         speed,                  & ! mean ice speed averaged to cell centers (m/s)
          thck,                   & ! ice thickness (m)
+         thck_effective,         & ! effective ice thickness (m) at the CF
+         effective_areafrac,     & !
+         speed,                  & ! mean ice speed averaged to cell centers (m/s)
+         cf_length,              & ! length of calving front in each grid cell (m)
          tau_eigen1, tau_eigen2    ! eigenvalues of the horizontal stress tensor (Pa)
 
     real(dp), intent(in) :: &
          tau_eigenconstant1,     & ! multiplier for tau_eigen1 (unitless)
          tau_eigenconstant2,     & ! multiplier for tau_eigen2 (unitless)
-         stress_threshold          ! stress threshold for calving front retreat
+         stress_threshold,       & ! stress threshold for calving front retreat (Pa)
+         effec_stress_min,       & ! minimum effec stress (Pa) for purposes of computing CF retreat
+         length_scale              ! length scale for calving events (m);
+                                   ! typically less than or equal to the grid scale
 
     real(dp), dimension(nx,ny), intent(inout) :: &
          calving_dthck             ! thickness lost due to calving (m)
 
     ! local variables
 
-    integer :: i, j, count, count_save, iter, max_iter
-
-    real(dp) :: rnd                ! random number between 0 and 1
+    integer :: i, j
+    integer :: count, count_save, iter, max_iter
 
     real(dp), dimension(nx,ny) :: &
          effec_stress,           & ! effective stress (Pa)
-         failure_probability       ! probability that the cell fails at this time
+         calving_probability       ! probability that all or part of a CF cell is calved during this time step
 
-    ! This mask identifies cells that will calve if there is a path
-    ! through other failed cells to the CF.
-    integer, dimension(nx,ny) :: &
-         failed_mask               ! mask = 1 for failed calls, else = 0
+    real(dp) :: &
+         rnd                       ! random number between 0 and 1
 
-    integer,  dimension(nx,ny) ::  &
-         color                     ! integer 'color' for identifying cells that will calve
+    real(dp) :: &
+         stress_fac, speed_fac, length_fac  ! unitless factors that determine calving probability
 
-    ! Compute an effective stress in each cell
-    ! Based on a stress threshold, compute a probability of cell failure.
-    !  (When effec_stress = stress_threshold, we have p = 1 - 1/e, or about 63%.)
-    ! Then determine whether the cell fails.
+    real(dp) :: grid_scale         ! sqrt(dx*dy) = grid cell length scale (= dx = dy on a square grid)
+    real(dp) :: length_ratio       ! calving length_scale / grid_scale
 
-    failed_mask = 0
+    ! Initialize
     effec_stress = 0.0d0
+    calving_probability = 0.0d0
+    calving_dthck = 0.0d0
+    grid_scale = sqrt(dx*dy)
 
-    !TODO - Incorporate the ice speed and timestep somehow?
+    ! Compute the effective stress
     do j = nhalo+1, ny-nhalo
        do i = nhalo+1, nx-nhalo
-          if (floating_mask(i,j) == 1) then
-
-             effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
-                               + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
-             failure_probability(i,j) = 1.0d0 - exp(-effec_stress(i,j)/stress_threshold)
-             call random_number(rnd)
-             if (rnd < failure_probability(i,j)) failed_mask(i,j) = 1
-
-          endif   ! floating
-       enddo   ! i
-    enddo   ! j
-
-    call parallel_halo(failed_mask, parallel)
-
-    ! Mark all floating cells with the initial color.
-    ! Mark other cells with the boundary color.
-
-    do j = nhalo+1, ny-nhalo
-       do i = nhalo+1, nx-nhalo
-          if (floating_mask(i,j) == 1) then
-             color(i,j) = initial_color
-          else
-             color(i,j) = boundary_color
-          endif
+          effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
+                            + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
+          effec_stress(i,j) = max(effec_stress(i,j), effec_stress_min)
        enddo
     enddo
 
-    call parallel_halo(color, parallel)
+    if (verbose_calving) then
+       call point_diag(tau_eigen1, 'Stochastic calving, tau_eigen1 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
+       call point_diag(tau_eigen2, 'tau_eigen2 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
+       call point_diag(effec_stress, 'effec_stress (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
+    endif
 
-    ! Seed the fill with failed CF cells, and then ecursively fill all cells that are to be calved.
-    ! Repeat the recursion as necessary to spread the fill to adjacent processors.
+    ! Calve cells at the calving front, with a probability based on effec_stress, speed, and other factors.
+    ! Notes:
+    ! (1) If the timestep is doubled, the probability of a calving event during a given timestep is doubled,
+    !      as desired (assuming p << 1). This follows from exp[-(t1 + t2)] = exp(-t1)*exp(-t2).
+    ! (2) The calved ice thickness (calving_dthck) is based on thck_effective, not thck.
+    !     In CF cells where calving_dthck > thck, the calving will extend into upstream cells.
+    !     This is done in subroutine apply_calving_dthck.
+    ! (3) If length_scale = grid_scale, then the calving probability p is the probability
+    !      of a calving event of extent grid_scale^2 (i.e., one grid cell area) during interval dt.
+    !     length_scale < grid_scale, then the calving_probability is greater, but less
+    !      area is calved per event. E.g., if length_scale = grid_scale/2, then calving events
+    !      are 4x as likely, but the calved area per event is 4x smaller.
+    !     In either case, the time-average calving area is the same.
+    ! (4) A larger value of length_ratio (i.e., fewer, bigger icebergs) implies greater random variation in CF location.
+    ! (5) Deterministic stress-based calving can be viewed as equivalent to stochastic stress-based calving,
+    !     in the limit as length_scale -> 0 and there are many small calving events.
+    ! (6) The method is probably more realistic for length_ratio < 1 (icebergs smaller than grid scale)
+    !     than length_ratio > 1 (icebergs larger than grid scale).
 
-    max_iter = max(parallel%ewtasks, parallel%nstasks)
-    count_save = 0
+    length_ratio = length_scale/grid_scale
 
-    do iter = 1, max_iter
-
-       if (iter == 1) then
-
-          do j = 1, ny
-             do i = 1, nx
-                if (calving_front_mask(i,j) == 1 .and. failed_mask(i,j) == 1) then  ! cell that can seed the fill
-                   if (color(i,j) /= fill_color) then
-                      ! assign the fill color to this cell, and recursively fill neighbor cells
-                      call glissade_fill(&
-                           nx,    ny,    &
-                           i,     j,     &
-                           color, failed_mask)
-                   endif
-                endif
-             enddo
-          enddo
-
-       else   ! iter > 1
-
-          call parallel_halo(color, parallel)
-
-          ! Loop through halo cells that were just filled on neighbor processors
-
-          ! west halo layer
-          i = nhalo
-          do j = 1, ny
-             if (color(i,j) == fill_color) then
-                call glissade_fill(&
-                     nx,    ny,    &
-                     i+1,   j,     &
-                     color, failed_mask)
+    do j = nhalo+1, ny-nhalo
+       do i = nhalo+1, nx-nhalo
+          if (calving_front_mask(i,j) == 1) then
+             ! compute three unitless factors
+             stress_fac = effec_stress(i,j) / stress_threshold
+             speed_fac = speed(i,j) * (dt/length_ratio**2) / grid_scale
+             length_fac = cf_length(i,j) / grid_scale
+             ! compute the calving probability
+             calving_probability(i,j) = 1.0d0 - exp(-stress_fac*speed_fac*length_fac)
+             call random_number(rnd)
+             if (rnd < calving_probability(i,j)) then
+                calving_dthck(i,j) = thck_effective(i,j) * length_ratio**2
              endif
-          enddo
+          endif   ! CF mask
+       enddo   ! i
+    enddo   ! j
 
-          ! east halo layer
-          i = nx - nhalo + 1
-          do j = 1, ny
-             if (color(i,j) == fill_color) then
-                call glissade_fill(&
-                     nx,    ny,    &
-                     i-1,   j,     &
-                     color, failed_mask)
-             endif
-          enddo
-
-          ! south halo layer
-          j = nhalo
-          do i = nhalo+1, nx-nhalo  ! already checked halo corners above
-             if (color(i,j) == fill_color) then
-                call glissade_fill(&
-                     nx,    ny,    &
-                     i,     j+1,   &
-                     color, failed_mask)
-             endif
-          enddo
-
-          ! north halo layer
-          j = ny-nhalo+1
-          do i = nhalo+1, nx-nhalo  ! already checked halo corners above
-             if (color(i,j) == fill_color) then
-                call glissade_fill(&
-                     nx,    ny,    &
-                     i,     j-1,   &
-                     color, failed_mask)
-             endif
-          enddo
-
-       endif   ! iter
-
-       ! Count the calving cells
-       count = 0
-       do j = nhalo+1, ny-nhalo
-          do i = nhalo+1, nx-nhalo
-             if (color(i,j) == fill_color) count = count + 1
-          enddo
-       enddo
-       !WHL - If running a large problem, may want to reduce the frequency of this global sum
-       count = parallel_reduce_sum(count)
-
-       if (count == count_save) then
-!!          if (verbose_calving .and. main_task) &
-!!               write(6,*) 'Fill converged: iter, global_count =', iter, global_count
-          exit
-       else
-!!          if (verbose_calving .and. main_task) &
-!!               write(6,*) 'Convergence check: iter, global_count =', iter, global_count
-          count_save = count
-       endif
-
-    enddo   ! max_iter
-
-    call parallel_halo(color, parallel)
-
-    ! Once the fill is done, any cells with the fill color are to be calved.
-    ! The actual calving is done in another subroutine.
-
-    where (color == fill_color)
-       calving_dthck = thck
-    elsewhere
-       calving_dthck = 0.0d0
-    endwhere
+    call parallel_halo(calving_probability, parallel)
+    call parallel_halo(calving_dthck, parallel)
 
     if (verbose_calving) then
-       call point_diag(speed*scyr, 'Stochastic calving, ice speed (m/yr)', itest, jtest, rtest, 7, 7)
-       call point_diag(tau_eigen1, 'tau_eigen1 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
-       call point_diag(tau_eigen2, 'tau_eigen2 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
-       call point_diag(effec_stress, 'eff_stress (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
-       call point_diag(failure_probability, 'failure probability', itest, jtest, rtest, 7, 7, '(f10.3)')
-       call point_diag(failed_mask, 'failed mask', itest, jtest, rtest, 7, 7)
-       call point_diag(color, 'color', itest, jtest, rtest, 7, 7)
-       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7)
+       call point_diag(calving_probability, 'calving probability', itest, jtest, rtest, 7, 7, '(f10.3)')
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7, '(f10.3)')
     endif
 
   end subroutine stochastic_stress_based_calving
@@ -1940,6 +1888,9 @@ contains
 
 !---------------------------------------------------------------------------
 
+  ! This subroutine previously was called for the CALVING_DAMAGE option,
+  ! which now uses subroutine stochastic_damage_based_calving.
+  ! Keeping the older version for reference and further testing.
   subroutine damage_based_calving(&
        nx,       ny,       nz,            &
        dx,                 dy,            &  ! m
@@ -2056,9 +2007,6 @@ contains
 
              d_damage_dt = effec_stress(i,j) / (damage_scale*scyr)
 
-             !WHL: Alternatives would be to (1) accumulate damage only when effec_stress is above
-             !     a given threshold and (2) allow the ice to heal under low or negative tensile stress.
-
              damage(:,i,j) = damage(:,i,j) + d_damage_dt * dt
              damage(:,i,j) = min(damage(:,i,j), 1.0d0)
              damage(:,i,j) = max(damage(:,i,j), 0.0d0)
@@ -2117,6 +2065,339 @@ contains
     endif
 
   end subroutine damage_based_calving
+
+!---------------------------------------------------------------------------
+
+  subroutine stochastic_damage_based_calving(&
+       nx,       ny,       nz,            &
+       dx,                 dy,            &  ! m
+       sigma,              dt,            &
+       itest,   jtest,     rtest,         &
+       parallel,                          &
+       floating_mask,                     &
+       calving_front_mask,                &
+       thck,                              &  ! m
+       topg,                              &  ! m
+       tau_eigen1,    tau_eigen2,         &  ! Pa
+       tau_eigenconstant1,                &  ! 1/s
+       tau_eigenconstant2,                &  ! 1/s
+       stress_threshold,                  &  ! Pa
+       effec_stress_min,                  &  ! Pa
+       damage_constant,                   &  ! Pa s
+       damage,                            &
+       calving_dthck,                     &  ! m
+       eps_eigen1,    eps_eigen2)            ! 1/s
+
+    ! Calve ice based on accumulated damage.
+    ! This is similar to stress-based calving, except that stresses contribute to damage
+    ! instead of directly determining the lateral calving rate.
+
+    use glide_diagnostics, only: point_diag
+    use glissade_masks, only: glissade_fill, initial_color, fill_color, boundary_color
+
+    ! input/output arguments
+
+    integer, intent(in) :: &
+         nx, ny, nz,             & ! grid dimensions
+         itest, jtest, rtest       ! coordinates of diagnostic point
+
+    type(parallel_type), intent(in) :: &
+         parallel                  ! info for parallel communication
+
+    real(dp), intent(in) :: &
+         dx, dy,                 & ! grid cell size (m)
+         dt                        ! time step (s)
+
+    real(dp), dimension(nz), intent(in) ::&
+         sigma                     ! vertical sigma coordinate
+
+    integer, dimension(nx,ny), intent(in) ::  &
+         floating_mask,          & ! = 1 where ice is present and floating, else = 0
+         calving_front_mask        ! = 1 where ice is floating and borders at least one ocean cell, else = 0
+
+    real(dp), dimension(nx,ny), intent(in) :: &
+         thck,                   & ! ice thickness (m)
+         topg,                   & ! bed topography (m)
+         tau_eigen1, tau_eigen2    ! eigenvalues of the horizontal stress tensor (Pa)
+
+    real(dp), intent(in) :: &
+         tau_eigenconstant1,     & ! multiplier for tau_eigen1 (unitless)
+         tau_eigenconstant2,     & ! multiplier for tau_eigen2 (unitless)
+         stress_threshold,       & ! stress value at which damage begins (Pa)
+         effec_stress_min,       & ! min value for effec_stress (Pa)
+         damage_constant           ! damage scaling term (Pa s)
+
+    real(dp), dimension(nz-1,nx,ny), intent(inout) :: &
+         damage                    ! 3D damage tracer, 0 > damage < 1
+
+    real(dp), dimension(nx,ny), intent(inout) :: &
+         calving_dthck             ! thickness lost due to calving (m)
+
+    real(dp), dimension(nx,ny), intent(in), optional :: &
+         eps_eigen1, eps_eigen2    ! eigenvalues of the horizontal strain rate tensor (s^-1)
+
+    ! local variables
+
+    integer :: i, j, k
+
+    integer, dimension(nx,ny) :: &
+         damage_mask               ! = 1 for damaged cells, else = 0
+
+    real(dp), dimension(nx,ny) :: &
+         damage_column,          & ! average damage in an ice column
+         effec_stress              ! effective stress (Pa)
+
+    real(dp) :: &
+         d_damage_dt,            & ! rate of change of damage scalar (1/s)
+         rnd                       ! random number
+
+    integer :: count, count_save, iter, max_iter
+
+    integer,  dimension(nx,ny) ::  &
+         color                     ! integer 'color' for identifying cells that will calve
+
+    logical, parameter :: tau2_only = .false.
+
+    ! Compute calving based on damage, a scalar quantity prognosed from eigenvalues
+    ! of the horizontal stress tensor (or strain rate tensor).
+    !
+    ! This is a stochastic version of a damage-based scheme. The idea is as follows:
+    ! * Damage is a scalar D in the range [0,1]. At each timestep, the pre-existing damage field is advected with the ice.
+    ! * In this subroutine, first compute changes in damage due to stress.
+    ! * The resulting field D can have any values in the range [0,1].
+    ! * Use a random number to convert damage into a binary field, with values of 0 and 1 only.
+    ! * Use a flood-fill algorithm to remove connected regions of damaged ice (D = 1) at the CF.
+
+    ! Compute the change in damage in each cell
+    ! For now, this is done using a simple scheme based on the horizontal stress tensor.
+    ! At some point, we may want to prognose damage in a way that depends on other factors such as mass balance.
+    ! Note: Damage is formally a 3D field, which makes it easier to advect, even though
+    !       (in the current scheme) the damage source term is uniform in each column.
+
+    ! Compute an effective stress for damage, based on the eigenvalues of the horizontal stress tensor
+
+    effec_stress = 0.0d0
+
+    do j = 2, ny-1
+       do i = 1, nx-1
+          if (floating_mask(i,j) == 1) then
+             effec_stress(i,j) = &
+                  max(tau_eigenconstant1*tau_eigen1(i,j) + tau_eigenconstant2*tau_eigen2(i,j), 0.0d0)
+          endif
+       enddo
+    enddo
+
+    ! In calving-front cells, impose a lower bound for effec_stress
+    do j = 2, ny-1
+       do i = 1, nx-1
+          if (calving_front_mask(i,j) == 1) then
+             effec_stress(i,j) = max(effec_stress(i,j), effec_stress_min)
+          endif
+       enddo
+    enddo
+
+    ! Compute the change in damage as a function of effec_stress
+    do j = 2, ny-1
+       do i = 1, nx-1
+          if (floating_mask(i,j) == 1) then
+             !WHL - Assume a threshold of zero?
+!!             d_damage_dt = (effec_stress(i,j) - stress_threshold) / damage_constant
+             ! Note: damage_constant has units of Pa*s, so d_damage_dt has units of 1/s
+             d_damage_dt = effec_stress(i,j) / damage_constant
+             damage(:,i,j) = damage(:,i,j) + d_damage_dt * dt
+             damage(:,i,j) = min(damage(:,i,j), 1.0d0)
+             damage(:,i,j) = max(damage(:,i,j), 0.0d0)
+          else    ! set damage to zero elsewhere (grounded or ice-free)
+             damage(:,i,j) = 0.0d0
+          endif   ! floating_mask
+       enddo   ! i
+    enddo   ! j
+
+    ! Compute the vertically integrated damage in each column.
+    damage_column(:,:) = 0.0d0
+    do j = 2, ny-1
+       do i = 2, nx-1
+          do k = 1, nz-1
+             damage_column(i,j) = damage_column(i,j) + damage(k,i,j) * (sigma(k+1) - sigma(k))
+          enddo
+       enddo
+    enddo
+
+    call parallel_halo(damage_column, parallel)
+
+    if (verbose_calving) then
+       call point_diag(tau_eigen1, 'tau_eigen1 (Pa)',  itest, jtest, rtest, 9, 9, '(f8.0)')
+       call point_diag(tau_eigen2, 'tau_eigen2 (Pa)',  itest, jtest, rtest, 9, 9, '(f8.0)')
+       call point_diag(effec_stress, 'effec_stress (Pa)',  itest, jtest, rtest, 9, 9, '(f8.0)')
+       call point_diag(sqrt(tau_eigen1**2 + tau_eigen2**2), 'true eff stress (Pa)',  itest, jtest, rtest, 9, 9, '(f8.0)')
+       call point_diag(damage_column, 'new damage', itest, jtest, rtest, 9, 9, '(f8.4)')
+    endif
+
+    ! Convert damage to a binary field, with D = 0.0 or 1.0 everywhere
+
+    do j = nhalo+1, ny-nhalo
+       do i = nhalo+1, nx-nhalo
+          if (damage_column(i,j) > 0.0d0) then
+             call random_number(rnd)
+             if (rnd < damage_column(i,j)) then
+                damage_column(i,j) = 1.0d0
+                damage(:,i,j) = 1.0d0
+             else
+                damage_column(i,j) = 0.0d0
+                damage(:,i,j) = 0.0d0
+             endif
+          endif   ! damage > 0
+       enddo   ! i
+    enddo   ! j
+
+    call parallel_halo(damage_column, parallel)
+
+    ! Based on damage_column, compute a binary integer mask
+    where (damage_column == 1.0d0)
+       damage_mask = 1
+    elsewhere
+       damage_mask = 0
+    endwhere
+
+    if (verbose_calving) then
+       call point_diag(damage_mask, 'damage_mask', itest, jtest, rtest, 9, 9, '(i8)')
+    endif
+
+    ! Mark all floating cells with the initial color.
+    ! Mark other cells with the boundary color.
+
+    do j = nhalo+1, ny-nhalo
+       do i = nhalo+1, nx-nhalo
+          if (floating_mask(i,j) == 1) then
+             color(i,j) = initial_color
+          else
+             color(i,j) = boundary_color
+          endif
+       enddo
+    enddo
+
+    call parallel_halo(color, parallel)
+
+    ! Seed the fill with damaged CF cells, and then recursively fill all damaged cells that
+    !  have a path to the CF through other damaged cells and are therefore to be calved.
+    ! Repeat the recursion as necessary to spread the fill to adjacent processors.
+
+    max_iter = max(parallel%ewtasks, parallel%nstasks)
+    count_save = 0
+
+    do iter = 1, max_iter
+
+       if (iter == 1) then
+
+          do j = 1, ny
+             do i = 1, nx
+                if (calving_front_mask(i,j) == 1 .and. damage_mask(i,j) == 1) then  ! cell that can seed the fill
+                   if (color(i,j) /= fill_color) then
+                      ! assign the fill color to this cell, and recursively fill neighbor cells
+                      call glissade_fill(&
+                           nx,    ny,    &
+                           i,     j,     &
+                           color, damage_mask)
+                   endif
+                endif
+             enddo
+          enddo
+
+       else   ! iter > 1
+
+          call parallel_halo(color, parallel)
+
+          ! Loop through halo cells that were just filled on neighbor processors
+
+          ! west halo layer
+          i = nhalo
+          do j = 1, ny
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i+1,   j,     &
+                     color, damage_mask)
+             endif
+          enddo
+
+          ! east halo layer
+          i = nx - nhalo + 1
+          do j = 1, ny
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i-1,   j,     &
+                     color, damage_mask)
+             endif
+          enddo
+
+          ! south halo layer
+          j = nhalo
+          do i = nhalo+1, nx-nhalo  ! already checked halo corners above
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i,     j+1,   &
+                     color, damage_mask)
+             endif
+          enddo
+
+          ! north halo layer
+          j = ny-nhalo+1
+          do i = nhalo+1, nx-nhalo  ! already checked halo corners above
+             if (color(i,j) == fill_color) then
+                call glissade_fill(&
+                     nx,    ny,    &
+                     i,     j-1,   &
+                     color, damage_mask)
+             endif
+          enddo
+
+       endif   ! iter
+
+       ! Count the calving cells
+       count = 0
+       do j = nhalo+1, ny-nhalo
+          do i = nhalo+1, nx-nhalo
+             if (color(i,j) == fill_color) count = count + 1
+          enddo
+       enddo
+       !WHL - If running a large problem, may want to reduce the frequency of this global sum
+       count = parallel_reduce_sum(count)
+
+       if (count == count_save) then
+!!          if (verbose_calving .and. main_task) &
+!!               write(6,*) 'Fill converged: iter, global_count =', iter, global_count
+          exit
+       else
+!!          if (verbose_calving .and. main_task) &
+!!               write(6,*) 'Convergence check: iter, global_count =', iter, global_count
+          count_save = count
+       endif
+
+    enddo   ! max_iter
+
+    call parallel_halo(color, parallel)
+
+    ! Once the fill is done, any cells with the fill color are to be calved.
+    ! The actual calving is done in another subroutine.
+
+    where (color == fill_color .and. floating_mask == 1)
+       calving_dthck = thck
+    elsewhere
+       calving_dthck = 0.0d0
+    endwhere
+
+    if (verbose_calving) then
+!       if (main_task) then
+!          print*, 'boundary_color, initial color, fill color:', &
+!               boundary_color, initial_color, fill_color
+!       endif
+       call point_diag(color, 'After damage, color', itest, jtest, rtest, 9, 9, '(i8)')
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 9, 9, '(f8.0)')
+    endif
+
+  end subroutine stochastic_damage_based_calving
 
 !---------------------------------------------------------------------------
 
@@ -2511,7 +2792,10 @@ contains
 
     real(dp), dimension(nx,ny), intent(inout) :: thck            !> ice thickness
     real(dp), dimension(nx,ny), intent(in)    :: f_ground_cell   !> grounded fraction in each grid cell
-    integer,  dimension(nx,ny), intent(in)    :: ice_mask        !> = 1 where ice is present (thck > thklim), else = 0
+    !Note: When using a subgrid CF scheme, it is safer to pass in full_mask in place of the usual ice_mask,
+    !      so that partial CF cells do not spread the fill.
+    integer,  dimension(nx,ny), intent(inout) :: ice_mask        !> = 1 where ice is present (thck > thklim), else = 0;
+                                                                 !> may exclude partial CF cells
     integer,  dimension(nx,ny), intent(in)    :: floating_mask   !> = 1 where ice is present and floating, else = 0
     integer,  dimension(nx,ny), intent(in)    :: land_mask       !> = 1 where topg - eus >= 0, else = 0
     real(dp), dimension(nx,ny), intent(inout) :: calving_thck    !> thickness lost due to calving in each grid cell;
@@ -2531,7 +2815,7 @@ contains
 
     if (verbose_calving) then
        call point_diag(thck, 'Remove icebergs, thck (m)', itest, jtest, rtest, 7, 7)
-!!       call point_diag(ice_mask, 'ice_mask', itest, jtest, rtest, 7, 7)
+       call point_diag(ice_mask, 'ice_mask', itest, jtest, rtest, 7, 7)
 !!       call point_diag(f_ground_cell, 'f_ground_cell', itest, jtest, rtest, 7, 7)
     endif
     
@@ -2592,7 +2876,7 @@ contains
        else  ! iter > 1
 
           ! Check for halo cells that were just filled on neighbor processors
-          ! TODO - Is the 'ice_mask = 1' logic redundant? (Here and below?)  Use glissade_fill without buffer?
+          ! TODO - Is the 'ice_mask = 1' logic redundant?
           call parallel_halo(color, parallel)
 
           ! west halo layer
@@ -2696,8 +2980,8 @@ contains
 
     ! Remove any ice isthmuses.
     ! An isthmus is defined as a floating or weakly grounded grid cell with ice-free ocean
-    !  or thin floating ice (H < 10 m) on both sides: i.e., in cells (i-1,j) and (i+1,j),
-    !  or (i,j-1) and (i,j+1).
+    !  or thin floating ice (H < 10 m) on two opposite sides (i.e., in cells (i-1,j) and (i+1,j),
+    !  or (i,j-1) and (i,j+1)), connected to ice on the other two sides.
     ! When using an ice_fraction_retreat_mask derived from a model (e.g., CESM),
     !  it may be necessary to remove isthmuses to prevent unstable ice configurations,
     !  e.g. a shelf split into two parts connected by a bridge one cell wide.
@@ -2756,14 +3040,22 @@ contains
                   (floating_mask (i,j-1) == 1 .and. thck(i,j-1) < thin_threshold) ) then
                 mask_s = 1
              endif
-             if ( (mask_e == 1 .and. mask_w == 1) .or. &
-                  (mask_n == 1 .and. mask_s == 1) ) then
-                calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
-                thck(i,j) = 0.0d0
+             ! Note: We call a cell an isthmus only if it borders floating ice on the other two edges.
+             !       Without this requirement, we will remove many cells that are not true isthmuses.
+             if (mask_e == 1 .and. mask_w == 1) then
+                if (floating_mask(i,j-1) == 1 .and. floating_mask (i,j+1) == 1) then
+                   calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
+                   thck(i,j) = 0.0d0
+                endif
+             elseif (mask_n == 1 .and. mask_s == 1) then
+                if (floating_mask(i-1,j) == 1 .and. floating_mask (i+1,j) == 1) then
+                   calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
+                   thck(i,j) = 0.0d0
+                endif
              endif
-          endif
-       enddo
-    enddo
+          endif  ! floating or lightly grounded
+       enddo  ! i
+    enddo  ! j
 
     if (verbose_calving) then
        call point_diag(thck, 'After isthmus removal, thck', itest, jtest, rtest, 7, 7)

--- a/libglissade/glissade_calving.F90
+++ b/libglissade/glissade_calving.F90
@@ -44,8 +44,7 @@ module glissade_calving
 
   private
   public :: glissade_calving_mask_init, glissade_calve_ice, &
-            glissade_remove_icebergs, glissade_remove_isthmuses, &
-            glissade_cull_calving_front, glissade_limit_cliffs,  &
+            glissade_remove_icebergs, glissade_remove_isthmuses, glissade_limit_cliffs,  &
             glissade_stress_tensor_eigenvalues, glissade_strain_rate_tensor_eigenvalues
   public :: verbose_calving
 
@@ -470,6 +469,8 @@ contains
             velnorm_mean,  speed,   &
             vmask,         stagger_margin_in = 1)
 
+       call parallel_halo(speed, parallel)
+
        ! Compute the ice flux into each cell from each neighbor cell.
        ! This is an upwind estimate based on cell-center thickness.
        ! It is not equivalent to computing the incremental remapping flux,
@@ -517,21 +518,21 @@ contains
             land_mask = land_mask)
 
        call glissade_calving_front_mask(&
-            nx,            ny,                       &
-            which_ho_calving_front,                  &
-            parallel,                                &
-            thck,          topg,                     &
-            eus,                                     &
-            ice_mask,      floating_mask,            &
-            ocean_mask,    land_mask,                &
-            calving_front_mask,                      &
-            dthck_dx_cf = calving%dthck_dx_cf,       &
-            dx = dx,       dy = dy,                  &
-            thck_effective = calving%thck_effective, &
-            thck_effective_min = calving%thck_effective_min, &
-            partial_cf_mask = partial_cf_mask,       &
-            full_mask = full_mask,                   &
-            effective_areafrac = calving%effective_areafrac)
+            nx,            ny,             &
+            which_ho_calving_front,        &
+            parallel,                      &
+            thck,          topg,           &
+            eus,                           &
+            ice_mask,      floating_mask,  &
+            ocean_mask,    land_mask,      &
+            calving_front_mask,            &
+            calving%dthck_dx_cf,           &
+            dx,            dy,             &
+            calving%thck_effective,        &
+            calving%thck_effective_min,    &
+            partial_cf_mask,               &
+            full_mask,                     &
+            calving%effective_areafrac)
 
        if (verbose_calving) then
           call point_diag(calving_front_mask, 'calving_front_mask', itest, jtest, rtest, 7, 7)
@@ -612,6 +613,13 @@ contains
 
        elseif (which_calving == CALVING_THCK_THRESHOLD) then
 
+          call extrapolate_to_calving_front(&
+               nx,                 ny,     &
+               partial_cf_mask,            &
+               full_mask,                  &
+               calving%effective_areafrac, &
+               speed)
+
           call thickness_based_calving(&
                nx,                 ny,                    &
                dx,                 dy,                    &  ! m
@@ -625,6 +633,13 @@ contains
                calving_dthck)                                ! m
 
        elseif (which_calving == CALVING_STRESS) then
+
+          call extrapolate_to_calving_front(&
+               nx,                 ny,     &
+               partial_cf_mask,            &
+               full_mask,                  &
+               calving%effective_areafrac, &
+               speed)
 
           call extrapolate_to_calving_front(&
                nx,                 ny,     &
@@ -680,6 +695,16 @@ contains
                partial_cf_mask,            &
                full_mask,                  &
                calving%effective_areafrac, &
+               speed)
+
+          !Note - Optionally, instead of weighting by areafrac, we could assign zero weight
+          !        to the CF cell and use the upstream value. This would increase damage at the CF.
+
+          call extrapolate_to_calving_front(&
+               nx,                 ny,     &
+               partial_cf_mask,            &
+               full_mask,                  &
+               calving%effective_areafrac, &
                calving%tau_eigen1,         &
                calving%tau_eigen2)
 
@@ -694,8 +719,8 @@ contains
                cf_length,                              &  ! m
                calving%thck_effective,                 &  ! m
                calving%tau_eigen1, calving%tau_eigen2, &  ! Pa
-               calving%tau_eigenconstant1,               &
-               calving%tau_eigenconstant2,               &
+               calving%tau_eigenconstant1,             &
+               calving%tau_eigenconstant2,             &
                calving%damage_threshold,               &
                calving%damage,                         &
                calving_dthck)                             ! m
@@ -718,11 +743,6 @@ contains
             thck,                    &
             calving%calving_thck)
 
-       if (verbose_calving) then
-          call point_diag(calving_dthck, 'dthck (m)', itest, jtest, rtest, 7, 7)
-          call point_diag(thck, 'New thck (m)', itest, jtest, rtest, 7, 7)
-       endif
-
        !TODO - Add a bug check for negative thicknesses?
        thck = max(thck, 0.0d0)
 
@@ -742,21 +762,21 @@ contains
             land_mask = land_mask)
 
        call glissade_calving_front_mask(&
-            nx,            ny,                       &
-            which_ho_calving_front,                  &
-            parallel,                                &
-            thck,          topg,                     &
-            eus,                                     &
-            ice_mask,      floating_mask,            &
-            ocean_mask,    land_mask,                &
-            calving_front_mask,                      &
-            dthck_dx_cf = calving%dthck_dx_cf,       &
-            dx = dx,       dy = dy,                  &
-            thck_effective = calving%thck_effective, &
-            thck_effective_min = calving%thck_effective_min, &
-            partial_cf_mask = partial_cf_mask,       &
-            full_mask = full_mask,                   &
-            effective_areafrac = calving%effective_areafrac)
+            nx,            ny,             &
+            which_ho_calving_front,        &
+            parallel,                      &
+            thck,          topg,           &
+            eus,                           &
+            ice_mask,      floating_mask,  &
+            ocean_mask,    land_mask,      &
+            calving_front_mask,            &
+            calving%dthck_dx_cf,           &
+            dx,            dy,             &
+            calving%thck_effective,        &
+            calving%thck_effective_min,    &
+            partial_cf_mask,               &
+            full_mask,                     &
+            calving%effective_areafrac)
 
        if (which_calving == CF_ADVANCE_RETREAT_RATE) then
 
@@ -826,6 +846,7 @@ contains
                thck)
 
           ! Recompute the calving masks
+          !TODO - Are these calls needed? These subroutines are called again before the velocity solver.
 
           call glissade_get_masks(&
                nx,            ny,             &
@@ -838,21 +859,21 @@ contains
                land_mask = land_mask)
 
           call glissade_calving_front_mask(&
-               nx,            ny,                       &
-               which_ho_calving_front,                  &
-               parallel,                                &
-               thck,          topg,                     &
-               eus,                                     &
-               ice_mask,      floating_mask,            &
-               ocean_mask,    land_mask,                &
-               calving_front_mask,                      &
-               dthck_dx_cf = calving%dthck_dx_cf,       &
-               dx = dx,       dy = dy,                  &
-               thck_effective = calving%thck_effective, &
-               thck_effective_min = calving%thck_effective_min, &
-               partial_cf_mask = partial_cf_mask,       &
-               full_mask = full_mask,                   &
-               effective_areafrac = calving%effective_areafrac)
+               nx,            ny,             &
+               which_ho_calving_front,        &
+               parallel,                      &
+               thck,          topg,           &
+               eus,                           &
+               ice_mask,      floating_mask,  &
+               ocean_mask,    land_mask,      &
+               calving_front_mask,            &
+               calving%dthck_dx_cf,           &
+               dx,            dy,             &
+               calving%thck_effective,        &
+               calving%thck_effective_min,    &
+               partial_cf_mask,               &
+               full_mask,                     &
+               calving%effective_areafrac)
 
        endif
 
@@ -1057,9 +1078,9 @@ contains
                          dthck = total_dthck * flux_in(ii,jj,i,j)/total_flux
                          thck(iup,jup) = thck(iup,jup) + dthck
                          thck(i,j) = thck(i,j) - dthck
-                         if (verbose_calving .and. i==itest .and. j==jtest .and. this_rank==rtest) then
-                            print*, '   Upstream ii, jj, frac:', ii, jj, flux_in(ii,jj,i,j)/total_flux
-                         endif
+!                         if (verbose_calving .and. i==itest .and. j==jtest .and. this_rank==rtest) then
+!                            print*, '   Upstream ii, jj, frac:', ii, jj, flux_in(ii,jj,i,j)/total_flux
+!                         endif
                       endif
                    enddo
                 enddo
@@ -1430,6 +1451,7 @@ contains
     if (verbose_calving) then
        call point_diag(speed*scyr, 'Thickness-based calving, ice speed (m/yr)', itest, jtest, rtest, 7, 7)
        call point_diag(lateral_rate*scyr, 'lateral calving rate (m/yr)', itest, jtest, rtest, 7, 7)
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7)
     endif
 
   end subroutine thickness_based_calving
@@ -1519,14 +1541,15 @@ contains
 
     do j = nhalo+1, ny-nhalo
        do i = nhalo+1, nx-nhalo
-          if (calving_front_mask(i,j) == 1) then
 
-             effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
-                               + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
+          effec_stress(i,j) = tau_eigenconstant1 * max(tau_eigen1(i,j), 0.0d0)   &
+                            + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
+
+          if (calving_front_mask(i,j) == 1) then
              lateral_rate(i,j) =  speed(i,j) * effec_stress(i,j) / stress_threshold
              calving_dthck(i,j) = lateral_rate(i,j) * dt * thck_effective(i,j) * cf_length(i,j) / (dx*dy)
-
           endif   ! CF mask
+
        enddo   ! i
     enddo   ! j
 
@@ -1536,6 +1559,7 @@ contains
        call point_diag(tau_eigen2, 'tau_eigen2 (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
        call point_diag(effec_stress, 'eff_stress (Pa)', itest, jtest, rtest, 7, 7, '(f10.0)')
        call point_diag(lateral_rate*scyr, 'lateral calving rate (m/yr)', itest, jtest, rtest, 7, 7)
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7)
     endif
 
   end subroutine stress_based_calving
@@ -1631,12 +1655,13 @@ contains
        call point_diag(sqrt(max(eps_eigen1,0.d0)*max(eps_eigen2,0.0d0))*scyr, &
             'eps geom mean (yr^-1)',  itest, jtest, rtest, 7, 7, '(f10.6)')
        call point_diag(lateral_rate*scyr, 'lateral calving rate (m/yr)', itest, jtest, rtest, 7, 7)
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7)
     endif
 
   end subroutine eigencalving
 
 !---------------------------------------------------------------------------
-  
+
   subroutine damage_based_calving(&
        nx,       ny,       nz,            &
        dx,                 dy,            &  ! m
@@ -1654,11 +1679,9 @@ contains
        damage,                            &
        calving_dthck)                        ! m
 
-    ! Calve ice based on the eigenvalues of the 2D horizontal stress tensor near the calving front.
-    ! This is similar to damage-based calving, except that instead of allowing damage to accumulate,
-    !  we prescribe a lateral calving rate proportional to one or more eigenvalues.
-    ! The lateral rate is converted to a thinning rate based on the effective calving thickness.
-    ! TODO - Calving rates are currently based on stress eigenvalues only.  Add strain-rate option.
+    ! Calve ice based on accumulated damage.
+    ! This is similar to stress-based calving, except that stresses contribute to damage
+    ! instead of directly determining the lateral calving rate.
 
     use glide_diagnostics, only: point_diag
 
@@ -1710,7 +1733,7 @@ contains
          damage_frac               ! ratio of damage to damage_threshold (unitless)
 
     !TODO - Make this a config parameter (similar to damage_threshold, but different units)
-    real(dp), parameter :: damage_scale = 1.e7   ! sustained stress over time (Pa yr) required to yield D = 1
+    real(dp), parameter :: damage_scale = 1.d7   ! sustained stress over time (Pa yr) required to yield D = 1
 
     ! Compute thinning in calving-front cells based on damage, a acalar quantity
     !  prognosed from eigenvalues of the horizontal stress tensor (or strain rate tensor).
@@ -1754,6 +1777,9 @@ contains
                                + tau_eigenconstant2 * max(tau_eigen2(i,j), 0.0d0)
 
              d_damage_dt = effec_stress(i,j) / (damage_scale*scyr)
+
+             !WHL: Alternatives would be to (1) accumulate damage only when effec_stress is above
+             !     a given threshold and (2) allow the ice to heal under low or negative tensile stress.
 
              damage(:,i,j) = damage(:,i,j) + d_damage_dt * dt
              damage(:,i,j) = min(damage(:,i,j), 1.0d0)
@@ -1809,7 +1835,7 @@ contains
 
     if (verbose_calving) then
        call point_diag(lateral_rate*scyr, 'lateral calving rate (m/yr)', itest, jtest, rtest, 7, 7)
-       call point_diag(calving_dthck, 'dthck (m)', itest, jtest, rtest, 7, 7)
+       call point_diag(calving_dthck, 'calving_dthck (m)', itest, jtest, rtest, 7, 7)
     endif
 
   end subroutine damage_based_calving
@@ -2053,10 +2079,10 @@ contains
                          thck(iup,jup) = thck(iup,jup) - my_dthck
                          calving_thck(iup,jup) = calving_thck(iup,jup) + my_dthck
                          calving_dthck(i,j) = calving_dthck(i,j) - my_dthck
-                         if (verbose_calving .and. i==itest .and. j==jtest .and. this_rank==rtest) then
-                            print*, '   Upstream ii, jj, frac, remaining calving_dthck:', &
-                                 ii, jj, flux_in(ii,jj,i,j)/total_flux, calving_dthck(i,j)
-                         endif
+!                         if (verbose_calving .and. i==itest .and. j==jtest .and. this_rank==rtest) then
+!                            print*, '   Upstream ii, jj, frac, remaining calving_dthck:', &
+!                                 ii, jj, flux_in(ii,jj,i,j)/total_flux, calving_dthck(i,j)
+!                         endif
                       endif
                    enddo
                 enddo
@@ -2166,110 +2192,6 @@ contains
 
 !---------------------------------------------------------------------------
   
-  !TODO - Remove this subroutine? Ideally, unstable ice can be removed by other means.
-  subroutine glissade_cull_calving_front(&
-       nx,           ny,          &
-       parallel,                  &
-       itest, jtest, rtest,       &
-       thck,         topg,        &
-       eus,          thklim,      &
-       which_ho_calving_front,    &
-       ncull_calving_front,       &
-       calving_thck)
-
-    ! Optionally, remove all cells currently at the calving front are removed.
-    ! This subroutine would typically be called at initialization, if at all.
-    ! Culling can removed long, skinny floating peninsulas that can be dynamically unstable.
-    !  Without this step, peninsulas up to two cells thick (with calving-front cells on each side)
-    !  will typically be removed as icebergs (because there is no path back to grounded ice through active cells).
-    ! With one round of culling, peninsulas up to four cells thick will be removed (two outer layers
-    !  during the preliminary step, followed by two inner layers on the remove_iceberg step).
-    ! If necessary, culling can be repeated to remove peninsulas with a thickness of 6 layers, 8 layers, etc.
-
-    use glissade_masks, only: glissade_get_masks, glissade_calving_front_mask
-
-    integer, intent(in) :: nx, ny                       !> horizontal grid dimensions
-    type(parallel_type), intent(in) :: parallel         !> info for parallel communication
-    integer, intent(in) :: itest, jtest, rtest          !> coordinates of diagnostic point
-
-    real(dp), dimension(nx,ny), intent(inout) :: thck   !> ice thickness
-    real(dp), dimension(nx,ny), intent(in)    :: topg   !> present bedrock topography
-    real(dp), intent(in)    :: eus                      !> eustatic sea level
-    real(dp), intent(in)    :: thklim                   !> minimum thickness for dynamically active grounded ice
-    integer, intent(in)     :: which_ho_calving_front   !> = 1 for subgrid calving-front scheme, else = 0
-    integer, intent(in) :: &
-         ncull_calving_front           !> number of times to cull calving_front cells at initialization
-
-    real(dp), dimension(nx,ny), intent(inout) :: calving_thck   !> thickness lost due to calving in each grid cell;
-                                                              !> on output, includes ice that is culled here
-    ! local variables
-
-    integer :: i, j, n
-
-    integer,  dimension(nx,ny) ::  &
-         ice_mask,           & ! = 1 where ice is present (thck > thklim), else = 0
-         floating_mask,      & ! = 1 where ice is present (thck > thklim) and floating, else = 0
-         ocean_mask,         & ! = 1 where topg is below sea level and ice is absent, else = 0
-         land_mask,          & ! = 1 where topg is at or above sea level, else = 0
-         calving_front_mask    ! = 1 where ice is floating and borders the ocean, else = 0
-
-    do n = 1, ncull_calving_front
-
-       ! calculate masks
-       ! Note: Passing in thklim = 0.0 does not work because it erroneously counts thin floating cells as active.
-       !       Then the algorithm can fail to identify floating regions that should be removed
-       !       (since they are separated from any active cells).
-
-       call glissade_get_masks(&
-            nx,            ny,             &
-            parallel,                      &
-            thck,          topg,           &
-            eus,           thklim,         &
-            ice_mask,                      &
-            floating_mask = floating_mask, &
-            ocean_mask = ocean_mask,       &
-            land_mask = land_mask)
-
-       call glissade_calving_front_mask(&
-            nx,            ny,                 &
-            which_ho_calving_front,            &
-            parallel,                          &
-            thck,          topg,               &
-            eus,                               &
-            ice_mask,      floating_mask,      &
-            ocean_mask,    land_mask,          &
-            calving_front_mask)
-
-       if (main_task) then
-          call write_log ('cull_calving_front: Removing ice from calving_front cells')
-          write(6,*) 'cull_calving_front: Removing ice from calving_front cells'
-       endif
-
-       if (verbose_calving) then
-          call point_diag(calving_front_mask, 'calving_front_mask for culling', &
-               itest, jtest, rtest, 7, 7)
-          call point_diag(thck, 'thck (before CF culling)', itest, jtest, rtest, 7, 7)
-       endif
-
-       do j = 1, ny
-          do i = 1, nx
-             if (calving_front_mask(i,j) == 1) then
-                calving_thck(i,j) = calving_thck(i,j) + thck(i,j)
-                thck(i,j) = 0.0d0
-             endif
-          enddo
-       enddo
-
-       if (verbose_calving) then
-          call point_diag(thck, 'thck (after CF culling)', itest, jtest, rtest, 7, 7)
-       endif
-
-    enddo  ! ncull_calving_front
-
-  end subroutine glissade_cull_calving_front
-
-!---------------------------------------------------------------------------
-
   subroutine glissade_remove_icebergs(&
        nx,           ny,            &
        parallel,                    &

--- a/libglissade/glissade_masks.F90
+++ b/libglissade/glissade_masks.F90
@@ -314,22 +314,22 @@
     integer, dimension(nx,ny), intent(out) ::  &
          calving_front_mask       ! = 1 if ice is floating and borders at least one ocean cell, else = 0
 
-    real(dp), intent(in), optional :: &
+    real(dp), intent(in) :: &
          dthck_dx_cf,           & ! assumed max value of |dH/dx| at the CF for full cells
          dx, dy                   ! grid cell size (m)
 
-    real(dp), dimension(nx,ny), intent(out), optional :: &
+    real(dp), dimension(nx,ny), intent(out) :: &
          thck_effective,        & ! effective ice thickness (m) for calving
                                   ! Generally, H_eff > H at the CF, with H_eff = H elsewhere
          effective_areafrac       ! effective ice-covered fraction, in range [0,1]
                                   ! 0 < f < 1 for partial calving-front cells
 
-    integer, dimension(nx,ny), intent(out), optional :: &
+    real(dp), intent(in) :: &
+         thck_effective_min       ! minimum effective thickness for CF cells
+
+    integer, dimension(nx,ny), intent(out) :: &
          partial_cf_mask,       & ! = 1 for partially filled CF cells (thck < thck_effective), else = 0
          full_mask                ! = 1 for ice-filled cells that are not partial_cf cells, else = 0
-
-    real(dp), intent(in), optional :: &
-         thck_effective_min       ! minimum effective thickness for CF cells
 
     !----------------------------------------------------------------
     ! Local arguments
@@ -338,7 +338,8 @@
     integer :: i, j, ii, jj, ig, jg
 
     real(dp), dimension(nx,ny) :: &
-         thck_flotation         ! flotation thickness
+         thck_flotation,           & ! flotation thickness (m)
+         capped_thck                 ! min(thck, thck_flotation)
 
     real(dp) :: &
          max_neighbor_thck,        & ! max thickness (m) of the four edge neighbors
@@ -364,6 +365,16 @@
              if (ocean_mask(i-1,j) == 1 .or. ocean_mask(i+1,j) == 1 .or. &
                  ocean_mask(i,j-1) == 1 .or. ocean_mask(i,j+1) == 1) then
                 calving_front_mask(i,j) = 1
+              ! Note - The following logic adds some CF cells in regions with thin floating ice.
+              ! Commmented out for now because it changes CalvingMIP answers.
+             elseif (thck(i,j) < thck_effective_min) then
+                ! If two adjacent floating cells have very thin ice, we can think of them as sharing a CF
+                if ( (floating_mask(i-1,j) == 1 .and. thck(i-1,j) < thck_effective_min) .or. &
+                     (floating_mask(i+1,j) == 1 .and. thck(i+1,j) < thck_effective_min) .or. &
+                     (floating_mask(i,j-1) == 1 .and. thck(i,j-1) < thck_effective_min) .or. &
+                     (floating_mask(i,j+1) == 1 .and. thck(i,j+1) < thck_effective_min) ) then
+                   calving_front_mask(i,j) = 1
+                endif
              else
                 interior_mask(i,j) = 1
              endif
@@ -378,136 +389,107 @@
 
     if (which_ho_calving_front == HO_CALVING_FRONT_SUBGRID) then
 
-       if (present(thck_effective)) then
+       ! Initialize thck_effective and masks
+       thck_effective = thck
+       full_mask = 0
+       partial_cf_mask = 0
 
-          ! Note: thck_effective, full_mask, partial_cf_mask, dx, dy, and dthck_dx_cf should all be passed together.
-          !       The following fatal error message does not account for all permutations of missing arguments,
-          !        but will prevent bad calculations of thck_effective.
-          if (.not.present(full_mask) .or. .not.present(partial_cf_mask) .or. &
-              .not.present(dx) .or. .not.present(dy) .or. .not.present(dthck_dx_cf)) then
-             write(message,*) &
-                  'Must pass full_mask, partial_cf_mask, dx, dy and dthck_dx_cf to compute thck_effective'
-             call write_log(message, GM_FATAL)
-          endif
+       ! Identify full cells and partial CF cells.
+       ! All ice-covered cells not at the CF are full cells.
+       ! For CF cells, compute the max thickness of interior neighbors (capped at the flotation thicknes)..
+       ! * If the thickness of the CF cell is close to that of the interior cell,
+       !   mark the CF cell as a full cell.
+       ! * Otherwise, mark the CF cell as a partial CF cell.
+       ! If there are no interior neighbors with nonzero (capped) thickness, then compare
+       ! to the thickness of CF neighbors.
 
-          ! Initialize thck_effective and masks
-          thck_effective = thck
-          full_mask = 0
-          partial_cf_mask = 0
+       thck_flotation = max(-(rhoo/rhoi) * (topg - eus), 0.0d0)
+       capped_thck = min(thck, thck_flotation)
 
-          ! Identify full cells and partial_cf cells.
-          ! All ice-covered cells not at the CF are full cells.
-          ! For CF cells, compute the max thickness of interior neighbors.
-          ! * If the thickness of the CF cell is close to that of the interior cell
-          !   (based on the thickness gradient), mark the CF cell as a full cell.
-          ! * Otherwise, mark the CF cell as a partial CF cell.
-
-          do j = 2, ny-1
-             do i = 2, nx-1
-                if (ice_mask(i,j) == 1) then
-                   if (calving_front_mask(i,j) == 1) then
-                      max_neighbor_thck = max(&
-                           interior_mask(i-1,j)*thck(i-1,j), interior_mask(i+1,j)*thck(i+1,j), &
-                           interior_mask(i,j-1)*thck(i,j-1), interior_mask(i,j+1)*thck(i,j+1))
-                      if (max_neighbor_thck > 0.0d0) then
-                         distance = sqrt(dx*dy)
-                         dthck_dx = (max_neighbor_thck - thck(i,j)) / distance
-                         ! If the gradient exceeds a critical value, this is a partial CF cell;
-                         !  set thck_effective based on the critical gradient.
-                         ! If the gradient is at or below the critical valude, this is a full cell with thck_effective = thck.
-                         if (dthck_dx > dthck_dx_cf) then
-                            partial_cf_mask(i,j) = 1
-                            thck_effective(i,j) = max_neighbor_thck - dthck_dx_cf*distance
-                         else
-                            full_mask(i,j) = 1
-                         endif   ! dthck_dx > dthck_dx_cf
-                      else   ! no interior neighbors
-                         ! Mark as a partial cell, and compute thck_effective from a CF neighbor
+       do j = 2, ny-1
+          do i = 2, nx-1
+             if (ice_mask(i,j) == 1) then
+                if (calving_front_mask(i,j) == 1) then
+                   max_neighbor_thck = max(&
+                        interior_mask(i-1,j)*capped_thck(i-1,j), interior_mask(i+1,j)*capped_thck(i+1,j), &
+                        interior_mask(i,j-1)*capped_thck(i,j-1), interior_mask(i,j+1)*capped_thck(i,j+1))
+                   if (max_neighbor_thck > 0.0d0) then
+                      distance = sqrt(dx*dy)
+                      dthck_dx = (max_neighbor_thck - thck(i,j)) / distance
+                      ! If the gradient exceeds a critical value, this is a partial CF cell;
+                      !  set thck_effective based on the critical gradient.
+                      ! If the gradient is at or below the critical valude, this is a full cell with thck_effective = thck.
+                      if (dthck_dx > dthck_dx_cf) then
                          partial_cf_mask(i,j) = 1
-                         max_neighbor_thck = max(&
-                              calving_front_mask(i-1,j)*thck(i-1,j), calving_front_mask(i+1,j)*thck(i+1,j), &
-                              calving_front_mask(i,j-1)*thck(i,j-1), calving_front_mask(i,j+1)*thck(i,j+1))
-                         distance = sqrt(dx*dy)
-                         dthck_dx = (max_neighbor_thck - thck(i,j)) / distance
-                         if (dthck_dx > dthck_dx_cf) then
-                            thck_effective(i,j) = max_neighbor_thck - dthck_dx_cf*distance
-                         endif
+                         thck_effective(i,j) = max_neighbor_thck - dthck_dx_cf*distance
+                      else
+                         full_mask(i,j) = 1
+                      endif   ! dthck_dx > dthck_dx_cf
+                   else   ! no interior neighbors
+                      ! Mark as a partial cell, and compute thck_effective from a CF neighbor
+                      partial_cf_mask(i,j) = 1
+                      max_neighbor_thck = max(&
+                           calving_front_mask(i-1,j)*thck(i-1,j), calving_front_mask(i+1,j)*thck(i+1,j), &
+                           calving_front_mask(i,j-1)*thck(i,j-1), calving_front_mask(i,j+1)*thck(i,j+1))
+                      distance = sqrt(dx*dy)
+                      dthck_dx = (max_neighbor_thck - thck(i,j)) / distance
+                      if (dthck_dx > dthck_dx_cf) then
+                         thck_effective(i,j) = max_neighbor_thck - dthck_dx_cf*distance
+                      endif
 !!                         call parallel_globalindex(i, j, ig, jg, parallel)
 !!                         write(6,*) 'No interior neighbor:', ig, jg, thck(i,j)
 !!                         write(6,*) '   New H_eff:', thck_effective(i,j)
-                      endif   ! max_neighbor_thck > 0
+                   endif   ! max_neighbor_thck > 0
 
-                   else   ! not a CF cell; thck_effective = thck
+                else   ! not a CF cell; thck_effective = thck
 
-                      full_mask(i,j) = 1
+                   full_mask(i,j) = 1
 
-                   endif   ! calving_front_mask
-                endif   ! ice_mask
-             enddo   ! i
-          enddo   ! j
+                endif   ! calving_front_mask
+             endif   ! ice_mask
+          enddo   ! i
+       enddo   ! j
 
-          ! Limit thck_effective at the CF so as not to exceed the flotation thickness
-          where (calving_front_mask == 1)
-             thck_flotation = -(rhoo/rhoi) * (topg - eus)
-             thck_effective = min(thck_effective, thck_flotation)
-          endwhere
+       ! Limit thck_effective at the CF so as not to exceed the flotation thickness
+       where (calving_front_mask == 1)
+          thck_effective = min(thck_effective, thck_flotation)
+       endwhere
 
-          ! Optionally, set a minimum value for thck_effective
-          if (present(thck_effective_min)) then
-             where (calving_front_mask == 1)
-                thck_effective = max(thck_effective, thck_effective_min)
-             endwhere
-          endif
+       ! Set a lower limit for thck_effective
+       where (calving_front_mask == 1)
+          thck_effective = max(thck_effective, thck_effective_min)
+       endwhere
 
-          call parallel_halo(thck_effective, parallel)
-          call parallel_halo(full_mask, parallel)
-          call parallel_halo(partial_cf_mask, parallel)
+       call parallel_halo(thck_effective, parallel)
+       call parallel_halo(full_mask, parallel)
+       call parallel_halo(partial_cf_mask, parallel)
 
-       endif   ! present(thck_effective)
+       ! Use the ratio thck/thck_effective to compute effective_areafrac.
 
-       ! Optionally, use the ratio thck/thck_effective to compute effective_areafrac.
-
-       if (present(effective_areafrac)) then
-          if (present(thck_effective)) then
-             do j = 1, ny
-                do i = 1, nx
-                   if (calving_front_mask(i,j) == 1) then
-                      effective_areafrac(i,j) = thck(i,j) / thck_effective(i,j)
-                      effective_areafrac(i,j) = min(effective_areafrac(i,j), 1.0d0)
-                   elseif (ocean_mask(i,j) == 1) then
-                      effective_areafrac(i,j) = 0.0d0
-                   else  ! non-CF ice-covered cells and/or land cells
-                      effective_areafrac(i,j) = 1.0d0
-                   endif
-                enddo
-             enddo
-          else
-             write(message,*) 'Cannot compute effective_areafrac without thck_effective'
-             call write_log(message, GM_FATAL)
-          endif  ! present(thck_effective)
-       endif   ! present(effective_areafrac)
+       do j = 1, ny
+          do i = 1, nx
+             if (calving_front_mask(i,j) == 1) then
+                effective_areafrac(i,j) = thck(i,j) / thck_effective(i,j)
+                effective_areafrac(i,j) = min(effective_areafrac(i,j), 1.0d0)
+             elseif (ocean_mask(i,j) == 1) then
+                effective_areafrac(i,j) = 0.0d0
+             else  ! non-CF ice-covered cells and/or land cells
+                effective_areafrac(i,j) = 1.0d0
+             endif
+          enddo
+       enddo
 
     else   ! no subgrid calving front scheme
 
-       if (present(thck_effective)) then
-          thck_effective = thck
-       endif
+       thck_effective = thck
+       partial_cf_mask = 0
+       full_mask = ice_mask
 
-       if (present(partial_cf_mask)) then
-          partial_cf_mask = 0
-       endif
-
-       if (present(full_mask)) then
-          full_mask = ice_mask
-       endif
-
-       if (present(effective_areafrac)) then
-          where (ice_mask == 1 .or. land_mask == 1)
-             effective_areafrac = 1.0d0
-          elsewhere
-             effective_areafrac = 0.0d0
-          endwhere
-       endif
+       where (ice_mask == 1 .or. land_mask == 1)
+          effective_areafrac = 1.0d0
+       elsewhere
+          effective_areafrac = 0.0d0
+       endwhere
 
     endif  ! which_ho_calving_front
 

--- a/libglissade/glissade_masks.F90
+++ b/libglissade/glissade_masks.F90
@@ -378,9 +378,7 @@
              else
                 interior_mask(i,j) = 1
              endif
-          elseif (ice_mask(i,j) == 1) then ! grounded ice-covered cell
-             interior_mask(i,j) = 1
-          endif
+          endif   ! floating
        enddo
     enddo
 
@@ -425,7 +423,7 @@
                       else
                          full_mask(i,j) = 1
                       endif   ! dthck_dx > dthck_dx_cf
-                   else   ! no interior neighbors
+                   else   ! no floating interior neighbors
                       ! Mark as a partial cell, and compute thck_effective from a CF neighbor
                       partial_cf_mask(i,j) = 1
                       max_neighbor_thck = max(&

--- a/libglissade/glissade_velo_higher.F90
+++ b/libglissade/glissade_velo_higher.F90
@@ -1012,7 +1012,6 @@
     real(dp) :: L2_norm_alpha_sav     ! value of L2 norm of residual, given the previous alpha_accel
     logical :: assembly_is_done       ! true when the final assembled matrix is formed, based on the best value of alpha_accel
 
-
     real(dp), parameter :: &
          gamma_accel = 0.40d0         ! how much to increase alpha_accel for each attempt to extend the solution vector
 
@@ -1093,6 +1092,7 @@
      !       instead of a full cell with unrealistically thin ice.
      !      Instead of pointing to model%geometry%usrf, compute a local value of usrf
      !       that is consistent with the local value of thck.
+
      if (model%options%which_ho_calving_front == HO_CALVING_FRONT_SUBGRID) then
         thck  => model%calving%thck_effective(:,:)
      else
@@ -4487,7 +4487,6 @@
     !       geometry%thck or calving%thck_effective, which have different units.
     !       To be removed when scaling goes away.
     if (whichcalving_front == HO_CALVING_FRONT_NO_SUBGRID) thck = thck / thk0
-
     topg = topg / thk0
 
     ! Convert flow factor from Pa^(-n) yr^(-1) to dimensionless units


### PR DESCRIPTION
This PR includes three commits that immediately follow the commits on the lipscomb/calving_mip_update branch. These three commits touch the same parts of the code (mostly glissade_calving.F90) and can be combined with the PR for calving_mip_update.

The last commit on the calving_mip_update branch ("Changed the thck_effective calculation at the calving front") was made just before doing the official CISM runs submitted for CalvingMIP. We should make a tag at this point so we can reproduce the CalvingMIP runs BFB, if desired.

The next three commits, which are on the antarctic_calving branch, were made to improve calving results when applying physically-based calving schemes to the entire Antarctic ice sheet. There are several logic changes that improve numerical behavior and are answer-changing. Also, the deprecated cull_calving_front option has been removed from the code.

I changed the numbering and logic associated with some of the calving options:
- Option 8 is deterministic stress-based calving. This calving law is working pretty well for the AIS, with some results presented at the winter 2025 LIWG meeting.
- Option 9 is similar to option 8 but is stochastic; it doesn't work as well as option 8 and needs more work.
- Option 10 is damage-based calving, which also is still in progress.
- Option 11 is eigencalving following Levermann et al. (2012); this was already in the code but is now renumbered.
