### PR TITLE
bugfix in parallel

### DIFF
--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -6737,20 +6737,20 @@ contains
     endif
 
     ! unstaggered grid
-    call mpi_irecv(wrecv,size(wrecv),mpi_real8,west,west,&
+    call mpi_irecv(wrecv,size(wrecv),mpi_integer,west,west,&
          comm,wrequest,ierror)
-    call mpi_irecv(erecv,size(erecv),mpi_real8,east,east,&
+    call mpi_irecv(erecv,size(erecv),mpi_integer,east,east,&
          comm,erequest,ierror)
-    call mpi_irecv(srecv,size(srecv),mpi_real8,south,south,&
+    call mpi_irecv(srecv,size(srecv),mpi_integer,south,south,&
          comm,srequest,ierror)
-    call mpi_irecv(nrecv,size(nrecv),mpi_real8,north,north,&
+    call mpi_irecv(nrecv,size(nrecv),mpi_integer,north,north,&
          comm,nrequest,ierror)
 
     esend(:,:,:) = &
          a(:,local_ewn-uhalo-lhalo+1:local_ewn-uhalo,1+lhalo:local_nsn-uhalo)
-    call mpi_send(esend,size(esend),mpi_real8,east,this_rank,comm,ierror)
+    call mpi_send(esend,size(esend),mpi_integer,east,this_rank,comm,ierror)
     wsend(:,:,:) = a(:,1+lhalo:1+lhalo+uhalo-1,1+lhalo:local_nsn-uhalo)
-    call mpi_send(wsend,size(wsend),mpi_real8,west,this_rank,comm,ierror)
+    call mpi_send(wsend,size(wsend),mpi_integer,west,this_rank,comm,ierror)
 
     call mpi_wait(wrequest,mpi_status_ignore,ierror)
     a(:,:lhalo,1+lhalo:local_nsn-uhalo) = wrecv(:,:,:)
@@ -6758,9 +6758,9 @@ contains
     a(:,local_ewn-uhalo+1:,1+lhalo:local_nsn-uhalo) = erecv(:,:,:)
 
     nsend(:,:,:) = a(:,:,local_nsn-uhalo-lhalo+1:local_nsn-uhalo)
-    call mpi_send(nsend,size(nsend),mpi_real8,north,this_rank,comm,ierror)
+    call mpi_send(nsend,size(nsend),mpi_integer,north,this_rank,comm,ierror)
     ssend(:,:,:) = a(:,:,1+lhalo:1+lhalo+uhalo-1)
-    call mpi_send(ssend,size(ssend),mpi_real8,south,this_rank,comm,ierror)
+    call mpi_send(ssend,size(ssend),mpi_integer,south,this_rank,comm,ierror)
 
     call mpi_wait(srequest,mpi_status_ignore,ierror)
     a(:,:,:lhalo) = srecv(:,:,:)
@@ -7267,20 +7267,20 @@ contains
     endif
 
     ! unstaggered grid
-    call mpi_irecv(wrecv,size(wrecv),mpi_real8,west,west,&
+    call mpi_irecv(wrecv,size(wrecv),mpi_integer,west,west,&
          comm,wrequest,ierror)
-    call mpi_irecv(erecv,size(erecv),mpi_real8,east,east,&
+    call mpi_irecv(erecv,size(erecv),mpi_integer,east,east,&
          comm,erequest,ierror)
-    call mpi_irecv(srecv,size(srecv),mpi_real8,south,south,&
+    call mpi_irecv(srecv,size(srecv),mpi_integer,south,south,&
          comm,srequest,ierror)
-    call mpi_irecv(nrecv,size(nrecv),mpi_real8,north,north,&
+    call mpi_irecv(nrecv,size(nrecv),mpi_integer,north,north,&
          comm,nrequest,ierror)
 
     esend(:,:,:) = &
          a(:,local_ewn-uhalo-lhalo+1:local_ewn-uhalo,1+lhalo:local_nsn-uhalo)
-    call mpi_send(esend,size(esend),mpi_real8,east,this_rank,comm,ierror)
+    call mpi_send(esend,size(esend),mpi_integer,east,this_rank,comm,ierror)
     wsend(:,:,:) = a(:,1+lhalo:1+lhalo+uhalo-1,1+lhalo:local_nsn-uhalo)
-    call mpi_send(wsend,size(wsend),mpi_real8,west,this_rank,comm,ierror)
+    call mpi_send(wsend,size(wsend),mpi_integer,west,this_rank,comm,ierror)
 
     call mpi_wait(wrequest,mpi_status_ignore,ierror)
     a(:,:lhalo,1+lhalo:local_nsn-uhalo) = wrecv(:,:,:)
@@ -7288,9 +7288,9 @@ contains
     a(:,local_ewn-uhalo+1:,1+lhalo:local_nsn-uhalo) = erecv(:,:,:)
 
     nsend(:,:,:) = a(:,:,local_nsn-uhalo-lhalo+1:local_nsn-uhalo)
-    call mpi_send(nsend,size(nsend),mpi_real8,north,this_rank,comm,ierror)
+    call mpi_send(nsend,size(nsend),mpi_integer,north,this_rank,comm,ierror)
     ssend(:,:,:) = a(:,:,1+lhalo:1+lhalo+uhalo-1)
-    call mpi_send(ssend,size(ssend),mpi_real8,south,this_rank,comm,ierror)
+    call mpi_send(ssend,size(ssend),mpi_integer,south,this_rank,comm,ierror)
 
     call mpi_wait(srequest,mpi_status_ignore,ierror)
     a(:,:,:lhalo) = srecv(:,:,:)

--- a/libglimmer/parallel_mpi.F90
+++ b/libglimmer/parallel_mpi.F90
@@ -7267,20 +7267,20 @@ contains
     endif
 
     ! unstaggered grid
-    call mpi_irecv(wrecv,size(wrecv),mpi_integer,west,west,&
+    call mpi_irecv(wrecv,size(wrecv),mpi_real8,west,west,&
          comm,wrequest,ierror)
-    call mpi_irecv(erecv,size(erecv),mpi_integer,east,east,&
+    call mpi_irecv(erecv,size(erecv),mpi_real8,east,east,&
          comm,erequest,ierror)
-    call mpi_irecv(srecv,size(srecv),mpi_integer,south,south,&
+    call mpi_irecv(srecv,size(srecv),mpi_real8,south,south,&
          comm,srequest,ierror)
-    call mpi_irecv(nrecv,size(nrecv),mpi_integer,north,north,&
+    call mpi_irecv(nrecv,size(nrecv),mpi_real8,north,north,&
          comm,nrequest,ierror)
 
     esend(:,:,:) = &
          a(:,local_ewn-uhalo-lhalo+1:local_ewn-uhalo,1+lhalo:local_nsn-uhalo)
-    call mpi_send(esend,size(esend),mpi_integer,east,this_rank,comm,ierror)
+    call mpi_send(esend,size(esend),mpi_real8,east,this_rank,comm,ierror)
     wsend(:,:,:) = a(:,1+lhalo:1+lhalo+uhalo-1,1+lhalo:local_nsn-uhalo)
-    call mpi_send(wsend,size(wsend),mpi_integer,west,this_rank,comm,ierror)
+    call mpi_send(wsend,size(wsend),mpi_real8,west,this_rank,comm,ierror)
 
     call mpi_wait(wrequest,mpi_status_ignore,ierror)
     a(:,:lhalo,1+lhalo:local_nsn-uhalo) = wrecv(:,:,:)
@@ -7288,9 +7288,9 @@ contains
     a(:,local_ewn-uhalo+1:,1+lhalo:local_nsn-uhalo) = erecv(:,:,:)
 
     nsend(:,:,:) = a(:,:,local_nsn-uhalo-lhalo+1:local_nsn-uhalo)
-    call mpi_send(nsend,size(nsend),mpi_integer,north,this_rank,comm,ierror)
+    call mpi_send(nsend,size(nsend),mpi_real8,north,this_rank,comm,ierror)
     ssend(:,:,:) = a(:,:,1+lhalo:1+lhalo+uhalo-1)
-    call mpi_send(ssend,size(ssend),mpi_integer,south,this_rank,comm,ierror)
+    call mpi_send(ssend,size(ssend),mpi_real8,south,this_rank,comm,ierror)
 
     call mpi_wait(srequest,mpi_status_ignore,ierror)
     a(:,:,:lhalo) = srecv(:,:,:)


### PR DESCRIPTION
This is a bug discovered by Mariana. It has limited/no impact on physics, but was responsible for failing GNU debug tests with NorESM. 
See https://github.com/NorESMhub/CISM/commit/b31d3365b59a743f8a75f216a5bebcca88e1d231
M: The problem is in the   parallel_mpi.F90, subroutine parallel_halo_integer_3d (lines 6740–6763): All eight MPI send/receive calls used mpi_real8 instead of mpi_integer. Since mpi_integer is 4 bytes and mpi_real8 is 8 bytes,  MPI was posting receives expecting twice as many bytes as the integer buffers (wrecv, erecv, srecv, nrecv) could hold. This wrote past the end of those stack-allocated buffers, corrupting the heap —
exactly what the malloc assertion failure in glibc's _int_malloc indicates.
The crash surfaces during the parallel_halo(marine_connection_mask_3d, ...) call in glissade_bmlt_float.F90:1391 because that's the first integer 3D halo exchange triggered in this code path.
With the fix in place - the GNU debug test is running now.